### PR TITLE
Closes #785: Remove DOMFocusedElement globalOnFocusChangeListener in …

### DIFF
--- a/app/src/amazonWebview/java/org/mozilla/focus/iwebview/WebViewProvider.kt
+++ b/app/src/amazonWebview/java/org/mozilla/focus/iwebview/WebViewProvider.kt
@@ -7,21 +7,16 @@ package org.mozilla.focus.iwebview
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import android.util.AttributeSet
 import android.view.View
 import com.amazon.android.webkit.AmazonWebKitFactory
 import com.amazon.android.webkit.AmazonWebSettings
 import org.mozilla.focus.R
 import org.mozilla.focus.browser.UserAgent
-import org.mozilla.focus.ext.hasChild
 import org.mozilla.focus.webview.FirefoxAmazonWebChromeClient
 import org.mozilla.focus.webview.FirefoxAmazonWebView
 import org.mozilla.focus.webview.FocusWebViewClient
 import org.mozilla.focus.webview.TrackingProtectionWebViewClient
-
-private val uiHandler = Handler(Looper.getMainLooper())
 
 /** Creates a WebView-based IWebView implementation. */
 object WebViewProvider {
@@ -61,31 +56,6 @@ private fun initWebview(webView: FirefoxAmazonWebView) = with (webView) {
     //if (BuildConfig.DEBUG) {
     //    setWebContentsDebuggingEnabled(true);
     //}
-
-    // onFocusChangeListener isn't called for AmazonWebView (unlike Android's WebView)
-    // so we use the global listener instead.
-    viewTreeObserver.addOnGlobalFocusChangeListener { oldFocus: View?, newFocus: View? ->
-        if (!viewTreeObserver.isAlive) return@addOnGlobalFocusChangeListener
-
-        // These can both be false if the WebView is not involved in this transaction.
-        val isLosingFocus = webView.hasChild(oldFocus)
-        val isGainingFocus = webView.hasChild(newFocus)
-
-        // From a user's perspective, the WebView receives focus. Under the hood,
-        // the AmazonWebView's child, *Delegate, is actually receiving focus.
-        //
-        // For why we're doing this, see FocusedDOMElementCache.
-        if (isLosingFocus) {
-            // Any views (like BrowserNavigationOverlay) that may clear the cache, e.g. by
-            // reloading the page, are required to handle their own caching. Here we'll handle
-            // cases where the page cache isn't cleared.
-            focusedDOMElement.cache()
-        } else if (isGainingFocus) {
-            // Trying to restore immediately doesn't work - perhaps the WebView hasn't actually
-            // received focus yet? Posting to the end of the UI queue seems to solve the problem.
-            uiHandler.post { focusedDOMElement.restore() }
-        }
-    }
 }
 
 @SuppressLint("SetJavaScriptEnabled") // We explicitly want to enable JavaScript

--- a/app/src/amazonWebview/java/org/mozilla/focus/webview/FirefoxAmazonWebView.kt
+++ b/app/src/amazonWebview/java/org/mozilla/focus/webview/FirefoxAmazonWebView.kt
@@ -8,16 +8,22 @@ package org.mozilla.focus.webview
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.support.annotation.VisibleForTesting
 import android.util.AttributeSet
 import android.view.View
+import android.view.ViewTreeObserver
 import com.amazon.android.webkit.AmazonWebChromeClient
 import com.amazon.android.webkit.AmazonWebView
 import org.mozilla.focus.ext.deleteData
+import org.mozilla.focus.ext.hasChild
 import org.mozilla.focus.iwebview.FirefoxAmazonFocusedDOMElementCache
 import org.mozilla.focus.iwebview.IWebView
 import org.mozilla.focus.session.Session
 import org.mozilla.focus.utils.UrlUtils
+
+private val uiHandler = Handler(Looper.getMainLooper())
 
 /**
  * An IWebView implementation using AmazonWebView.
@@ -30,6 +36,8 @@ internal class FirefoxAmazonWebView(
         private val client: FocusWebViewClient,
         private val chromeClient: FirefoxAmazonWebChromeClient
 ) : NestedWebView(context, attrs), IWebView {
+
+    private val onGlobalFocusChangeListener = FirefoxAmazonWebViewFocusChangeListener(this)
 
     @get:VisibleForTesting
     override var callback: IWebView.Callback? = null
@@ -45,6 +53,14 @@ internal class FirefoxAmazonWebView(
     init {
         setOnLongClickListener(linkHandler)
         isLongClickable = true
+    }
+
+    override fun onStart() {
+        viewTreeObserver.addOnGlobalFocusChangeListener(onGlobalFocusChangeListener)
+    }
+
+    override fun onStop() {
+        viewTreeObserver.removeOnGlobalFocusChangeListener(onGlobalFocusChangeListener)
     }
 
     override fun restoreWebViewState(session: Session) {
@@ -166,5 +182,33 @@ internal class FirefoxAmazonWebChromeClient : AmazonWebChromeClient() {
 
     override fun onHideCustomView() {
         callback?.onExitFullScreen()
+    }
+}
+
+// onFocusChangeListener isn't called for AmazonWebView (unlike Android's WebView)
+// so we use the global listener instead.
+private class FirefoxAmazonWebViewFocusChangeListener(val webView: FirefoxAmazonWebView) : ViewTreeObserver.OnGlobalFocusChangeListener {
+    override fun onGlobalFocusChanged(oldFocus: View?, newFocus: View?) {
+        val viewTreeObserver = (oldFocus ?: newFocus)?.viewTreeObserver
+        if (viewTreeObserver == null || !viewTreeObserver.isAlive) return
+
+        // These can both be false if the WebView is not involved in this transaction.
+        val isLosingFocus = webView.hasChild(oldFocus)
+        val isGainingFocus = webView.hasChild(newFocus)
+
+        // From a user's perspective, the WebView receives focus. Under the hood,
+        // the AmazonWebView's child, *Delegate, is actually receiving focus.
+        //
+        // For why we're doing this, see FocusedDOMElementCache.
+        if (isLosingFocus) {
+            // Any views (like BrowserNavigationOverlay) that may clear the cache, e.g. by
+            // reloading the page, are required to handle their own caching. Here we'll handle
+            // cases where the page cache isn't cleared.
+            webView.focusedDOMElement.cache()
+        } else if (isGainingFocus) {
+            // Trying to restore immediately doesn't work - perhaps the WebView hasn't actually
+            // received focus yet? Posting to the end of the UI queue seems to solve the problem.
+            uiHandler.post { webView.focusedDOMElement.restore() }
+        }
     }
 }

--- a/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
@@ -98,6 +98,14 @@ public class WebViewProvider {
         }
 
         @Override
+        public void onStart() {
+        }
+
+        @Override
+        public void onStop() {
+        }
+
+        @Override
         public void scrollByClamped(int vx, int vy) {
 
         }

--- a/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
+++ b/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
@@ -25,6 +25,8 @@ interface IWebView {
 
     fun onPause()
     fun onResume()
+    fun onStart()
+    fun onStop()
 
     fun pauseTimers()
     fun resumeTimers()

--- a/app/src/main/java/org/mozilla/focus/iwebview/IWebViewLifecycleFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/iwebview/IWebViewLifecycleFragment.kt
@@ -79,6 +79,16 @@ abstract class IWebViewLifecycleFragment : LocaleAwareFragment() {
         super.onResume()
     }
 
+    override fun onStart() {
+        super.onStart()
+        webView!!.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        webView!!.onStop()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
 


### PR DESCRIPTION
…onStop.

ViewTreeObserver listeners outlive the view hierarchy so we need to be
sure to remove it when it's no longer needed.

This appears to fix the memory leak:
- In my STR, GC'ing once causes 2 instances to be retained instead of 3.
- If I GC again, there are 0 instances retained.
- LeakCanary doesn't warn me with this implementation.