### PR TITLE
Fixes #567

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -190,7 +190,7 @@ class BrowserFragment : IWebViewLifecycleFragment(),
                 goBack()
                 TelemetryWrapper.browserBackControllerEvent()
             }
-            browserOverlay.isVisible -> browserOverlay.setOverlayVisibleByUser(false)
+            browserOverlay.isVisible -> showOverlay(false)
             else -> {
                 fragmentManager.popBackStack()
                 SessionManager.getInstance().removeCurrentSession()


### PR DESCRIPTION
 Re-enables the cursor when using the back button to closing the overlay.

@mcomella I'm curious if we just never caught this before? I could have sworn this was working between the last time this code has changed.