### PR TITLE
Add menu navigation telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -46,6 +46,7 @@ import org.mozilla.focus.locale.LocaleAwareAppCompatActivity;
 import org.mozilla.focus.session.Session;
 import org.mozilla.focus.session.SessionManager;
 import org.mozilla.focus.session.Source;
+import org.mozilla.focus.telemetry.MenuAppNavButton;
 import org.mozilla.focus.telemetry.MenuBrowserNavButton;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.telemetry.UrlTextInputLocation;
@@ -165,12 +166,15 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
         fragmentNavigationBar.setNavigationItemSelectedListener(new NavigationView.OnNavigationItemSelectedListener() {
             @Override
             public boolean onNavigationItemSelected(@NonNull final MenuItem item) {
+                final MenuAppNavButton button;
                 switch (item.getItemId()) {
                     case R.id.drawer_home:
+                        button = MenuAppNavButton.HOME;
                         showHomeScreen();
                         break;
 
                     case R.id.drawer_settings:
+                        button = MenuAppNavButton.SETTINGS;
                         showSettingsScreen();
                         break;
 
@@ -178,6 +182,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
                         return false;
                 }
 
+                TelemetryWrapper.menuAppNavEvent(button);
                 drawer.closeDrawer(GravityCompat.START);
                 return true;
             }

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -13,6 +13,7 @@ import android.os.Bundle;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -13,7 +13,6 @@ import android.os.Bundle;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
@@ -47,6 +46,7 @@ import org.mozilla.focus.locale.LocaleAwareAppCompatActivity;
 import org.mozilla.focus.session.Session;
 import org.mozilla.focus.session.SessionManager;
 import org.mozilla.focus.session.Source;
+import org.mozilla.focus.telemetry.MenuBrowserNavButton;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.telemetry.UrlTextInputLocation;
 import org.mozilla.focus.utils.Direction;
@@ -311,16 +311,21 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
         if (fragment == null || !fragment.isVisible()) {
             return;
         }
+
+        final MenuBrowserNavButton navButton;
         switch (view.getId()) {
             case R.id.drawer_refresh_button:
+                navButton = MenuBrowserNavButton.REFRESH;
                 fragment.reload();
                 break;
             case R.id.drawer_back_button:
+                navButton = MenuBrowserNavButton.BACK;
                 if (fragment.canGoBack()) {
                     fragment.goBack();
                 }
                 break;
             case R.id.drawer_forward_button:
+                navButton = MenuBrowserNavButton.FORWARD;
                 if (fragment.canGoForward()) {
                     fragment.goForward();
                 }
@@ -329,6 +334,8 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
                 // Return so that we don't try to close the drawer
                 return;
         }
+
+        TelemetryWrapper.menuBrowserNavEvent(navButton);
         drawer.closeDrawer(GravityCompat.START);
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -422,12 +422,12 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
         if (canGoBack()) {
             // Go back in web history
             goBack();
+            TelemetryWrapper.browserBackControllerEvent();
         } else {
             getFragmentManager().popBackStack();
             SessionManager.getInstance().removeCurrentSession();
         }
 
-        TelemetryWrapper.browserBackControllerEvent();
         return true;
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -36,6 +36,7 @@ import org.mozilla.focus.session.NullSession;
 import org.mozilla.focus.session.Session;
 import org.mozilla.focus.session.SessionCallbackProxy;
 import org.mozilla.focus.session.SessionManager;
+import org.mozilla.focus.telemetry.ControllerBackLocation;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.Browsers;
 import org.mozilla.focus.utils.Direction;
@@ -427,6 +428,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
             SessionManager.getInstance().removeCurrentSession();
         }
 
+        TelemetryWrapper.controllerBackEvent(ControllerBackLocation.BROWSER);
         return true;
     }
 

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.java
@@ -36,7 +36,6 @@ import org.mozilla.focus.session.NullSession;
 import org.mozilla.focus.session.Session;
 import org.mozilla.focus.session.SessionCallbackProxy;
 import org.mozilla.focus.session.SessionManager;
-import org.mozilla.focus.telemetry.ControllerBackLocation;
 import org.mozilla.focus.telemetry.TelemetryWrapper;
 import org.mozilla.focus.utils.Browsers;
 import org.mozilla.focus.utils.Direction;
@@ -428,7 +427,7 @@ public class BrowserFragment extends WebFragment implements View.OnClickListener
             SessionManager.getInstance().removeCurrentSession();
         }
 
-        TelemetryWrapper.controllerBackEvent(ControllerBackLocation.BROWSER);
+        TelemetryWrapper.browserBackControllerEvent();
         return true;
     }
 

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -104,7 +104,7 @@ object TelemetryWrapper {
         const val HOME_TILE = "home_tile"
     }
 
-    private object Value {
+    internal object Value {
         val DEFAULT = "default"
         val FIREFOX = "firefox"
         val SELECTION = "selection"
@@ -128,6 +128,8 @@ object TelemetryWrapper {
         val RESUME = "resume"
         val RELOAD = "refresh"
         val CLEAR_DATA = "clear_data"
+        val BACK = "back"
+        val FORWARD = "forward"
     }
 
     private object Extra {
@@ -699,10 +701,22 @@ object TelemetryWrapper {
         val method = if (isShowing) Method.SHOW else Method.HIDE
         TelemetryEvent.create(Category.ACTION, method, Object.MENU).queue()
     }
+
+    @JvmStatic
+    fun menuBrowserNavEvent(button: MenuBrowserNavButton) {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.MENU, button.value).queue()
+    }
 }
 
 enum class UrlTextInputLocation(internal val extra: String) {
     // We hardcode the Strings so we can change the enum
     HOME("home"),
     MENU("menu"),
+}
+
+enum class MenuBrowserNavButton(val value: String) {
+    // We define separate `value`s so we can rename the enum without interfering.
+    REFRESH(TelemetryWrapper.Value.RELOAD),
+    BACK(TelemetryWrapper.Value.BACK),
+    FORWARD(TelemetryWrapper.Value.FORWARD),
 }

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -131,6 +131,8 @@ object TelemetryWrapper {
         val CLEAR_DATA = "clear_data"
         val BACK = "back"
         val FORWARD = "forward"
+        val HOME = "home"
+        val SETTINGS = "settings"
     }
 
     private object Extra {
@@ -709,6 +711,11 @@ object TelemetryWrapper {
     }
 
     @JvmStatic
+    fun menuAppNavEvent(button: MenuAppNavButton) {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.MENU, button.value).queue()
+    }
+
+    @JvmStatic
     fun controllerBackEvent(location: ControllerBackLocation) {
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.CONTROLLER, Value.BACK)
                 .extra(Extra.SOURCE, location.extra)
@@ -727,6 +734,12 @@ enum class MenuBrowserNavButton(val value: String) {
     REFRESH(TelemetryWrapper.Value.RELOAD),
     BACK(TelemetryWrapper.Value.BACK),
     FORWARD(TelemetryWrapper.Value.FORWARD),
+}
+
+enum class MenuAppNavButton(val value: String) {
+    // We define separate `value`s so we can rename the enum without interfering.
+    HOME(TelemetryWrapper.Value.HOME),
+    SETTINGS(TelemetryWrapper.Value.SETTINGS),
 }
 
 enum class ControllerBackLocation(val extra: String) {

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -102,6 +102,7 @@ object TelemetryWrapper {
         val CUSTOM_SEARCH_ENGINE = "custom_search_engine"
         val REMOVE_SEARCH_ENGINES = "remove_search_engines"
         const val HOME_TILE = "home_tile"
+        val CONTROLLER = "controller"
     }
 
     internal object Value {
@@ -706,6 +707,13 @@ object TelemetryWrapper {
     fun menuBrowserNavEvent(button: MenuBrowserNavButton) {
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.MENU, button.value).queue()
     }
+
+    @JvmStatic
+    fun controllerBackEvent(location: ControllerBackLocation) {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.CONTROLLER, Value.BACK)
+                .extra(Extra.SOURCE, location.extra)
+                .queue()
+    }
 }
 
 enum class UrlTextInputLocation(internal val extra: String) {
@@ -719,4 +727,9 @@ enum class MenuBrowserNavButton(val value: String) {
     REFRESH(TelemetryWrapper.Value.RELOAD),
     BACK(TelemetryWrapper.Value.BACK),
     FORWARD(TelemetryWrapper.Value.FORWARD),
+}
+
+enum class ControllerBackLocation(val extra: String) {
+    // We define separate `extra`s so we can rename the enum without interfering.
+    BROWSER("browser"),
 }

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -715,10 +715,14 @@ object TelemetryWrapper {
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.MENU, button.value).queue()
     }
 
+    /**
+     * The browser goes back from a controller press. Another way to track back presses is
+     * [menuBrowserNavEvent] with [MenuBrowserNavButton.BACK].
+     */
     @JvmStatic
-    fun controllerBackEvent(location: ControllerBackLocation) {
-        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.CONTROLLER, Value.BACK)
-                .extra(Extra.SOURCE, location.extra)
+    fun browserBackControllerEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.PAGE, Object.BROWSER, Value.BACK)
+                .extra(Extra.SOURCE, "controller")
                 .queue()
     }
 }
@@ -740,9 +744,4 @@ enum class MenuAppNavButton(val value: String) {
     // We define separate `value`s so we can rename the enum without interfering.
     HOME(TelemetryWrapper.Value.HOME),
     SETTINGS(TelemetryWrapper.Value.SETTINGS),
-}
-
-enum class ControllerBackLocation(val extra: String) {
-    // We define separate `extra`s so we can rename the enum without interfering.
-    BROWSER("browser"),
 }


### PR DESCRIPTION
One thing that feels silly to me is that the enums passed into my events
reference external Strings for their values, but I like that all of the
possible Category, Action, Method, Values, and Extras are listed in one place
so I kept it in.

Let me know if you think it's silly, liuche!

---

# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

1) What questions will you answer with this data?

- How often do users navigate back via the controller?
- How often do user go back, forward, and reload via the menu?
- How does back on menu compare to back on controller?
- How often do users use the menu to go home, or to settings?

2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements? Some example responses:

- Establish baselines about how users interact with websites via back/forward/refresh navigation
- Establish baselines about how often users use the menu and home screens

3) What alternative methods did you consider to answer these questions? Why were they not sufficient?

None. Could do UR but it's less telling than an aggregated data set.

4) Can current instrumentation answer these questions?

No.

5) List all proposed measurements and indicate the category of data collection for each measurement, using the Firefox [data c](https://wiki.mozilla.org/Firefox/Data_Collection)[ollection ](https://wiki.mozilla.org/Firefox/Data_Collection)[categories](https://wiki.mozilla.org/Firefox/Data_Collection) on the found on the Mozilla wiki.   

**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>Click on menu nav button (back, forward, reload)</td>
    <td>Interaction data</td>
    <td>#325</td>
  </tr>
  <tr>
    <td>Click on controller back button</td>
    <td>Interaction data</td>
    <td>#325</td>
  </tr>
  <tr>
    <td>Click on menu app nav button (home, settings)</td>
    <td>Interaction data</td>
    <td>#325</td>
  </tr>
</table>


6) How long will this data be collected?  Choose one of the following:

I want to permanently monitor this data (@bbinto).

7) What populations will you measure?

* Which release channels?

All.

* Which countries?

All

* Which locales?

All

* Any other filters?  Please describe in detail below.

No.

8) Please provide a general description of how you will analyze this data.

- See if users use back/forward/reload in unexpected ways for the product (e.g. they reload pages frequently)
- See if users access back/forward/reload at all (e.g. maybe to annoying to access in menu)
- See how often users use home screen (e.g. because entering urls via controller is difficult)
- See how often users change settings (e.g. especially useful after a new feature was added with settings)

9) Where do you intend to share the results of your analysis?

sql.tmo dashboards