### PR TITLE
Adds espresso-contrib library and basic UI page load test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,6 +152,16 @@ dependencies {
     androidTestCompile "com.android.support.test.espresso:espresso-core:$espresso_version", {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
+
+    androidTestCompile("com.android.support.test.espresso:espresso-contrib:$espresso_version") {
+        exclude module: 'appcompat-v7'
+        exclude module: 'support-v4'
+        exclude module: 'support-annotations'
+        exclude module: 'recyclerview-v7'
+        exclude module: 'design'
+        exclude module: 'espresso-core'
+    }
+
     androidTestCompile "com.android.support.test.espresso:espresso-idling-resource:$espresso_version"
     androidTestCompile "com.android.support.test.espresso:espresso-web:$espresso_version", {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/app/src/androidTest/java/org/mozilla/focus/activity/PageLoadTest.java
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/PageLoadTest.java
@@ -1,0 +1,109 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.activity;
+
+import android.content.Context;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.contrib.RecyclerViewActions;
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.espresso.web.webdriver.Locator;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.test.uiautomator.UiDevice;
+import android.support.test.uiautomator.UiObjectNotFoundException;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.focus.R;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.pressImeActionButton;
+import static android.support.test.espresso.action.ViewActions.typeTextIntoFocusedView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.hasFocus;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static android.support.test.espresso.web.sugar.Web.onWebView;
+import static android.support.test.espresso.web.webdriver.DriverAtoms.findElement;
+import static org.hamcrest.Matchers.allOf;
+import static org.mozilla.focus.activity.OnboardingActivity.ONBOARD_SHOWN_PREF;
+import static org.hamcrest.core.StringContains.containsString;
+
+@RunWith(AndroidJUnit4.class)
+public class PageLoadTest {
+
+    private UiDevice mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+    private static final Integer TILE_POSITION = 1; // Google Video Search
+    private static final String TILE_WEBSITE_ELEMENT = "hplogo"; // Google logo
+    private static final String MOZILLA_URL = "mozilla.org";
+    private static final String MOZILLA_PAGE_ELEMENT = ".content h2";
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityTestRule
+            = new ActivityTestRule<MainActivity>(MainActivity.class) {
+        @Override
+        protected void beforeActivityLaunched() {
+            super.beforeActivityLaunched();
+
+            Context appContext = InstrumentationRegistry.getInstrumentation()
+                    .getTargetContext()
+                    .getApplicationContext();
+
+            PreferenceManager.getDefaultSharedPreferences(appContext)
+                    .edit()
+                    .putBoolean(ONBOARD_SHOWN_PREF, true)
+                    .apply();
+        }
+    };
+
+    @After
+    public void tearDown() throws Exception {
+        mActivityTestRule.getActivity().finishAndRemoveTask();
+    }
+
+    @Test
+    public void PageLoadTest() throws InterruptedException, UiObjectNotFoundException {
+        onView(ViewMatchers.withId(R.id.tileContainer))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(TILE_POSITION, click()));
+
+        onView(ViewMatchers.withId(R.id.webview))
+                .check(matches(isDisplayed()));
+
+        onWebView()
+                .withElement(findElement(Locator.ID, TILE_WEBSITE_ELEMENT));
+
+        mDevice.pressMenu();
+
+        onView(ViewMatchers.withId(R.id.navUrlInput))
+                .check(matches(isDisplayed()))
+                .check(matches(withText(containsString("google"))));
+
+        onView(ViewMatchers.withId(R.id.navButtonHome))
+                .check(matches(isDisplayed()))
+                .perform(click());
+
+        onView(allOf(withId(R.id.urlInputView), isDisplayed(), hasFocus()))
+                .perform(typeTextIntoFocusedView(MOZILLA_URL))
+                .perform(pressImeActionButton());
+
+        onView(ViewMatchers.withId(R.id.webview))
+                .check(matches(isDisplayed()));
+
+        onWebView()
+                .withElement(findElement(Locator.CSS_SELECTOR, MOZILLA_PAGE_ELEMENT));
+
+        mDevice.pressMenu();
+
+        onView(ViewMatchers.withId(R.id.navUrlInput))
+                .check(matches(isDisplayed()))
+                .check(matches(withText(containsString("mozilla"))));
+    }
+}


### PR DESCRIPTION
- Adds espresso-contrib library to Gradle in order to extend Espresso to work with RecyclerViewAction interactions for the home-screen tiles

- Adds a basic page-load UI test