### PR TITLE
Fixes #173 - Remaps back to escape when the cursor is disabled

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -522,14 +522,17 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
         final FragmentManager fragmentManager = getSupportFragmentManager();
         final BrowserFragment browserFragment = (BrowserFragment) fragmentManager.findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
 
+        // Remaps the back button to escape when:
+        // - The browser is visible
+        // - The cursor is disabled
+        // - The drawer isn't open
+        if (event.getKeyCode() == KeyEvent.KEYCODE_BACK && browserFragment != null && browserFragment.isVisible() && !isCursorEnabled && !isDrawerOpen) {
+            KeyEvent keyEvent = new KeyEvent(event.getAction(), KeyEvent.KEYCODE_ESCAPE);
+            dispatchKeyEvent(keyEvent);
+            return true;
+        }
+
         if (browserFragment == null || !browserFragment.isVisible() || isDrawerOpen || !isCursorEnabled) {
-
-            if(event.getKeyCode() == KeyEvent.KEYCODE_BACK && browserFragment.isVisible() && !isDrawerOpen) {
-                KeyEvent keyEvent = new KeyEvent(event.getAction(), KeyEvent.KEYCODE_ESCAPE);
-                dispatchKeyEvent(keyEvent);
-                return true;
-            }
-
             return super.dispatchKeyEvent(event);
         }
 


### PR DESCRIPTION
There are a few cases where you can use escape to scroll to the top of the page. So to stay consistent I didn't try to change the behavior based on any other variables.

One other idea that I had was to add a long-press event but I'm not sure how useful that would be without any education.