### PR TITLE
i276: Clean up InlineAutocompleteEditText; disable autocomplete on Fire TV Remote app

### DIFF
--- a/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
+++ b/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
@@ -97,8 +97,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
 
     // The previous autocomplete result returned to us
     private AutocompleteResult mAutoCompleteResult = AutocompleteResult.emptyResult();
-    // Length of the user-typed portion of the result
-    private int mAutoCompletePrefixLength;
     // If text change is due to us setting autocomplete
     private boolean mSettingAutoComplete;
     // Spans used for marking the autocomplete text
@@ -209,16 +207,8 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
 
         mAutoCompleteResult = AutocompleteResult.emptyResult();
 
-        // Pretend we already autocompleted the existing text,
-        // so that actions like backspacing don't trigger autocompletion.
-        mAutoCompletePrefixLength = getText().length();
-
         // Show the cursor.
         setCursorVisible(true);
-    }
-
-    protected String getNonAutocompleteText() {
-        return getNonAutocompleteText(getText());
     }
 
     /**
@@ -254,10 +244,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
         // When we call delete() here, the autocomplete spans we set are removed as well.
         text.delete(start, text.length());
 
-        // Keep mAutoCompletePrefixLength the same because the prefix has not changed.
-        // Clear mAutoCompleteResult to make sure we get fresh autocomplete text next time.
-        mAutoCompleteResult = AutocompleteResult.emptyResult();
-
         // Reshow the cursor.
         setCursorVisible(true);
 
@@ -283,10 +269,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
         for (final Object span : mAutoCompleteSpans) {
             text.removeSpan(span);
         }
-
-        // Keep mAutoCompleteResult the same because the result has not changed.
-        // Reset mAutoCompletePrefixLength because the prefix now includes the autocomplete text.
-        mAutoCompletePrefixLength = text.length();
 
         // Reshow the cursor.
         setCursorVisible(true);
@@ -411,12 +393,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
         }
 
         announceForAccessibility(text.toString());
-    }
-
-    public String getOriginalText() {
-        final Editable text = getText();
-
-        return text.subSequence(0, mAutoCompletePrefixLength).toString();
     }
 
     @NonNull
@@ -553,8 +529,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
                 // If you're hitting backspace (the string is getting smaller), don't autocomplete
                 doAutocomplete = false;
             }
-
-            mAutoCompletePrefixLength = textLength;
 
             // If we are not autocompleting, we set mDiscardAutoCompleteResult to true
             // to discard any autocomplete results that are in-flight, and vice versa.

--- a/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
+++ b/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
@@ -125,7 +125,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
     public void onAttachedToWindow() {
         super.onAttachedToWindow();
         setOnKeyListener(new KeyListener());
-        setOnKeyPreImeListener(new KeyPreImeListener());
         addTextChangedListener(new TextChangeListener());
     }
 
@@ -535,9 +534,35 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
         }
     }
 
-    private class KeyPreImeListener implements OnKeyPreImeListener {
+    private class KeyListener implements View.OnKeyListener {
         @Override
-        public boolean onKeyPreIme(View v, int keyCode, KeyEvent event) {
+        public boolean onKey(View v, int keyCode, KeyEvent event) {
+            if (keyCode == KeyEvent.KEYCODE_ENTER) {
+                if (event.getAction() != KeyEvent.ACTION_DOWN) {
+                    return true;
+                }
+
+                if (mCommitListener != null) {
+                    mCommitListener.onCommit();
+                }
+
+                return true;
+            }
+
+            if ((keyCode == KeyEvent.KEYCODE_DEL ||
+                    (keyCode == KeyEvent.KEYCODE_FORWARD_DEL)) &&
+                    removeAutocomplete(getText())) {
+                // Delete autocomplete text when backspacing or forward deleting.
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (isAttachedToWindow()) {
             // We only want to process one event per tap
             if (event.getAction() != KeyEvent.ACTION_DOWN) {
                 return false;
@@ -565,49 +590,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
             }
 
             return false;
-        }
-    }
-
-    private class KeyListener implements View.OnKeyListener {
-        @Override
-        public boolean onKey(View v, int keyCode, KeyEvent event) {
-            if (keyCode == KeyEvent.KEYCODE_ENTER) {
-                if (event.getAction() != KeyEvent.ACTION_DOWN) {
-                    return true;
-                }
-
-                if (mCommitListener != null) {
-                    mCommitListener.onCommit();
-                }
-
-                return true;
-            }
-
-            if ((keyCode == KeyEvent.KEYCODE_DEL ||
-                    (keyCode == KeyEvent.KEYCODE_FORWARD_DEL)) &&
-                    removeAutocomplete(getText())) {
-                // Delete autocomplete text when backspacing or forward deleting.
-                return true;
-            }
-
-            return false;
-        }
-    }
-
-    private OnKeyPreImeListener mOnKeyPreImeListener;
-
-    public interface OnKeyPreImeListener {
-        public boolean onKeyPreIme(View v, int keyCode, KeyEvent event);
-    }
-
-    public void setOnKeyPreImeListener(OnKeyPreImeListener listener) {
-        mOnKeyPreImeListener = listener;
-    }
-
-    @Override
-    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
-        if (mOnKeyPreImeListener != null) {
-            return mOnKeyPreImeListener.onKeyPreIme(this, keyCode, event);
         }
 
         return false;

--- a/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
+++ b/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
@@ -149,9 +149,7 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
 
     @Override
     public void setText(final CharSequence text, final TextView.BufferType type) {
-        final String textString = (text == null) ? "" : text.toString();
-
-        super.setText(textString, type);
+        super.setText(text, type);
 
         // Any autocomplete text would have been overwritten, so reset our autocomplete states.
         resetAutocompleteState();

--- a/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
+++ b/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
@@ -42,10 +42,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
         void onFilter(String searchText, InlineAutocompleteEditText view);
     }
 
-    public interface OnSearchStateChangeListener {
-        void onSearchStateChange(boolean isActive);
-    }
-
     public interface OnBackPressedListener {
         void onBackPressed();
     }
@@ -97,7 +93,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
 
     private OnCommitListener mCommitListener;
     private OnFilterListener mFilterListener;
-    private OnSearchStateChangeListener mSearchStateChangeListener;
     private OnBackPressedListener mOnBackPressedListener;
 
     // The previous autocomplete result returned to us
@@ -128,10 +123,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
         mOnBackPressedListener = listener;
     }
 
-    void setOnSearchStateChangeListener(OnSearchStateChangeListener listener) {
-        mSearchStateChangeListener = listener;
-    }
-
     @Override
     public void onAttachedToWindow() {
         super.onAttachedToWindow();
@@ -144,13 +135,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
     @Override
     public void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
         super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
-
-        // Make search icon inactive when edit toolbar search term isn't a user entered
-        // search term
-        final boolean isActive = !TextUtils.isEmpty(getText());
-        if (mSearchStateChangeListener != null) {
-            mSearchStateChangeListener.onSearchStateChange(isActive);
-        }
 
         if (gainFocus) {
             resetAutocompleteState();
@@ -585,11 +569,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
                 // Otherwise, remove the old autocomplete text
                 // until any new autocomplete text gets added.
                 removeAutocomplete(editable);
-            }
-
-            // Update search icon with an active state since user is typing
-            if (mSearchStateChangeListener != null) {
-                mSearchStateChangeListener.onSearchStateChange(textLength > 0);
             }
 
             if (mFilterListener != null) {

--- a/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
+++ b/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
@@ -46,10 +46,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
         void onSearchStateChange(boolean isActive);
     }
 
-    public interface OnTextChangeListener {
-        void onTextChange(String originalText, String autocompleteText);
-    }
-
     public interface OnBackPressedListener {
         void onBackPressed();
     }
@@ -102,7 +98,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
     private OnCommitListener mCommitListener;
     private OnFilterListener mFilterListener;
     private OnSearchStateChangeListener mSearchStateChangeListener;
-    private OnTextChangeListener mTextChangeListener;
     private OnBackPressedListener mOnBackPressedListener;
 
     // The previous autocomplete result returned to us
@@ -135,10 +130,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
 
     void setOnSearchStateChangeListener(OnSearchStateChangeListener listener) {
         mSearchStateChangeListener = listener;
-    }
-
-    public void setOnTextChangeListener(OnTextChangeListener listener) {
-        mTextChangeListener = listener;
     }
 
     @Override
@@ -603,10 +594,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
 
             if (mFilterListener != null) {
                 mFilterListener.onFilter(text, doAutocomplete ? InlineAutocompleteEditText.this : null);
-            }
-
-            if (mTextChangeListener != null) {
-                mTextChangeListener.onTextChange(text, getText().toString());
             }
         }
 

--- a/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
+++ b/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
@@ -7,7 +7,6 @@ package org.mozilla.focus.widget;
 
 import android.content.Context;
 import android.graphics.Rect;
-import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.text.Editable;
@@ -20,7 +19,6 @@ import android.text.style.BackgroundColorSpan;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.inputmethod.BaseInputConnection;
@@ -620,33 +618,5 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
         }
 
         super.onSelectionChanged(selStart, selEnd);
-    }
-
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        if (android.os.Build.VERSION.SDK_INT == Build.VERSION_CODES.M &&
-                event.getActionMasked() == MotionEvent.ACTION_UP) {
-            // Android 6 occasionally throws a NullPointerException inside Editor.onTouchEvent()
-            // for ACTION_UP when attempting to display (uninitialised) text handles. The Editor
-            // and TextView IME interactions are quite complex, so I don't know how to properly
-            // work around this issue, but we can at least catch the NPE to prevent crashing
-            // the whole app.
-            // (Editor tries to make both selection handles visible, but in certain cases they haven't
-            // been initialised yet, causing the NPE. It doesn't bother to check the selection handle
-            // state, and making some other calls to ensure the handles exist doesn't seem like a
-            // clean solution either since I don't understand most of the selection logic. This implementation
-            // only seems to exist in Android 6, both Android 5 and 7 have different implementations.)
-            try {
-                return super.onTouchEvent(event);
-            } catch (NullPointerException ignored) {
-                // Ignore this (see above) - since we're now in an unknown state let's clear all selection
-                // (which is still better than an arbitrary crash that we can't control):
-                clearFocus();
-                return true;
-            }
-        } else {
-            return super.onTouchEvent(event);
-
-        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
+++ b/app/src/main/java/org/mozilla/focus/widget/InlineAutocompleteEditText.java
@@ -682,7 +682,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
 
     private OnKeyPreImeListener mOnKeyPreImeListener;
     private OnSelectionChangedListener mOnSelectionChangedListener;
-    private OnWindowFocusChangeListener mOnWindowFocusChangeListener;
 
     public interface OnKeyPreImeListener {
         public boolean onKeyPreIme(View v, int keyCode, KeyEvent event);
@@ -716,22 +715,6 @@ public class InlineAutocompleteEditText extends android.support.v7.widget.AppCom
         }
 
         super.onSelectionChanged(selStart, selEnd);
-    }
-
-    public interface OnWindowFocusChangeListener {
-        public void onWindowFocusChanged(boolean hasFocus);
-    }
-
-    public void setOnWindowFocusChangeListener(OnWindowFocusChangeListener listener) {
-        mOnWindowFocusChangeListener = listener;
-    }
-
-    @Override
-    public void onWindowFocusChanged(boolean hasFocus) {
-        super.onWindowFocusChanged(hasFocus);
-        if (mOnWindowFocusChangeListener != null) {
-            mOnWindowFocusChangeListener.onWindowFocusChanged(hasFocus);
-        }
     }
 
     @Override


### PR DESCRIPTION
I haven't had a chance to test the iOS Fire TV Remote App yet – the batteries are dead on the office iPhone. :(