### PR TITLE
Closes #535: Use separate Docker image on taskcluster.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -26,7 +26,7 @@ tasks:
     payload:
       maxRunTime: 3600
       deadline: "{{ '2 hours' | $fromNow }}"
-      image: 'mozillamobile/focus-android'
+      image: 'mozillamobile/firefox-tv'
       command:
         - /bin/bash
         - '--login'
@@ -70,7 +70,7 @@ tasks:
     payload:
       maxRunTime: 3600
       deadline: "{{ '2 hours' | $fromNow }}"
-      image: 'mozillamobile/focus-android'
+      image: 'mozillamobile/firefox-tv'
       command:
         - /bin/bash
         - '--login'

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -5,7 +5,7 @@
 # Inspired by:
 # https://hub.docker.com/r/runmymind/docker-android-sdk/~/dockerfile/
 
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 
 MAINTAINER Sebastian Kaspari "skaspari@mozilla.com"
 
@@ -85,11 +85,11 @@ RUN /opt/tools/android-accept-licenses.sh android update sdk --no-ui --obsolete 
 WORKDIR /opt
 
 # Checkout source code
-RUN git clone https://github.com/mozilla-mobile/focus-android.git
+RUN git clone https://github.com/mozilla-mobile/firefox-tv.git
 
 # Build project and run gradle tasks once to pull all dependencies
-WORKDIR /opt/focus-android
-RUN ./gradlew assemble testAmazonWebviewDebugUnitTest lint pmd checkstyle findbugs
+WORKDIR /opt/firefox-tv/
+RUN ./gradlew clean assemble lint checkstyle ktlint pmd test
 
 # -- Post setup -------------------------------------------------------------------------
 


### PR DESCRIPTION
To avoid builds breaking on taskcluster whenever the Focus image changes:
Let's use a separate image.

As a side effect this fixes archiving test artifacts too.