### PR TITLE
I329 tp telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -139,8 +139,8 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
         drawerBack.setOnClickListener(this);
         drawerTrackingProtectionSwitch = findViewById(R.id.tracking_protection_switch);
 
-        // setChecked must be called by we add the listener, otherwise the listener will fired when we
-        // set the new value. In particular, this makes the telemetry inaccurate.
+        // setChecked must be called before we add the listener, otherwise the listener will fired when we
+        // call setChecked this first time. In particular, this would make telemetry inaccurate.
         drawerTrackingProtectionSwitch.setChecked(PreferenceManager.getDefaultSharedPreferences(this)
                 .getBoolean(TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF,
                         TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_DEFAULT));

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -138,6 +138,12 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
         drawerBack = findViewById(R.id.drawer_back_button);
         drawerBack.setOnClickListener(this);
         drawerTrackingProtectionSwitch = findViewById(R.id.tracking_protection_switch);
+
+        // setChecked must be called by we add the listener, otherwise the listener will fired when we
+        // set the new value. In particular, this makes the telemetry inaccurate.
+        drawerTrackingProtectionSwitch.setChecked(PreferenceManager.getDefaultSharedPreferences(this)
+                .getBoolean(TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF,
+                        TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_DEFAULT));
         drawerTrackingProtectionSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
@@ -157,9 +163,6 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
                 }, /* Switch.THUMB_ANIMATION_DURATION */ 250);
             }
         });
-        drawerTrackingProtectionSwitch.setChecked(PreferenceManager.getDefaultSharedPreferences(this)
-                .getBoolean(TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF,
-                        TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_DEFAULT));
 
         hintSettings = findViewById(R.id.hint_settings);
         hintSettings.setImageResource(R.drawable.ic_settings);

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -143,6 +143,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 PreferenceManager.getDefaultSharedPreferences(MainActivity.this).edit()
                         .putBoolean(TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF, b).apply();
+                TelemetryWrapper.turboModeSwitchEvent(b);
 
                 ThreadUtils.postToMainThreadDelayed(new Runnable() {
                     @Override

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -15,6 +15,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.search.SearchEngineManager
 import org.mozilla.focus.session.SessionManager
 import org.mozilla.focus.utils.AppConstants
+import org.mozilla.focus.webview.TrackingProtectionWebViewClient
 import org.mozilla.focus.widget.InlineAutocompleteEditText.AutocompleteResult
 import org.mozilla.telemetry.Telemetry
 import org.mozilla.telemetry.TelemetryHolder
@@ -206,7 +207,9 @@ object TelemetryWrapper {
                             resources.getString(R.string.pref_key_secure),
                             resources.getString(R.string.pref_key_default_browser),
                             resources.getString(R.string.pref_key_autocomplete_preinstalled),
-                            resources.getString(R.string.pref_key_autocomplete_custom))
+                            resources.getString(R.string.pref_key_autocomplete_custom),
+                            TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF
+                            )
                     .setSettingsProvider(TelemetrySettingsProvider(context))
                     .setCollectionEnabled(telemetryEnabled)
                     .setUploadEnabled(telemetryEnabled)

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -104,6 +104,7 @@ object TelemetryWrapper {
         val REMOVE_SEARCH_ENGINES = "remove_search_engines"
         const val HOME_TILE = "home_tile"
         val CONTROLLER = "controller"
+        val TURBO_MODE = "turbo_mode"
     }
 
     internal object Value {
@@ -134,6 +135,8 @@ object TelemetryWrapper {
         val FORWARD = "forward"
         val HOME = "home"
         val SETTINGS = "settings"
+        val ON = "on"
+        val OFF = "off"
     }
 
     private object Extra {
@@ -727,6 +730,13 @@ object TelemetryWrapper {
         TelemetryEvent.create(Category.ACTION, Method.PAGE, Object.BROWSER, Value.BACK)
                 .extra(Extra.SOURCE, "controller")
                 .queue()
+    }
+
+    /** @param isSwitchedOn true if the switch was turned on, false otherwise. */
+    @JvmStatic
+    fun turboModeSwitchEvent(isSwitchedOn: Boolean) {
+        val value = if (isSwitchedOn) Value.ON else Value.OFF
+        TelemetryEvent.create(Category.ACTION, Method.CHANGE, Object.TURBO_MODE, value).queue()
     }
 }
 


### PR DESCRIPTION
~~**NB: this is still untested**~~ Tested by:
- Setting breakpoint in TP
- Setting breakpoint in SettingsMeasurement.flush, which apparently gets called each time we background the app.

Found a bug, added a commit (and rebased).

---

# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

1) What questions will you answer with this data?

- What percentage of users have turbo mode enabled?
- How often do users enable and disable turbo mode?

2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements? Some example responses:

Establish baselines about how useful this feature is to users and how it might break their experience

3) What alternative methods did you consider to answer these questions? Why were they not sufficient?

None. Could do UR but it'd take longer than this, and this qualitative is more telling than UR.

4) Can current instrumentation answer these questions?

No.

5) List all proposed measurements and indicate the category of data collection for each measurement, using the Firefox [data c](https://wiki.mozilla.org/Firefox/Data_Collection)[ollection ](https://wiki.mozilla.org/Firefox/Data_Collection)[categories](https://wiki.mozilla.org/Firefox/Data_Collection) on the found on the Mozilla wiki.   

**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**

<table>
  <tr>
    <td>Measurement Description</td>
    <td>Data Collection Category</td>
    <td>Tracking Bug #</td>
  </tr>
  <tr>
    <td>User enabled/disabled turbo mode via menu</td>
    <td>Interaction data</td>
    <td>#329</td>
  </tr>
  <tr>
    <td>Does this user have turbo mode enabled generally?</td>
    <td>Interaction data</td>
    <td>#329</td>
  </tr>
</table>


6) How long will this data be collected?  Choose one of the following:

I want to permanently monitor this data (@bbinto).

7) What populations will you measure?

* Which release channels?

All.

* Which countries?

All

* Which locales?

All

* Any other filters?  Please describe in detail below.

No.

8) Please provide a general description of how you will analyze this data.

- See how often users enable/disable turbo mode for anomalies
- See what percentage of users of turbo mode enabled to determine continued investment in feature

9) Where do you intend to share the results of your analysis?

sql.tmo dashboards