### PR TITLE
Closes #493: Set root container to focus descendants first.

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,8 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:focusable="true">
+    android:focusable="true"
+    android:descendantFocusability="afterDescendants"
+    >
 </LinearLayout>
 


### PR DESCRIPTION
This prevents focus from getting stuck on the root container, rather
than one of its children views.

It's not a perfect solution: when we back out of the soft keyboard, the
last home tile is focused rather than the url bar, but I think it's good
enough for the amount of time I invested in it.

This does not fix the Youtube reload hack.