### PR TITLE
I472 60fps cursor

### DIFF
--- a/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
@@ -88,7 +88,7 @@ public class WebViewProvider {
         }
 
         @Override
-        public void flingScroll(int vx, int vy) {
+        public void scrollBy(int vx, int vy) {
 
         }
 

--- a/app/src/main/java/org/mozilla/focus/browser/cursor/CursorController.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/cursor/CursorController.kt
@@ -17,7 +17,7 @@ import org.mozilla.focus.ext.getAccessibilityManager
 import org.mozilla.focus.ext.isVoiceViewEnabled
 import kotlin.properties.Delegates
 
-private const val SCROLL_MULTIPLIER = 45
+private const val SCROLL_MULTIPLIER = 0.60f
 
 /**
  * Encapsulates interactions of the Cursors components. It has the following responsibilities:
@@ -97,7 +97,7 @@ class CursorController(
     private fun scrollWebView(scrollVel: PointF) {
         val scrollX = Math.round(scrollVel.x * SCROLL_MULTIPLIER)
         val scrollY = Math.round(scrollVel.y * SCROLL_MULTIPLIER)
-        browserFragment.webView?.flingScroll(scrollX, scrollY)
+        browserFragment.webView?.scrollBy(scrollX, scrollY)
     }
 
     private inner class CursorIsLoadingObserver : NonNullObserver<Boolean>() {

--- a/app/src/main/java/org/mozilla/focus/browser/cursor/CursorViewModel.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/cursor/CursorViewModel.kt
@@ -19,11 +19,11 @@ import java.util.EnumSet
 import java.util.concurrent.TimeUnit
 import kotlin.properties.Delegates
 
-private const val UPDATE_DELAY_MILLIS = 20L
+private const val UPDATE_DELAY_MILLIS = 17L // ~60 FPS.
 private const val UPDATE_DELAY_MILLIS_F = UPDATE_DELAY_MILLIS.toFloat() // Avoid conversion in update loop.
 
 private const val ACCEL_MODIFIER = 0.98f
-private const val MAX_VELOCITY = 25f
+private const val MAX_VELOCITY = 21.25f
 
 private const val DOWN_TIME_OFFSET_MILLIS = 100
 

--- a/app/src/main/java/org/mozilla/focus/browser/cursor/CursorViewModel.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/cursor/CursorViewModel.kt
@@ -44,7 +44,7 @@ private const val DOWN_TIME_OFFSET_MILLIS = 100
  * @param simulateTouchEvent Takes the given touch event and simulates a touch to the screen.
  */
 class CursorViewModel(
-        private val onUpdate: (x: Float, y: Float, scrollVel: PointF) -> Unit,
+        private val onUpdate: (x: Float, y: Float, percentMaxScrollVel: PointF, framesPassed: Float) -> Unit,
         private val simulateTouchEvent: (MotionEvent) -> Unit
 ) {
 
@@ -62,7 +62,7 @@ class CursorViewModel(
             isInitialPosSet = true
             pos.set(newValue.x / 2, newValue.y / 2) // Center.
         }
-        onUpdate(pos.x, pos.y, getScrollVel())
+        onUpdate(pos.x, pos.y, getPercentMaxScrollVel(), 1f)
     }
 
     private var isInitialPosSet = false
@@ -95,7 +95,7 @@ class CursorViewModel(
         }
 
         clampPos(pos, maxBounds)
-        onUpdate(pos.x, pos.y, getScrollVel())
+        onUpdate(pos.x, pos.y, getPercentMaxScrollVel(), framesPassed)
     }
 
     private fun updatePosForVel(dir: Direction, vel: Float, framesPassed: Float) {
@@ -108,19 +108,20 @@ class CursorViewModel(
         }
     }
 
-    private fun getScrollVel(): PointF {
+    private fun getPercentMaxScrollVel(): PointF {
         scrollVelReturnVal.set(0f, 0f)
         if (vel > 0f) {
+            val percentMaxVel = vel / MAX_VELOCITY
             if (pos.x == 0f && pressedDirections.contains(Direction.LEFT)) {
-                scrollVelReturnVal.x = -vel
+                scrollVelReturnVal.x = -percentMaxVel
             } else if (pos.x == maxBounds.x && pressedDirections.contains(Direction.RIGHT)) {
-                scrollVelReturnVal.x = vel
+                scrollVelReturnVal.x = percentMaxVel
             }
 
             if (pos.y == 0f && pressedDirections.contains(Direction.UP)) {
-                scrollVelReturnVal.y = -vel
+                scrollVelReturnVal.y = -percentMaxVel
             } else if (pos.y == maxBounds.y && pressedDirections.contains(Direction.DOWN)) {
-                scrollVelReturnVal.y = vel
+                scrollVelReturnVal.y = percentMaxVel
             }
         }
         return scrollVelReturnVal

--- a/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
+++ b/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
@@ -37,7 +37,7 @@ interface IWebView {
     fun canGoForward(): Boolean
     fun canGoBack(): Boolean
 
-    fun flingScroll(vx: Int, vy: Int)
+    fun scrollBy(vx: Int, vy: Int)
     fun requestFocus(): Boolean
 
     fun cleanup()


### PR DESCRIPTION
This patch series:
- Smooths the cursor movement
- Smooths page scrolling
- Makes sure all user interactions are adjusted by time (which guarantees equal distance moved, no matter what the framerate is, e.g. we'll continue to scroll the same distance even during page load unlike the existing code)
- Otherwise preserves cursor/scrolling behavior. I think we can improve here by at least speeding up the scroll speed but maybe also applying slightly deceleration to scrolling (rather than immediate stops) and perhaps speeding up the cursor.