### PR TITLE
Initial fastlane screenshot support + home screen test

### DIFF
--- a/Screengrabfile
+++ b/Screengrabfile
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This is the template for our Screengrabfile used in automation.
+# tools/taskcluster/generate_screengrab_config.py will read this
+# file and generate the final configuration that we use inside
+# a taskcluster task.
+
+use_tests_in_packages ['org.mozilla.focus.screenshots']
+app_package_name 'org.mozilla.tv.firefox.debug'
+
+app_apk_path 'app/build/outputs/apk/app-amazonWebview-debug.apk'
+tests_apk_path 'app/build/outputs/apk/app-amazonWebview-debug-androidTest.apk'
+
+# Supported locales
+locales ['en-US', 'de', 'zh-cn', 'fr', 'it', 'ja', 'pt-BR', 'es-ES']
+
+# Clear all previous screenshots locally. Technically not needed in automation.
+# But it's easier to debug this on a local device if there are no old screenshots
+# hanging around.
+clear_previous_screenshots true
+
+exit_on_test_failure false
+
+skip_open_summary false

--- a/app/src/androidTest/java/org/mozilla/focus/screenshots/ScreenshotTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screenshots/ScreenshotTest.java
@@ -1,0 +1,79 @@
+package org.mozilla.focus.screenshots;
+
+import android.app.Instrumentation;
+import android.content.Context;
+import android.support.annotation.StringRes;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.IdlingRegistry;
+import android.support.test.uiautomator.UiDevice;
+import android.text.format.DateUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.mozilla.focus.helpers.SessionLoadedIdlingResource;
+
+import tools.fastlane.screengrab.Screengrab;
+import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
+
+/**
+ * Base class for tests that take screenshots.
+ */
+abstract class ScreenshotTest {
+    final long waitingTime = DateUtils.SECOND_IN_MILLIS * 10;
+
+    private Context targetContext;
+    private SessionLoadedIdlingResource loadingIdlingResource;
+
+    UiDevice device;
+
+    @Rule
+    public TestRule screenshotOnFailureRule = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            // On error take a screenshot so that we can debug it easily
+            Screengrab.screenshot("FAILURE-" + getScreenshotName(description));
+        }
+
+        private String getScreenshotName(Description description) {
+            return description.getClassName().replace(".", "-")
+                    + "_"
+                    + description.getMethodName().replace(".", "-");
+        }
+    };
+
+    @Before
+    public void setUpScreenshots() {
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+        targetContext = instrumentation.getTargetContext();
+        device = UiDevice.getInstance(instrumentation);
+
+        // Use this to switch between default strategy and HostScreencap strategy
+        Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
+        //Screengrab.setDefaultScreenshotStrategy(new HostScreencapScreenshotStrategy(device));
+
+        device.waitForIdle();
+    }
+
+    @Before
+    public void setUpIdlingResources() {
+        loadingIdlingResource = new SessionLoadedIdlingResource();
+        IdlingRegistry.getInstance().register(loadingIdlingResource);
+    }
+
+    @After
+    public void tearDownIdlingResources() {
+        IdlingRegistry.getInstance().unregister(loadingIdlingResource);
+    }
+
+    String getString(@StringRes int resourceId) {
+        return targetContext.getString(resourceId).trim();
+    }
+
+    String getString(@StringRes int resourceId, Object... formatArgs) {
+        return targetContext.getString(resourceId, formatArgs).trim();
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/screenshots/TVScreenshots.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screenshots/TVScreenshots.java
@@ -1,0 +1,137 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.screenshots;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.test.uiautomator.UiObjectNotFoundException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.MethodSorters;
+import org.mozilla.focus.R;
+import org.mozilla.focus.activity.MainActivity;
+
+import tools.fastlane.screengrab.Screengrab;
+import tools.fastlane.screengrab.locale.LocaleTestRule;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.pressBack;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.isDialog;
+import static android.support.test.espresso.matcher.ViewMatchers.hasFocus;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.mozilla.focus.activity.OnboardingActivity.ONBOARD_SHOWN_PREF;
+import static org.hamcrest.Matchers.allOf;
+
+@RunWith(AndroidJUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TVScreenshots extends ScreenshotTest {
+
+    private Intent intent;
+    private SharedPreferences.Editor preferencesEditor;
+
+    @ClassRule
+    public static final LocaleTestRule localeTestRule = new LocaleTestRule();
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<MainActivity>(MainActivity.class,
+            true, false);
+
+    @Before
+    public void setUp() throws Exception {
+        intent = new Intent();
+
+        Context appContext = InstrumentationRegistry.getInstrumentation()
+                .getTargetContext()
+                .getApplicationContext();
+
+        preferencesEditor = PreferenceManager.getDefaultSharedPreferences(appContext).edit();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mActivityTestRule.getActivity().finishAndRemoveTask();
+    }
+
+    @Test
+    public void TVFirstLaunchScreen() throws InterruptedException, UiObjectNotFoundException {
+        /* Overwrite the app preference before main activity launch */
+        preferencesEditor
+                .putBoolean(ONBOARD_SHOWN_PREF, false)
+                .apply();
+
+        mActivityTestRule.launchActivity(intent);
+
+        onView(withId(R.id.enable_turbo_mode))
+                .check(matches(isDisplayed()));
+        onView(withId(R.id.turbo_mode_title))
+                .check(matches(isDisplayed()));
+        onView(withId(R.id.disable_turbo_mode))
+                .check(matches(isDisplayed()));
+
+        Screengrab.screenshot("first-launch");
+    }
+
+    @Test
+    public void TVScreenshotsHomeScreen() throws InterruptedException, UiObjectNotFoundException {
+        /* capture a screenshot of the default home-screen */
+        mActivityTestRule.launchActivity(intent);
+
+        onView(withId(R.id.urlInputView))
+                .check(matches(isDisplayed()));
+        onView(withId(R.id.homeUrlBar))
+                .check(matches(isDisplayed()));
+
+        Screengrab.screenshot("home-screen");
+    }
+
+    @Test
+    public void TVScreenshotsSettings() throws InterruptedException, UiObjectNotFoundException {
+        /* default home-screen in the main activity should be displayed */
+        mActivityTestRule.launchActivity(intent);
+
+        onView(allOf(withId(R.id.urlInputView), isDisplayed(), hasFocus()));
+
+        /* visit settings */
+        onView(allOf(withId(R.id.settingsButton), isDisplayed()))
+                .perform(click());
+
+        /* current settings list view */
+        onView(allOf(withId(R.id.settingsWebView), isDisplayed()));
+
+        ViewInteraction clearButton = onView(
+                allOf(withId(R.id.deleteButton), isDisplayed()));
+
+        /* capture a screenshot of the default settings list */
+        Screengrab.screenshot("settings");
+
+        /* capture a screenshot of the clear data dialog */
+        clearButton.perform(click());
+
+        ViewInteraction confirmClear = onView(
+                allOf(withText(R.string.settings_cookies_dialog_content), isDisplayed()))
+                .inRoot(isDialog());
+
+        Screengrab.screenshot("clear-all-data");
+
+        confirmClear.perform(pressBack());
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# Android Studio sets android.inject.testOnly automatically on some APKs that are ran from the IDE
+# However on some devices the APK can not be installed. This is a work-around
+android.inject.testOnly = false


### PR DESCRIPTION
This PR adds initial fast lane screenshot support and an initial basic home-screen test. We'll be adding additional tests that tour through the available views