### PR TITLE
[MERGE V2.1] Closes #557: Use Delegates.observable instead of setter.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/cursor/CursorController.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/cursor/CursorController.kt
@@ -12,9 +12,10 @@ import android.view.View
 import android.view.accessibility.AccessibilityManager
 import kotlinx.android.synthetic.main.fragment_browser.*
 import org.mozilla.focus.architecture.NonNullObserver
+import org.mozilla.focus.browser.BrowserFragment
 import org.mozilla.focus.ext.getAccessibilityManager
 import org.mozilla.focus.ext.isVoiceViewEnabled
-import org.mozilla.focus.browser.BrowserFragment
+import kotlin.properties.Delegates
 
 private const val SCROLL_MULTIPLIER = 45
 
@@ -35,12 +36,11 @@ class CursorController(
         cursorParent: View,
         private val view: CursorView
 ) : AccessibilityManager.TouchExplorationStateChangeListener, LifecycleObserver {
-    var isEnabled = true
-        set(value) {
-            field = value
-            keyDispatcher.isEnabled = value
-            view.visibility = if (value) View.VISIBLE else View.GONE
-        }
+
+    private var isEnabled: Boolean by Delegates.observable(true) { _, _, newValue ->
+        keyDispatcher.isEnabled = newValue
+        view.visibility = if (newValue) View.VISIBLE else View.GONE
+    }
 
     private val viewModel = CursorViewModel(onUpdate = { x, y, scrollVel ->
         view.updatePosition(x, y)

--- a/app/src/main/java/org/mozilla/focus/browser/cursor/CursorViewModel.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/cursor/CursorViewModel.kt
@@ -17,6 +17,7 @@ import org.mozilla.focus.ext.use
 import org.mozilla.focus.utils.Direction
 import java.util.EnumSet
 import java.util.concurrent.TimeUnit
+import kotlin.properties.Delegates
 
 private const val UPDATE_DELAY_MILLIS = 20L
 
@@ -52,17 +53,16 @@ class CursorViewModel(
      * The bounds inside which this cursor should remain, i.e. the screen bounds.
      * Must be set by the caller.
      */
-    var maxBounds = PointF(0f, 0f)
-        @UiThread set(value) {
-            field = value
-            if (isInitialPosSet) {
-                clampPos(pos, value)
-            } else {
-                isInitialPosSet = true
-                pos.set(value.x / 2, value.y / 2) // Center.
-            }
-            onUpdate(pos.x, pos.y, getScrollVel())
+    @set:UiThread
+    var maxBounds by Delegates.observable(PointF(0f, 0f)) { _, _, newValue ->
+        if (isInitialPosSet) {
+            clampPos(pos, newValue)
+        } else {
+            isInitialPosSet = true
+            pos.set(newValue.x / 2, newValue.y / 2) // Center.
         }
+        onUpdate(pos.x, pos.y, getScrollVel())
+    }
 
     private var isInitialPosSet = false
     private val pos = PointF(0f, 0f)


### PR DESCRIPTION
observable is safer because you can't accidentally change the value
being set and it's more readable.

observable does not work in all cases - using observable in
CheckableImageButton throws a NPE. I think this is because the property
is referenced by onCreateDrawableState, which is referenced by the super
constructor and these properties can't be referenced before the
constructor has returned. I deduced this from this
discussion: https://discuss.kotlinlang.org/t/npe-with-delegate/1808/4