### PR TITLE
No issue: remove UTF-8 hack.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -36,7 +36,7 @@ tasks:
           && git config advice.detachedHead false
           && git checkout {{event.head.sha}}
           && echo "--" > .adjust_token
-          && LANG=en_US.UTF-8 ./gradlew clean assemble lint checkstyle ktlint pmd test
+          && ./gradlew clean assemble lint checkstyle ktlint pmd test
       artifacts:
         'public':
           type: 'directory'


### PR DESCRIPTION
Sebastian fixed this properly in #676 so this hack should no longer be
necessary.

Let's make sure TC passes the tests after this.