### PR TITLE
Closes #587: App Crashing After Pinning Youtube Video

### DIFF
--- a/app/src/main/java/org/mozilla/focus/web/IWebViewLifecycleFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/web/IWebViewLifecycleFragment.kt
@@ -78,11 +78,12 @@ abstract class IWebViewLifecycleFragment : LocaleAwareFragment() {
     }
 
     override fun onDestroyView() {
-        webView!!.callback = null
-        webView!!.destroy()
-        webView = null
-
         super.onDestroyView()
+        if (webView != null) {
+            webView!!.callback = null
+            webView!!.destroy()
+            webView = null
+        }
     }
 
     override fun applyLocale() {


### PR DESCRIPTION
We might be calling onDestroy() twice... so we do a null check.... LOL yay android 