### PR TITLE
Add constant for new m.youtube.com link

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -41,6 +41,7 @@ import org.mozilla.focus.session.Session;
 import org.mozilla.focus.session.SessionManager;
 import org.mozilla.focus.session.Source;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
+import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.Direction;
 import org.mozilla.focus.utils.OnUrlEnteredListener;
 import org.mozilla.focus.utils.SafeIntent;
@@ -170,7 +171,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
                 // If you open and close the menu on youtube, dpad navigation stops working for an unknown reason.
                 // One workaround is to reload the page, which we do here.
                 final BrowserFragment browserFragment = (BrowserFragment) getSupportFragmentManager().findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
-                if (browserFragment != null && browserFragment.isVisible() && browserFragment.getUrl().contains("youtube.com/tv")) {
+                if (browserFragment != null && browserFragment.isVisible() && browserFragment.getUrl().contains(AppConstants.YOUTUBE_MATCH_STRING)) {
                     final SystemWebView wv = (SystemWebView) browserFragment.getWebView();
                     wv.requestFocus();
                     wv.reload();

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -39,6 +39,7 @@ import org.mozilla.focus.session.Session;
 import org.mozilla.focus.session.SessionCallbackProxy;
 import org.mozilla.focus.session.SessionManager;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
+import org.mozilla.focus.utils.AppConstants;
 import org.mozilla.focus.utils.Browsers;
 import org.mozilla.focus.utils.Direction;
 import org.mozilla.focus.utils.Edge;
@@ -210,7 +211,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
                 final IWebView webView = getWebView();
                 // Bandaid null checks, underlying issue #249
                 final boolean enableCursor = webView == null ? false :
-                        (webView.getUrl() == null ? false : !webView.getUrl().contains("youtube.com/tv"));
+                        (webView.getUrl() == null ? false : !webView.getUrl().contains(AppConstants.YOUTUBE_MATCH_STRING));
                 activity.setCursorEnabled(enableCursor);
 
                 if (!loading && activity.isReloadingForYoutubeDrawerClosed) {

--- a/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.kt
@@ -21,6 +21,7 @@ import kotlinx.android.synthetic.main.fragment_home.*
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.MainActivity
 import org.mozilla.focus.autocomplete.UrlAutoCompleteFilter
+import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.OnUrlEnteredListener
 
 private const val COL_COUNT = 5
@@ -82,7 +83,7 @@ private class HomeTileAdapter(val onUrlEnteredListener: OnUrlEnteredListener) :
         RecyclerView.Adapter<TileViewHolder>() {
 
     val tiles = listOf(
-            HomeTile("https://youtube.com/tv", R.string.tile_youtube_tv,R.drawable.tile_youtube),
+            HomeTile(AppConstants.YOUTUBE_TILE_LINK, R.string.tile_youtube_tv,R.drawable.tile_youtube),
             HomeTile("https://www.google.com/search?tbm=vid", R.string.tile_google_video_search, R.drawable.tile_google),
             HomeTile("http://imdb.com", R.string.tile_imdb, R.drawable.tile_imdb),
             HomeTile("https://www.rottentomatoes.com", R.string.tile_rottentomatoes, R.drawable.tile_rotten_tomatoes),

--- a/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
@@ -37,4 +37,5 @@ public final class AppConstants {
     }
 
     public static final String YOUTUBE_TILE_LINK = "https://m.youtube.com";
+    public static final String YOUTUBE_MATCH_STRING = "m.youtube.com";
 }

--- a/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
@@ -35,4 +35,6 @@ public final class AppConstants {
     public static boolean supportsDownloadingFiles() {
         return true;
     }
+
+    public static final String YOUTUBE_TILE_LINK = "https://m.youtube.com";
 }


### PR DESCRIPTION
Based on discussion with @Sdaswani over slack, about possibly changing the url. Leaving this to @Sdaswani to merge, if needed.

You need to still do the following:
1) Update the autocomplete urls (in app/src/main/assets/domains/* for each locale) with the new locale
2) Verify that the new url shows the "remote control" navigation page, rather than the "cursor" mobile site - if the mobile site doesn't show the "remote control" navigation page, then the page won't work (users won't be able to play, pause, fast forward, full-screen, etc).