### PR TITLE
i483 re-enable travis/sputnik

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-26.0.1
+    - build-tools-26.0.2
     - android-26
     - extra-google-google_play_services
     - extra-google-m2repository


### PR DESCRIPTION
In addition to these code changes, I:
- Activated travis from their website
- Activated sputnik from their website

However, sputnik doesn't appear to be working correctly: see discussion in the issue #483.

@liuche Please review ASAP: other people's builds will fail with travis errors (because I reactivated it on their website but haven't updated the dependencies for the repo).