### PR TITLE
Update app id

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
     compileSdkVersion 26
     buildToolsVersion "26.0.1"
     defaultConfig {
-        applicationId "org.mozilla"
+        applicationId "org.mozilla.video"
         minSdkVersion 21
         targetSdkVersion 26
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we


### PR DESCRIPTION
Tested this and was able to install two versions of focus on the app tv.