### PR TITLE
Fixes #713 - Handle back button once for overlay/keyboard.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -208,11 +208,11 @@ class BrowserFragment : IWebViewLifecycleFragment() {
     private fun handleSpecialKeyEvent(event: KeyEvent): Boolean {
         val keyCodeIsMenu = event.keyCode == KeyEvent.KEYCODE_MENU
         val keyCodeIsBack = event.keyCode == KeyEvent.KEYCODE_BACK
-        val actionIsUp = event.action == KeyEvent.ACTION_UP
+        val actionIsDown = event.action == KeyEvent.ACTION_DOWN
         val isOverlayToggleKey = (keyCodeIsMenu || (keyCodeIsBack && browserOverlay.isVisible))
 
         if (isOverlayToggleKey) {
-            if (actionIsUp) {
+            if (actionIsDown) {
                 val toShow = !browserOverlay.isVisible
                 setOverlayVisibileByUser(toShow)
                 // Fix this youtube focus hack in #393


### PR DESCRIPTION
Handle menu-hiding only on keyDown of back button.

We have a lot of back handling code, and `onBackPressed` doesn't pass the keyUp/keyDown differentiation, so if we're using both `dispatchKeyEvent` to handle BACK_KEYPRESS and `onBackPressed`, they must both use keyDown.