### PR TITLE
Move isBlockingEnabled to global pref

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -141,14 +141,11 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
 
         // setChecked must be called before we add the listener, otherwise the listener will fired when we
         // call setChecked this first time. In particular, this would make telemetry inaccurate.
-        drawerTrackingProtectionSwitch.setChecked(PreferenceManager.getDefaultSharedPreferences(this)
-                .getBoolean(TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF,
-                        TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_DEFAULT));
+        drawerTrackingProtectionSwitch.setChecked(Settings.getInstance(this).isBlockingEnabled());
         drawerTrackingProtectionSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
-                PreferenceManager.getDefaultSharedPreferences(MainActivity.this).edit()
-                        .putBoolean(TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF, b).apply();
+                Settings.getInstance(MainActivity.this).setBlockingEnabled(b);
                 TelemetryWrapper.turboModeSwitchEvent(b);
 
                 ThreadUtils.postToMainThreadDelayed(new Runnable() {

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -12,6 +12,7 @@ import android.preference.PreferenceManager
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.OnboardingActivity
 import org.mozilla.focus.search.SearchEngine
+import org.mozilla.focus.webview.TrackingProtectionWebViewClient
 
 /**
  * A simple wrapper for SharedPreferences that makes reading preference a little bit easier.
@@ -67,4 +68,9 @@ class Settings private constructor(context: Context) {
 
     private fun getPreferenceKey(resourceId: Int): String =
             resources.getString(resourceId)
+
+    var isBlockingEnabled: Boolean // Delegates to shared prefs; could be custom delegate.
+        get() = preferences.getBoolean(TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF,
+                TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_DEFAULT)
+        set(value) = preferences.edit().putBoolean(TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF, value).apply()
 }

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -31,7 +31,7 @@ class Settings private constructor(context: Context) {
         }
     }
 
-    private val preferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+    val preferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
     private val resources: Resources = context.resources
 
     val defaultSearchEngineName: String?

--- a/app/src/webview/java/org/mozilla/focus/webview/SystemWebView.java
+++ b/app/src/webview/java/org/mozilla/focus/webview/SystemWebView.java
@@ -100,11 +100,6 @@ public class SystemWebView extends NestedWebView implements IWebView, SharedPref
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         WebViewProvider.applyAppSettings(getContext(), getSettings());
-        if (key.equals(TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF)) {
-            setBlockingEnabled(sharedPreferences.getBoolean(
-                    TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_PREF,
-                    TrackingProtectionWebViewClient.TRACKING_PROTECTION_ENABLED_DEFAULT));
-        }
     }
 
     @Override


### PR DESCRIPTION
Two major changes:
- Centralize access to TP in a property
- Cache global access directly in TrackingProtectionViewWebViewClient.blockingEnabled with shared prefs getter

I decide to add this second cache step to potentially improve perf