### PR TITLE
Closes #608: show subdomain.domain; strip common prefix.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/fragment/HomeFragment.kt
@@ -254,7 +254,10 @@ private fun onBindCustomHomeTile(uiLifecycleCancelJob: Job, holder: TileViewHold
         val title = if (validUri == null) {
             CompletableDeferred(item.url)
         } else {
-            async { FormattedDomain.format(itemView.context, validUri, true, 1) }
+            async {
+                val subdomainDotDomain = FormattedDomain.format(itemView.context, validUri, false, 1)
+                FormattedDomain.stripCommonPrefixes(subdomainDotDomain)
+            }
         }
 
         // Wait for both to complete so we can animate them together.

--- a/app/src/main/java/org/mozilla/focus/utils/FormattedDomain.java
+++ b/app/src/main/java/org/mozilla/focus/utils/FormattedDomain.java
@@ -93,6 +93,22 @@ public class FormattedDomain {
         return domainStr;
     }
 
+    public static String stripCommonPrefixes(@NonNull final String host) {
+        // In contrast to desktop, we also strip mobile subdomains,
+        // since its unlikely users are intentionally typing them
+        int start = 0;
+
+        if (host.startsWith("www.")) {
+            start = 4;
+        } else if (host.startsWith("mobile.")) {
+            start = 7;
+        } else if (host.startsWith("m.")) {
+            start = 2;
+        }
+
+        return host.substring(start);
+    }
+
     /** Strips any subdomains from the host over the given limit. */
     private static String stripSubdomains(String host, final int desiredSubdomainCount) {
         int includedSubdomainCount = 0;


### PR DESCRIPTION
This strip code is from fennec:
https://searchfox.org/mozilla-central/rev/efce4ceddfbe5fe4e2d74f1aed93894bada9b273/mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/StringUtils.java#142

Apparently I left the public suffix in. :(