### PR TITLE
Fixes #588 - Adds TV specific colors

### DIFF
--- a/app/src/main/res/values/tv_colors.xml
+++ b/app/src/main/res/values/tv_colors.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<resources>
+    <color name="tv_white">#eeeeee</color>
+    <color name="tv_blue50">@color/photonBlue50</color>
+    <color name="tv_blue60">@color/photonBlue60</color>
+    <color name="tv_ink">#0c0c15</color>
+    <color name="tv_ink2">#282938</color>
+</resources>


### PR DESCRIPTION
#564 is dependent on the new ink colors. So I figured we could start with the `tv_colors` now.

I noticed that I've been using snake case for the names. Should these be camel case?