### PR TITLE
Closes #627: Lock per file in HomeTileScreenshotStore.

### DIFF
--- a/app/src/test/java/org/mozilla/focus/home/HomeTileScreenshotStoreUnitTest.kt
+++ b/app/src/test/java/org/mozilla/focus/home/HomeTileScreenshotStoreUnitTest.kt
@@ -59,7 +59,7 @@ class HomeTileScreenshotStoreUnitTest {
     }
 
     @Test
-    fun testReadFileDoesNotExist() {
+    fun testReadFileDoesNotExist() = runBlocking {
         val actualBitmap = HomeTileScreenshotStore.read(RuntimeEnvironment.application, uuid)
         assertNull(actualBitmap)
     }


### PR DESCRIPTION
This mitigates #610, where the whole screenshot store can wait on a
single write, preventing custom home tiles from being shown.