### PR TITLE
Closes #442: add screenshots to custom tiles

### DIFF
--- a/app/src/amazonWebview/java/org/mozilla/focus/webview/FirefoxAmazonWebView.kt
+++ b/app/src/amazonWebview/java/org/mozilla/focus/webview/FirefoxAmazonWebView.kt
@@ -6,6 +6,7 @@
 package org.mozilla.focus.webview
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.os.Bundle
 import android.support.annotation.VisibleForTesting
 import android.util.AttributeSet
@@ -105,6 +106,15 @@ internal class FirefoxAmazonWebView(
 
     override fun cleanup() {
         this.deleteData()
+    }
+
+    override fun takeScreenshot(): Bitmap {
+        // Under the hood, createBitmap may create a new reference to the existing Bitmap so
+        // it's efficient: we don't have to copy the existing Bitmap or GC it on destroy.
+        buildDrawingCache()
+        val outBitmap = Bitmap.createBitmap(drawingCache)
+        destroyDrawingCache()
+        return outBitmap
     }
 }
 

--- a/app/src/androidTest/java/org/mozilla/focus/Assert.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/Assert.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import junit.framework.Assert.assertEquals
+
+/**
+ * Asserts the two bitmaps are the same by ensuring their dimensions, config, and
+ * pixel data are the same (within the provided delta): this is the same metrics that
+ * [Bitmap.sameAs] uses.
+ */
+fun assertEqualsWithDelta(expectedB: Bitmap, actualB: Bitmap, delta: Float) {
+    assertEquals("widths should be equal", expectedB.width, actualB.width)
+    assertEquals("heights should be equal", expectedB.height, actualB.height)
+    assertEquals("config should be equal", expectedB.config, actualB.config)
+
+    for (i in 0 until expectedB.width) {
+        for (j in 0 until expectedB.height) {
+            val ePx = expectedB.getPixel(i, j)
+            val aPx = actualB.getPixel(i, j)
+            val warn = "Pixel ${i}x$j"
+            assertEquals("$warn a", Color.alpha(ePx).toFloat(), Color.alpha(aPx).toFloat(), delta)
+            assertEquals("$warn r", Color.red(ePx).toFloat(), Color.red(aPx).toFloat(), delta)
+            assertEquals("$warn g", Color.green(ePx).toFloat(), Color.green(aPx).toFloat(), delta)
+            assertEquals("$warn b", Color.blue(ePx).toFloat(), Color.blue(aPx).toFloat(), delta)
+        }
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/integration/home/HomeTileScreenshotStoreIntegrationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/integration/home/HomeTileScreenshotStoreIntegrationTest.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.integration.home
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import junit.framework.Assert.assertNotNull
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.focus.assertEqualsWithDelta
+import org.mozilla.focus.home.HomeTileScreenshotStore
+import java.util.UUID
+
+@RunWith(AndroidJUnit4::class)
+class HomeTileScreenshotStoreIntegrationTest {
+
+    private lateinit var andyContext: Context // coroutines shadow `context` name.
+
+    @Before
+    fun setUp() {
+        andyContext = InstrumentationRegistry.getTargetContext()
+        andyContext.filesDir.listFiles().forEach { it.deleteRecursively() } // Clean up between tests.
+    }
+
+    /**
+     * Tests that the bitmap we save to the store is the same one we get out.
+     * This must be run on device because Robolectric replaces Bitmap with
+     * ShadowBitmap, which overrides the compress method. We could try to
+     * mock around it or write a custom shadow, but it's probably not worth it.
+     */
+    @Test
+    fun testSaveAndReadRestoresBitmap() = runBlocking {
+        // We use a bitmap that won't change much after compression.
+        val expectedBitmap = getRedSquare()
+        val uuid = UUID.randomUUID()
+        HomeTileScreenshotStore.saveAsync(andyContext, uuid, expectedBitmap).join()
+
+        val actualBitmap = HomeTileScreenshotStore.read(andyContext, uuid)
+
+        // Delta chosen by testing against our compression quality.
+        assertNotNull(actualBitmap)
+        assertEqualsWithDelta(expectedBitmap, actualBitmap!!, 7f)
+    }
+}
+
+private fun getRedSquare(): Bitmap {
+    val dimen = 140
+    val colors = IntArray(dimen * dimen) { Color.RED }
+    return Bitmap.createBitmap(colors, dimen, dimen, Bitmap.Config.ARGB_8888)
+}

--- a/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/web/WebViewProvider.java
@@ -6,6 +6,7 @@
 package org.mozilla.focus.web;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.view.View;
@@ -116,6 +117,12 @@ public class WebViewProvider {
         @Override
         public void cleanup() {
             // We're running in a private browsing window, so nothing to do
+        }
+
+        @NotNull
+        @Override
+        public Bitmap takeScreenshot() {
+            throw new NotImplementedError();
         }
 
         @Override

--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -142,7 +142,8 @@ class BrowserFragment : IWebViewLifecycleFragment(),
                 this@BrowserFragment.url?.let { url ->
                     when (value) {
                         NavigationEvent.VAL_CHECKED -> {
-                            CustomTilesManager.getInstance(context).pinSite(context, url)
+                            CustomTilesManager.getInstance(context).pinSite(context, url,
+                                    webView?.takeScreenshot())
                             showCenteredTopToast(context, R.string.notification_pinned_site, 0, 200)
                         }
                         NavigationEvent.VAL_UNCHECKED -> {

--- a/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.kt
@@ -134,11 +134,11 @@ private class HomeTileAdapter(val onUrlEnteredListener: OnUrlEnteredListener, va
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = TileViewHolder(
             LayoutInflater.from(parent.context).inflate(R.layout.home_tile, parent, false)
     )
+}
 
-    private fun onBindBundledHomeTile(holder: TileViewHolder, tile: BundledHomeTile) = with (holder) {
-        val bitmap = BundledTilesManager.getInstance(itemView.context).loadImageFromPath(itemView.context, tile.imagePath)
-        iconView.setImageBitmap(bitmap)
-    }
+private fun onBindBundledHomeTile(holder: TileViewHolder, tile: BundledHomeTile) = with (holder) {
+    val bitmap = BundledTilesManager.getInstance(itemView.context).loadImageFromPath(itemView.context, tile.imagePath)
+    iconView.setImageBitmap(bitmap)
 }
 
 private class TileViewHolder(

--- a/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.focus.fragment
 
 import android.animation.ObjectAnimator
-import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.os.Bundle
 import android.support.v4.app.Fragment
@@ -24,17 +23,16 @@ import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
-import org.json.JSONObject
 import org.mozilla.focus.R
 import org.mozilla.focus.autocomplete.UrlAutoCompleteFilter
 import org.mozilla.focus.ext.forceExhaustive
 import org.mozilla.focus.home.HomeTileScreenshotStore
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.telemetry.UrlTextInputLocation
-import org.mozilla.focus.tiles.CustomHomeTile
-import org.mozilla.focus.tiles.CustomTilesManager
 import org.mozilla.focus.tiles.BundledHomeTile
 import org.mozilla.focus.tiles.BundledTilesManager
+import org.mozilla.focus.tiles.CustomHomeTile
+import org.mozilla.focus.tiles.CustomTilesManager
 import org.mozilla.focus.tiles.HomeTile
 import org.mozilla.focus.utils.OnUrlEnteredListener
 

--- a/app/src/main/java/org/mozilla/focus/home/HomeTileScreenshotStore.kt
+++ b/app/src/main/java/org/mozilla/focus/home/HomeTileScreenshotStore.kt
@@ -105,6 +105,14 @@ object HomeTileScreenshotStore {
         }
     }
 
+    /** @param a unique identifier for this screenshot. */
+    @AnyThread
+    fun removeAsync(context: Context, uuid: UUID) = launch {
+        fileSystemLock.write {
+            getFileForUUID(context, uuid).delete()
+        }
+    }
+
     /**
      * A blocking function to read a bitmap from the store.
      *

--- a/app/src/main/java/org/mozilla/focus/home/HomeTileScreenshotStore.kt
+++ b/app/src/main/java/org/mozilla/focus/home/HomeTileScreenshotStore.kt
@@ -56,6 +56,16 @@ private val COMPRESSION_FORMAT = Bitmap.CompressFormat.WEBP
  */
 private const val COMPRESSION_QUALITY = 50
 
+private val BITMAP_FACTORY_OPTIONS = BitmapFactory.Options().apply {
+    // When full resolution in memory, 1080p Bitmap takes up ~7.9MiB, no matter how it's been
+    // compressed on disk. To save memory and reduce CPU downscale overhead, we downsample.
+    //
+    // In 1080p, our max resolution, screenshots are 1920x1080px and the tiles are 280x200px
+    // (not dp). We divide the screenshots by 4, 480x270px, which fits in the tiles: these
+    // Bitmaps take up ~0.5MiB in memory.
+    inSampleSize = 4
+}
+
 /**
  * Storage for webpage screenshots used for the home tiles.
  *
@@ -116,10 +126,6 @@ object HomeTileScreenshotStore {
     /**
      * A blocking function to read a bitmap from the store.
      *
-     * TODO: Add downscale argument.
-     * When full size in memory, a 1080p Bitmap takes up ~7.9MiB, no matter how it's been compressed
-     * on disk.
-     *
      * @param uuid unique identifier for this screenshot.
      * @return The decoded [Bitmap], or null if the file DNE or the bitmap could not be decoded.
      */
@@ -131,7 +137,7 @@ object HomeTileScreenshotStore {
                 null
             } else {
                 file.inputStream().use {
-                    BitmapFactory.decodeStream(it)
+                    BitmapFactory.decodeStream(it, null, BITMAP_FACTORY_OPTIONS)
                 }
             }
         }

--- a/app/src/main/java/org/mozilla/focus/home/HomeTileScreenshotStore.kt
+++ b/app/src/main/java/org/mozilla/focus/home/HomeTileScreenshotStore.kt
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.home
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.support.annotation.AnyThread
+import android.support.annotation.VisibleForTesting
+import android.support.annotation.WorkerThread
+import kotlinx.coroutines.experimental.launch
+import org.mozilla.focus.home.HomeTileScreenshotStore.DIR
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+/**
+ * The format with which to compress on disk. Our goals for storage:
+ * - Store full resolution, with minimal artifacting: we don't know how we'll display the images in
+ * future redesigns so we want to preserve them as best as possible.
+ * - Take up minimal space: we don't have how many tiles the user will store.
+ *
+ * WebP was chosen through testing: it produces the smallest file sizes with the least amount of
+ * visual artifacting but is the most computationally expensive to save (2000ms WebP vs. 200ms JPEG),
+ * which is irrelevant for our infrequent screenshots.
+ *
+ * For file size comparisons, at 1080p, quality 50 on IMDB (a dense page):
+ * - WebP is ~65 KiB with almost no artifacts
+ * - JPEG is ~130 KiB with noticeable artifacts up close
+ * - PNG is ~1.6MiB with no artifacts (it is lossless)
+ */
+private val COMPRESSION_FORMAT = Bitmap.CompressFormat.WEBP
+
+/**
+ * The quality argument to [Bitmap.compress]: this value was picked through testing (see
+ * [COMPRESSION_FORMAT] for goals). Here are comparisons at visual quality:
+ * - 100: Possibly lossless
+ * - 50: Visual artifacts essentially unnoticeable
+ * - 25: Colors are muted and text starts to have noticeable compression
+ *
+ * Some approximate data points:
+ * - IMDB quality 100: 426 KiB
+ * - IMDB quality 50: 65 KiB
+ * - IMDB quality 25: 43.6 KiB
+ * - Google Video quality 50: 16 KiB
+ * - Google Video quality 25: 13 KiB
+ *
+ * Since the data storage difference between 50 and 25 is negligible but there is a noticeable drop
+ * in visual quality, I chose to use 50. Since these screenshots will be shrunk, we could probably
+ * use lower quality but I'm concerned downscaling will make visual artifacts more significant and I
+ * didn't feel it was worth the time to test.
+ */
+private const val COMPRESSION_QUALITY = 50
+
+/**
+ * Storage for webpage screenshots used for the home tiles.
+ *
+ * We use UUIDs as identifiers for screenshots, rather than URLs (a natural choice) because:
+ * - URLs can exceed the maximum file name length; UUIDs can't
+ * - URLs can contain illegal file name characters; UUID's can't
+ * - URLs (as Strings) need to be validated (e.g. is it blank?)
+ * - The [CustomTilesManager] stores a unique identifier so we rely on it to provide one,
+ * pushing the complexity there.
+ *
+ * This class is thread-safe: see lock javadoc for details.
+ */
+object HomeTileScreenshotStore {
+
+    @VisibleForTesting const val DIR = "home_screenshots"
+
+    /**
+     * A lock on all file system operations: we acquire an exclusive lock for any writes and a
+     * shared lock for any reads. In practice, we should have little contention: reads happen only
+     * when showing the home tiles while writes can only happen when we pin or unpin a site, neither
+     * of which should happen concurrently with a read. This locking is important to ensure the
+     * initial write completes before any reads.
+     *
+     * We could do more granular locking by having a lock per file/URL/screenshot, but that would be
+     * more complex for little gain, given the little contention we expect.
+     *
+     * One downside to using a [ReentrantReadWriteLock] is that it's not coroutine aware: in the
+     * event of contention, threads from the common thread pool will be removed from scheduling
+     * until the write lock returns, forcing the thread pool to spin up more threads if there are
+     * more readers. However, coroutine aware solutions (e.g. [Mutex]) would require more
+     * coarse-grained locking that will generate contention, or more complexity, which isn't worth
+     * it given our low chances of contention.
+     */
+    private val fileSystemLock = ReentrantReadWriteLock()
+
+    /** @param uuid a unique identifier for this screenshot. */
+    @AnyThread
+    fun saveAsync(context: Context, uuid: UUID, screenshot: Bitmap) = launch {
+        fileSystemLock.write {
+            ensureParentDirs(context)
+
+            val screenshotFile = getFileForUUID(context, uuid)
+            screenshotFile.createNewFile()
+            screenshotFile.outputStream().use {
+                screenshot.compress(COMPRESSION_FORMAT, COMPRESSION_QUALITY, it)
+            }
+        }
+    }
+
+    /**
+     * A blocking function to read a bitmap from the store.
+     *
+     * TODO: Add downscale argument.
+     * When full size in memory, a 1080p Bitmap takes up ~7.9MiB, no matter how it's been compressed
+     * on disk.
+     *
+     * @param uuid unique identifier for this screenshot.
+     * @return The decoded [Bitmap], or null if the file DNE or the bitmap could not be decoded.
+     */
+    @WorkerThread // file access.
+    fun read(context: Context, uuid: UUID): Bitmap? {
+        return fileSystemLock.read {
+            val file = getFileForUUID(context, uuid)
+            if (!file.exists()) {
+                null
+            } else {
+                file.inputStream().use {
+                    BitmapFactory.decodeStream(it)
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting internal fun getFileForUUID(context: Context, uuid: UUID) = File(context.filesDir, getPathForUUID(uuid))
+}
+
+private fun ensureParentDirs(context: Context) { File(context.filesDir, DIR).mkdirs() }
+private fun getPathForUUID(uuid: UUID) = "$DIR/$uuid"

--- a/app/src/main/java/org/mozilla/focus/tiles/HomeTilesManager.kt
+++ b/app/src/main/java/org/mozilla/focus/tiles/HomeTilesManager.kt
@@ -7,12 +7,14 @@ package org.mozilla.focus.tiles
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.support.annotation.AnyThread
 import android.support.annotation.UiThread
 import org.json.JSONArray
 import org.mozilla.focus.ext.toUri
+import org.mozilla.focus.home.HomeTileScreenshotStore
 import org.mozilla.focus.utils.UrlUtils
 import java.util.UUID
 
@@ -134,19 +136,22 @@ class CustomTilesManager private constructor(context: Context) {
     fun getCustomHomeTilesList() = customTilesCache.values.reversed()
 
     @UiThread
-    fun pinSite(context: Context, url: String) {
-        // TODO: titles, screenshots/icons.
-        customTilesCache.put(url, CustomHomeTile(url, "custom", UUID.randomUUID()))
+    fun pinSite(context: Context, url: String, screenshot: Bitmap?) {
+        // TODO: titles
+        val uuid = UUID.randomUUID()
+        customTilesCache[url] = CustomHomeTile(url, "custom", uuid)
         writeCacheToSharedPreferences(context)
+
+        if (screenshot != null) {
+            HomeTileScreenshotStore.saveAsync(context, uuid, screenshot)
+        }
     }
 
     @UiThread
     fun unpinSite(context: Context, url: String): Boolean {
-        if (!customTilesCache.containsKey(url)) {
-            return false
-        }
-        customTilesCache.remove(url)
+        val tile = customTilesCache.remove(url) ?: return false
         writeCacheToSharedPreferences(context)
+        HomeTileScreenshotStore.removeAsync(context, tile.id)
         return true
     }
 

--- a/app/src/main/java/org/mozilla/focus/web/IWebView.kt
+++ b/app/src/main/java/org/mozilla/focus/web/IWebView.kt
@@ -5,8 +5,9 @@
 
 package org.mozilla.focus.web
 
+import android.graphics.Bitmap
+import android.support.annotation.CheckResult
 import android.view.View
-
 import org.mozilla.focus.session.Session
 
 interface IWebView {
@@ -44,6 +45,13 @@ interface IWebView {
     fun restoreWebViewState(session: Session)
     fun saveWebViewState(session: Session)
     fun destroy()
+
+    /**
+     * Take a screenshot of the screen.
+     * @return a bitmap with the contents of the screen: *don't forget to recycle it!*
+     */
+    @CheckResult
+    fun takeScreenshot(): Bitmap
 
     val isYoutubeTV: Boolean
         get() {

--- a/app/src/test/java/org/mozilla/focus/home/HomeTileScreenshotStoreUnitTest.kt
+++ b/app/src/test/java/org/mozilla/focus/home/HomeTileScreenshotStoreUnitTest.kt
@@ -49,6 +49,37 @@ class HomeTileScreenshotStoreUnitTest {
         val actualBitmap = HomeTileScreenshotStore.read(RuntimeEnvironment.application, uuid)
         assertNull(actualBitmap)
     }
+
+    /** Assumes [HomeTileScreenshotStore.getFileForUUID] works correctly. */
+    @Test
+    fun testRemoveAsyncRemovesFile() = runBlocking {
+        val context = RuntimeEnvironment.application
+        val file = HomeTileScreenshotStore.getFileForUUID(context, uuid)
+        file.parentFile.mkdirs()
+        file.createNewFile()
+        file.writeText("Some test text")
+        assertEquals(1, file.parentFile.list().size)
+
+        HomeTileScreenshotStore.removeAsync(context, uuid).join()
+
+        assertEquals(0, file.parentFile.list().size)
+    }
+
+    /**
+     * Assumes [HomeTileScreenshotStore.saveAsync] and [HomeTileScreenshotStore.getFileForUUID]
+     * works correctly.
+     */
+    @Test
+    fun testRemoveAsyncRemovesFileWrittenBySaveAsync() = runBlocking {
+        val context = RuntimeEnvironment.application
+        val parentFile = HomeTileScreenshotStore.getFileForUUID(context, uuid).parentFile
+        HomeTileScreenshotStore.saveAsync(context, uuid, getBitmap()).join()
+        assertEquals(1, parentFile.list().size)
+
+        HomeTileScreenshotStore.removeAsync(context, uuid).join()
+
+        assertEquals(0, parentFile.list().size)
+    }
 }
 
 private fun getBitmap() = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)

--- a/app/src/test/java/org/mozilla/focus/home/HomeTileScreenshotStoreUnitTest.kt
+++ b/app/src/test/java/org/mozilla/focus/home/HomeTileScreenshotStoreUnitTest.kt
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.home
+
+import android.graphics.Bitmap
+import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertNull
+import kotlinx.coroutines.experimental.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.UUID
+
+/**
+ * Unit tests for the screenshot store. Though HomeTileScreenshotStoreIntegrationTest exists,
+ * we run these as unit tests to conserve resources.
+ *
+ * We could improve the tests by additionally testing:
+ * - Read/write locking works correctly.
+ */
+@RunWith(RobolectricTestRunner::class)
+class HomeTileScreenshotStoreUnitTest {
+
+    private lateinit var uuid: UUID
+
+    @Before
+    fun setUp() {
+        RuntimeEnvironment.application.filesDir.listFiles().forEach { it.deleteRecursively() }
+        uuid = UUID.randomUUID()
+    }
+
+    /** Assumes [HomeTileScreenshotStore.getFileForUUID] works correctly. */
+    @Test
+    fun testSaveAsyncDoesNotOverwrite() = runBlocking {
+        val context = RuntimeEnvironment.application
+        HomeTileScreenshotStore.saveAsync(context, uuid, getBitmap()).join()
+        HomeTileScreenshotStore.saveAsync(context, UUID.randomUUID(), getBitmap()).join()
+
+        assertEquals(2,
+                HomeTileScreenshotStore.getFileForUUID(context, uuid).parentFile.list().size)
+    }
+
+    @Test
+    fun testReadFileDoesNotExist() {
+        val actualBitmap = HomeTileScreenshotStore.read(RuntimeEnvironment.application, uuid)
+        assertNull(actualBitmap)
+    }
+}
+
+private fun getBitmap() = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)


### PR DESCRIPTION
This patch series is still missing:
- Placeholders when screenshots could not be fetched
- Polished animation for async screenshot fetching
- UI polish

I was thinking we could do those in follow-ups (if Tif doesn't get back to me in time).