### PR TITLE
Closes #559: Allow home tile list to cut-off at bottom of screen.

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -7,7 +7,9 @@
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
-              android:padding="50dp"
+              android:paddingTop="50dp"
+              android:paddingStart="50dp"
+              android:paddingEnd="50dp"
               android:background="@drawable/background_home">
 
     <LinearLayout
@@ -73,6 +75,7 @@
             android:clipChildren="false"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingBottom="18dp"
             android:background="@android:color/transparent"/>
 
 </LinearLayout>


### PR DESCRIPTION
This doesn't entirely solve the issue: when focusing the fourth row (the
partially hidden row), the fifth row is not shown. I think this would
fix #634 if we fixed this behavior.