### PR TITLE
Closes #492 - Prevent proguarding necessary AmazonWebKitFactory files.

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,6 +32,9 @@
 #   public *;
 #}
 
+-keep public class com.amazon.android.webkit.android.AndroidWebKitFactory { public *; }
+-keep public class com.amazon.android.webkit.embedded.EmbeddedWebKitFactory { public *; }
+
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
 #-keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
Add missing files, see issue for more detailed explanation.