### PR TITLE
Closes #311: enable tracking protection

### DIFF
--- a/app/src/webview/java/org/mozilla/focus/webview/TrackingProtectionWebViewClient.java
+++ b/app/src/webview/java/org/mozilla/focus/webview/TrackingProtectionWebViewClient.java
@@ -112,6 +112,7 @@ public class TrackingProtectionWebViewClient extends AmazonWebViewClient {
         // The matcher code could be better named to make this apparent.
         if (blockedSiteMatcher.matches(resourceUri, currentPageUri)) {
             if (callback != null) {
+                // TODO: the variable this value updates is inaccurate: see #317.
                 callback.countBlockedTracker();
             }
             return new AmazonWebResourceResponse(null, null, null);

--- a/app/src/webview/java/org/mozilla/focus/webview/TrackingProtectionWebViewClient.java
+++ b/app/src/webview/java/org/mozilla/focus/webview/TrackingProtectionWebViewClient.java
@@ -102,19 +102,20 @@ public class TrackingProtectionWebViewClient extends AmazonWebViewClient {
             return new AmazonWebResourceResponse(null, null, null);
         }
 
-        final UrlMatcher matcher = getMatcher(view.getContext());
+        final UrlMatcher blockedSiteMatcher = getMatcher(view.getContext());
 
         // Don't block the main frame from being loaded. This also protects against cases where we
         // open a link that redirects to another app (e.g. to the play store).
-        final Uri pageUri = Uri.parse(currentPageURL);
+        final Uri currentPageUri = Uri.parse(currentPageURL);
 
-//        if ((!request.isForMainFrame()) &&
-//                matcher.matches(resourceUri, pageUri)) {
-//            if (callback != null) {
-//                callback.countBlockedTracker();
-//            }
-//            return new AmazonWebResourceResponse(null, null, null);
-//        }
+        // Matches is true if the resourceUri is on the blocklist and is not a first party request.
+        // The matcher code could be better named to make this apparent.
+        if (blockedSiteMatcher.matches(resourceUri, currentPageUri)) {
+            if (callback != null) {
+                callback.countBlockedTracker();
+            }
+            return new AmazonWebResourceResponse(null, null, null);
+        }
 
         return super.shouldInterceptRequest(view, request);
     }

--- a/app/src/webview/java/org/mozilla/focus/webview/matcher/UrlMatcher.java
+++ b/app/src/webview/java/org/mozilla/focus/webview/matcher/UrlMatcher.java
@@ -244,6 +244,7 @@ public class UrlMatcher implements  SharedPreferences.OnSharedPreferenceChangeLi
         final String resourceHost = resourceURI.getHost();
         final String pageHost = pageURI.getHost();
 
+        // Whitelist first party requests.
         if (pageHost != null && pageHost.equals(resourceHost)) {
             return false;
         }


### PR DESCRIPTION
The `isBlockingEnabled` flag should still work when we add the UI.

From my commit summary:

I think request.isForMainFrame() is unnecessary because of this line in
UrlMatcher.matches:

```java
        if (pageHost != null && pageHost.equals(resourceHost)) {
            return false;
        }
```

Which whitelists first party requests: this is assuming the `pageHost`, which
comes from `TrackingProtectionWebViewClient.currentPageUrl`, actually
represents the current page loading (and thus the main frame).

I noted that my Android TV emulator seems to block the same numbers of trackers
as Focus.