### PR TITLE
Closes #218: Remove browsing session at end of back stack.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -405,6 +405,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
             goBack();
         } else {
             getFragmentManager().popBackStack();
+            SessionManager.getInstance().removeCurrentSession();
         }
 
         return true;


### PR DESCRIPTION
This also changes the UX so that returning to the app after closing a browsing
session won't reopen the browsing session, which prevents the STR for #218.