### PR TITLE
Update gradle wrapper version and disable optimizations on beta.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,8 +40,8 @@ android {
         }
         beta {
             initWith debug
-            minifyEnabled true
-            shrinkResources true
+            minifyEnabled false // AmazonWebView is not configured properly.
+            shrinkResources false // Doesn't work properly
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             applicationIdSuffix ".beta"
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
We disabled some build optimizations on release, but never did that for the beta flavor, so updating that here.

The gradle wrapper also starts throwing errors while building apks, so updating to the minimum required version.

```
Error:Failed to complete Gradle execution.

Cause:
The version of Gradle you are using (3.3) does not support the forTasks() method on BuildActionExecuter. Support for this is available in Gradle 3.5 and all later versions.
```