### PR TITLE
i641 add settings pressed state

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
@@ -86,7 +86,7 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
 
         setupUrlInput()
         turboButton.isChecked = Settings.getInstance(context).isBlockingEnabled
-        navButtonSettings.setImageResource(R.drawable.ic_settings)
+        navButtonSettings.setImageResource(R.drawable.ic_settings) // Must be set in code for SVG to work correctly.
 
         val tintDrawable: (Drawable?) -> Unit = { it?.setTint(ContextCompat.getColor(context, R.color.tv_white)) }
         navCloseHint.compoundDrawablesRelative.forEach(tintDrawable)

--- a/app/src/main/java/org/mozilla/focus/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/HomeFragment.kt
@@ -82,7 +82,7 @@ class HomeFragment : Fragment() {
         initUrlInputView()
 
         settingsButton.alpha = SETTINGS_ICON_IDLE_ALPHA
-        settingsButton.setImageResource(R.drawable.ic_settings)
+        settingsButton.setImageResource(R.drawable.ic_settings) // Must be set in code for SVG to work correctly.
         settingsButton.setOnFocusChangeListener { v, hasFocus ->
             v.alpha = if (hasFocus) SETTINGS_ICON_ACTIVE_ALPHA else SETTINGS_ICON_IDLE_ALPHA
         }

--- a/app/src/main/res/color/home_settings_button_background_color.xml
+++ b/app/src/main/res/color/home_settings_button_background_color.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:state_pressed="true"
+        android:color="@color/white_a10p"/>
+
+    <item
+        android:state_focused="true"
+        android:color="@color/white_a20p"/>
+
+    <item
+        android:color="@android:color/transparent"/>
+
+</selector>

--- a/app/src/main/res/drawable/home_settings_button_background.xml
+++ b/app/src/main/res/drawable/home_settings_button_background.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <ripple android:color="@color/button_highlight">
-            <item android:id="@android:id/mask">
-                <shape android:shape="oval">
-                    <solid android:color="@android:color/black" />
-                </shape>
-            </item>
-        </ripple>
-    </item>
-</layer-list>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <size
+        android:height="40dp"
+        android:width="40dp"/>
+
+    <solid
+        android:color="@color/home_settings_button_background_color"/>
+
+</shape>

--- a/app/src/main/res/layout/browser_overlay.xml
+++ b/app/src/main/res/layout/browser_overlay.xml
@@ -73,10 +73,10 @@
             android:contentDescription="@string/menu_drawer_home"
             android:nextFocusLeft="@id/turboButton"/>
 
+        <!-- Image src set in code to fix SVG. -->
         <ImageButton
             android:id="@+id/navButtonSettings"
             style="@style/NavigationButton"
-            android:src="@drawable/ic_settings"
             android:contentDescription="@string/menu_settings"/>
 
         <!-- Drawable tinted in code (XML needs API 23+). -->

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -48,14 +48,14 @@
                 android:importantForAutofill="no"
                 tools:targetApi="o" /><!-- importantForAutofill is only supported on Android O+ -->
 
+        <!-- Image src set in code to fix SVGs. -->
         <ImageButton
             android:id="@+id/settingsButton"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:layout_marginEnd="50dp"
             android:background="@drawable/home_settings_button_background"
-            android:contentDescription="@string/menu_settings"
-            android:src="@drawable/ic_settings" />
+            android:contentDescription="@string/menu_settings"/>
 
         <ImageView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -37,4 +37,7 @@
     <color name="button_pressed">@color/tv_blue60</color>
     <color name="button_checked">@color/translucent_tv_ink2</color>
     <color name="button_border">@color/translucent_tv_gray40</color>
+
+    <color name="white_a10p">#1AFFFFFF</color>
+    <color name="white_a20p">#33FFFFFF</color>
 </resources>


### PR DESCRIPTION
I opted to remove the ripple because:
- The ripple changes the color that we set (because it adds
transparency), meaning I can't get the colors Tif specified
- The ripple doesn't work on the diamond but works on the stick, meaning
they have different colors for focused and pressed ^

For this detail, I figured this is good enough and we we can re-add the
ripple and fix it in #648.

@lime124 Please review my removal of the ripple on the settings button

. The colors are as you expected: (white @ 20% opacity for focus, 10% for pressed; note: this is white, not tv_white).

Focused:
![device-2018-03-20-161521](https://user-images.githubusercontent.com/759372/37687835-5adea1c8-2c5a-11e8-8b72-23427b73caee.png)

Pressed:
![device-2018-03-20-161532](https://user-images.githubusercontent.com/759372/37687840-5e390476-2c5a-11e8-928b-ae1f536e38e2.png)