### PR TITLE
Closes #387: disable left-to-open-menu when VoiceView is enabled.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.java
@@ -97,8 +97,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
     private final AccessibilityManager.TouchExplorationStateChangeListener voiceViewStateChangeListener = new AccessibilityManager.TouchExplorationStateChangeListener() {
         @Override
         public void onTouchExplorationStateChanged(final boolean enabled) {
-            // The user can turn on/off VoiceView, at which point we may want to change the cursor visibility.
-            updateCursorState();
+            updateForVoiceView(enabled);
         }
     };
 
@@ -311,6 +310,14 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
         }
     }
 
+    private void updateForVoiceView(final boolean isVoiceViewEnabled) {
+        // The user can turn on/off VoiceView, at which point we may want to change the cursor visibility.
+        updateCursorState();
+
+        // See declaration of hintNavigationBar in XML for details.
+        hintNavigationBar.setFocusable(!isVoiceViewEnabled);
+    }
+
     private void updateCursorState() {
         final BrowserFragment browserFragment =
                 (BrowserFragment) getSupportFragmentManager().findFragmentByTag(BrowserFragment.FRAGMENT_TAG);
@@ -323,7 +330,7 @@ public class MainActivity extends LocaleAwareAppCompatActivity implements OnUrlE
     protected void onStart() {
         super.onStart();
         ContextKt.getAccessibilityManager(this).addTouchExplorationStateChangeListener(voiceViewStateChangeListener);
-        updateCursorState(); // VoiceView could be disabled when we're outside the app.
+        updateForVoiceView(ContextKt.isVoiceViewEnabled(this));
     }
 
     @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -38,7 +38,12 @@
         </LinearLayout>
 
         <!-- A view that hints to the user that they can click left to get to the navigation bar.
-             We make this focusable so that we can open the real navigation bar when this is selected. -->
+             We make this focusable so that we can open the real navigation bar when this is selected.
+
+             a11y: However, non-visual users will find it unintuitive to open the menu, a new modal
+             state, by pressing left, especially if it cannot be undone by pressing the reverse
+             direction (as is the case now) so we dynamically disable focusability in code when
+             VoiceView is enabled: users can explicitly use the menu button to open the menu. -->
         <LinearLayout
                 xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:tools="http://schemas.android.com/tools"


### PR DESCRIPTION
We comment in XML, even though it's more intuitive to comment in code,
because we don't have a good way to point XML readers to the existing
code whereas code readers can always find the declaration of the view.