### PR TITLE
Update docker image

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -30,6 +30,8 @@ RUN gem install fastlane
 
 RUN locale-gen en_US.UTF-8
 
+ENV LANG en_US.UTF-8
+
 # -- Android SDK ------------------------------------------------------------------------
 
 RUN cd /opt && wget -q https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz -O android-sdk.tgz

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -43,11 +43,12 @@ ENV PATH ${PATH}:${ANDROID_SDK_HOME}/tools:${ANDROID_SDK_HOME}/platform-tools:/o
 # Platform tools
 RUN echo y | android update sdk --no-ui --all --filter platform-tools | grep 'package installed'
 
-# Android 8.0 / SDK 26
+# Android SDK
 RUN echo y | android update sdk --no-ui --all --filter android-26 | grep 'package installed'
 
-# Build tools 26.0.1
+# Build tools
 RUN echo y | android update sdk --no-ui --all --filter build-tools-26.0.1 | grep 'package installed'
+RUN echo y | android update sdk --no-ui --all --filter build-tools-26.0.2 | grep 'package installed'
 
 # Extras
 RUN echo y | android update sdk --no-ui --all --filter extra-android-m2repository | grep 'package installed'

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -61,21 +61,6 @@ COPY tools /opt/tools
 # Accept licenses
 COPY licenses ${ANDROID_SDK_HOME}/licenses
 
-# -- Emulator ---------------------------------------------------------------------------
-
-# Android 5.0 / SDK 21
-RUN echo y | android update sdk --no-ui --all --filter android-21 | grep 'package installed'
-
-# Emulator image
-RUN echo y | android update sdk --no-ui --all --filter sys-img-armeabi-v7a-android-21 | grep 'package installed'
-
-# Create emulator AVD
-RUN echo no | android create avd -f -n test -t android-21 --abi default/armeabi-v7a --skin 480x800
-
-# Create fake keymap file (Otherwise the emulator won't start up)
-RUN mkdir /opt/android-sdk-linux/tools/keymaps && \
-    touch /opt/android-sdk-linux/tools/keymaps/en-us
-
 # -- Update SDK -------------------------------------------------------------------------
 
 # Update SDK


### PR DESCRIPTION
This is mainly for PR #672 / #425.

But while I was at it I also updated the image to fix #594 and removed the API 21 Android emulator that shouldn't be needed for FireTV development.