### PR TITLE
Closes #507: don't create a new instance of WebView each time an intent is created

### DIFF
--- a/app/src/main/java/org/mozilla/focus/IntentValidator.kt
+++ b/app/src/main/java/org/mozilla/focus/IntentValidator.kt
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.text.TextUtils
+import org.mozilla.focus.session.Source
+import org.mozilla.focus.utils.SafeIntent
+import org.mozilla.focus.utils.UrlUtils
+
+typealias OnValidBrowserIntent = (url: String, source: Source) -> Unit
+
+/**
+ * A container for functions that parse Intents and notify the application of their validity.
+ *
+ * This class uses callbacks to notify the application in order to decouple the Intent parsing
+ * from the application logic, which also allows us to test the functionality.
+ *
+ * The functions in this class take [SafeIntent] in order to encourage the caller to use SafeIntents
+ * in their code.
+ */
+object IntentValidator {
+
+    fun validateOnCreate(context: Context, intent: SafeIntent, savedInstanceState: Bundle?, onValidBrowserIntent: OnValidBrowserIntent) {
+        if ((intent.getFlags() and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
+            // This Intent was launched from history (recent apps). Android will redeliver the
+            // original Intent (which might be a VIEW intent). However if there's no active browsing
+            // session then we do not want to re-process the Intent and potentially re-open a website
+            // from a session that the user already "erased".
+            return
+        }
+
+        if (savedInstanceState != null) {
+            // We are restoring a previous session - No need to handle this Intent.
+            return
+        }
+
+        validate(context, intent, onValidBrowserIntent)
+    }
+
+    fun validate(context: Context, intent: SafeIntent, onValidBrowserIntent: OnValidBrowserIntent) {
+        val action = intent.action
+
+        if (Intent.ACTION_VIEW.equals(action)) {
+            val dataString = intent.getDataString()
+            if (TextUtils.isEmpty(dataString)) {
+                return // If there's no URL in the Intent then we can't create a session.
+            }
+
+            onValidBrowserIntent(dataString, Source.VIEW)
+        } else if (Intent.ACTION_SEND.equals(action)) {
+            val dataString = intent.getStringExtra(Intent.EXTRA_TEXT)
+            if (TextUtils.isEmpty(dataString)) {
+                return
+            }
+
+            val isSearch = !UrlUtils.isUrl(dataString)
+            val url = if (isSearch) UrlUtils.createSearchUrl(context, dataString) else dataString
+            onValidBrowserIntent(url, Source.SHARE)
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -76,7 +76,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener {
     }
 
     private fun onValidBrowserIntent(url: String, source: Source) {
-        sessionManager.createSession(source, url)
+        ScreenController.showBrowserScreenForUrl(supportFragmentManager, url, source)
     }
 
     override fun applyLocale() {

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -134,8 +134,8 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener {
 
     override fun onNonTextInputUrlEntered(urlStr: String) {
         ViewUtils.hideKeyboard(container)
-        ScreenController.onUrlEnteredInner(this, supportFragmentManager, sessionManager, urlStr,
-                false, null, null)
+        ScreenController.onUrlEnteredInner(this, supportFragmentManager, urlStr, false,
+                null, null)
     }
 
     override fun onTextInputUrlEntered(urlStr: String,
@@ -143,8 +143,8 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener {
                                        inputLocation: UrlTextInputLocation?) {
         ViewUtils.hideKeyboard(container)
         // It'd be much cleaner/safer to do this with a kotlin callback.
-        ScreenController.onUrlEnteredInner(this, supportFragmentManager, sessionManager, urlStr,
-                true, autocompleteResult, inputLocation)
+        ScreenController.onUrlEnteredInner(this, supportFragmentManager, urlStr, true,
+                autocompleteResult, inputLocation)
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {

--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -42,10 +42,6 @@ object ScreenController {
             searchTerms = urlStr.trim()
         }
 
-        if (sessionManager.hasSession()) {
-            sessionManager.currentSession.searchTerms = searchTerms // todo: correct?
-        }
-
         // TODO: could this ever happen where browserFragment is on top? and do we need to do anything special for it?
         val browserFragment = fragmentManager.findFragmentByTag(BrowserFragment.FRAGMENT_TAG)
         val isSearch = !TextUtils.isEmpty(searchTerms)

--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -31,19 +31,10 @@ object ScreenController {
         }
 
         val isUrl = UrlUtils.isUrl(urlStr)
-        val updatedUrlStr: String
-        val searchTerms: String?
-        if (isUrl) {
-            updatedUrlStr = UrlUtils.normalize(urlStr)
-            searchTerms = null
-        } else {
-            updatedUrlStr = UrlUtils.createSearchUrl(context, urlStr)
-            searchTerms = urlStr.trim()
-        }
+        val updatedUrlStr = if (isUrl) UrlUtils.normalize(urlStr) else UrlUtils.createSearchUrl(context, urlStr)
 
         showBrowserScreenForUrl(fragmentManager, updatedUrlStr, Source.USER_ENTERED)
 
-        val isSearch = !TextUtils.isEmpty(searchTerms)
         if (isTextInput) {
             // Non-text input events are handled at the source, e.g. home tile click events.
             if (autocompleteResult == null) {
@@ -53,7 +44,7 @@ object ScreenController {
                 throw IllegalArgumentException("Expected non-null input location for text input")
             }
 
-            TelemetryWrapper.urlBarEvent(!isSearch, autocompleteResult, inputLocation)
+            TelemetryWrapper.urlBarEvent(isUrl, autocompleteResult, inputLocation)
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -57,11 +57,7 @@ object ScreenController {
                     .addToBackStack(null)
                     .commit()
         } else {
-            if (isSearch) {
-                SessionManager.getInstance().createSearchSession(Source.USER_ENTERED, updatedUrlStr, searchTerms)
-            } else {
-                SessionManager.getInstance().createSession(Source.USER_ENTERED, updatedUrlStr)
-            }
+            SessionManager.getInstance().createSession(Source.USER_ENTERED, updatedUrlStr)
         }
 
         if (isTextInput) {

--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -23,10 +23,9 @@ object ScreenController {
      * Loads the given url. If isTextInput is true, there should be no null parameters.
      */
     fun onUrlEnteredInner(context: Context, fragmentManager: FragmentManager,
-                          sessionManager: SessionManager,
                           urlStr: String,
-                          isTextInput: Boolean, autocompleteResult: InlineAutocompleteEditText.AutocompleteResult?,
-                          inputLocation: UrlTextInputLocation?) {
+                          isTextInput: Boolean,
+                          autocompleteResult: InlineAutocompleteEditText.AutocompleteResult?, inputLocation: UrlTextInputLocation?) {
         if (TextUtils.isEmpty(urlStr.trim())) {
             return
         }

--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -41,7 +41,7 @@ object ScreenController {
             searchTerms = urlStr.trim()
         }
 
-        showBrowserScreenForUrl(fragmentManager, updatedUrlStr)
+        showBrowserScreenForUrl(fragmentManager, updatedUrlStr, Source.USER_ENTERED)
 
         val isSearch = !TextUtils.isEmpty(searchTerms)
         if (isTextInput) {
@@ -101,7 +101,7 @@ object ScreenController {
                 .commit()
     }
 
-    fun showBrowserScreenForUrl(fragmentManager: FragmentManager, url: String) {
+    fun showBrowserScreenForUrl(fragmentManager: FragmentManager, url: String, source: Source) {
         // This code is not correct:
         // - We only support one session but it creates a new session when there's no BrowserFragment
         // such as each time we open a URL from the home screen.
@@ -117,7 +117,7 @@ object ScreenController {
             // for visibility in addition to existence.
             browserFragment.loadUrl(url)
         } else {
-            SessionManager.getInstance().createSession(Source.USER_ENTERED, url)
+            SessionManager.getInstance().createSession(source, url)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/ext/Intent.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/Intent.kt
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.ext
+
+import android.content.Intent
+import org.mozilla.focus.utils.SafeIntent
+
+fun Intent.toSafeIntent() = SafeIntent(this)

--- a/app/src/main/java/org/mozilla/focus/session/Session.java
+++ b/app/src/main/java/org/mozilla/focus/session/Session.java
@@ -6,7 +6,6 @@ package org.mozilla.focus.session;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
 
 import org.mozilla.focus.architecture.NonNullLiveData;
 import org.mozilla.focus.architecture.NonNullMutableLiveData;
@@ -24,7 +23,6 @@ public class Session {
     private final NonNullMutableLiveData<Boolean> secure;
     private final NonNullMutableLiveData<Boolean> loading;
     private Bundle webviewState;
-    private String searchTerms;
     private boolean isRecorded;
     private boolean isBlockingEnabled;
 
@@ -87,7 +85,6 @@ public class Session {
     }
 
     /* package */ void clearSearchTerms() {
-        searchTerms = null;
     }
 
     public void saveWebViewState(Bundle bundle) {
@@ -108,18 +105,6 @@ public class Session {
 
     public void markAsRecorded() {
         isRecorded = true;
-    }
-
-    public boolean isSearch() {
-        return !TextUtils.isEmpty(searchTerms);
-    }
-
-    public void setSearchTerms(String searchTerms) {
-        this.searchTerms = searchTerms;
-    }
-
-    public String getSearchTerms() {
-        return searchTerms;
     }
 
     public boolean isSameAs(@NonNull Session session) {

--- a/app/src/main/java/org/mozilla/focus/session/Session.java
+++ b/app/src/main/java/org/mozilla/focus/session/Session.java
@@ -25,7 +25,6 @@ public class Session {
     private final NonNullMutableLiveData<Boolean> loading;
     private Bundle webviewState;
     private String searchTerms;
-    private String searchUrl;
     private boolean isRecorded;
     private boolean isBlockingEnabled;
 
@@ -121,14 +120,6 @@ public class Session {
 
     public String getSearchTerms() {
         return searchTerms;
-    }
-
-    public String getSearchUrl() {
-        return searchUrl;
-    }
-
-    public void setSearchUrl(String searchUrl) {
-        this.searchUrl = searchUrl;
     }
 
     public boolean isSameAs(@NonNull Session session) {

--- a/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionCallbackProxy.java
@@ -59,11 +59,6 @@ public class SessionCallbackProxy implements IWebView.Callback {
 
     @Override
     public void onRequest(boolean isTriggeredByUserGesture) {
-        if (isTriggeredByUserGesture && session.isSearch()) {
-            // The user actively navigated away (no redirect) from the search page. Clear the
-            // search terms.
-            session.clearSearchTerms();
-        }
     }
 
     @Override

--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -168,7 +168,6 @@ public class SessionManager {
 
     public void createSearchSession(@NonNull Source source, @NonNull String url, String searchTerms) {
         final Session session = new Session(source, url);
-        session.setSearchTerms(searchTerms);
         addSession(session);
     }
 

--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -82,16 +82,10 @@ public class SessionManager {
             }
 
             final boolean isSearch = !UrlUtils.isUrl(dataString);
-
             final String url = isSearch
                     ? UrlUtils.createSearchUrl(context, dataString)
                     : dataString;
-
-            if (isSearch) {
-                createSearchSession(Source.SHARE, url, dataString);
-            } else {
-                createSession(Source.SHARE, url);
-            }
+            createSession(Source.SHARE, url);
         }
     }
 
@@ -162,11 +156,6 @@ public class SessionManager {
     }
 
     public void createSession(@NonNull Source source, @NonNull String url) {
-        final Session session = new Session(source, url);
-        addSession(session);
-    }
-
-    public void createSearchSession(@NonNull Source source, @NonNull String url, String searchTerms) {
         final Session session = new Session(source, url);
         addSession(session);
     }

--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -4,17 +4,11 @@
 
 package org.mozilla.focus.session;
 
-import android.content.Context;
-import android.content.Intent;
-import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import android.text.TextUtils;
 
 import org.mozilla.focus.architecture.NonNullLiveData;
 import org.mozilla.focus.architecture.NonNullMutableLiveData;
-import org.mozilla.focus.utils.SafeIntent;
-import org.mozilla.focus.utils.UrlUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,57 +30,6 @@ public class SessionManager {
     private SessionManager() {
         this.sessions = new NonNullMutableLiveData<>(
                 Collections.unmodifiableList(Collections.<Session>emptyList()));
-    }
-
-    /**
-     * Handle this incoming intent (via onCreate()) and create a new session if required.
-     */
-    public void handleIntent(final Context context, final SafeIntent intent, final Bundle savedInstanceState) {
-        if ((intent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
-            // This Intent was launched from history (recent apps). Android will redeliver the
-            // original Intent (which might be a VIEW intent). However if there's no active browsing
-            // session then we do not want to re-process the Intent and potentially re-open a website
-            // from a session that the user already "erased".
-            return;
-        }
-
-        if (savedInstanceState != null) {
-            // We are restoring a previous session - No need to handle this Intent.
-            return;
-        }
-
-        createSessionFromIntent(context, intent);
-    }
-
-    /**
-     * Handle this incoming intent (via onNewIntent()) and create a new session if required.
-     */
-    public void handleNewIntent(final Context context, final SafeIntent intent) {
-        createSessionFromIntent(context, intent);
-    }
-
-    private void createSessionFromIntent(Context context, SafeIntent intent) {
-        final String action = intent.getAction();
-
-        if (Intent.ACTION_VIEW.equals(action)) {
-            final String dataString = intent.getDataString();
-            if (TextUtils.isEmpty(dataString)) {
-                return; // If there's no URL in the Intent then we can't create a session.
-            }
-
-            createSession(Source.VIEW, intent.getDataString());
-        } else if (Intent.ACTION_SEND.equals(action)) {
-            final String dataString = intent.getStringExtra(Intent.EXTRA_TEXT);
-            if (TextUtils.isEmpty(dataString)) {
-                return;
-            }
-
-            final boolean isSearch = !UrlUtils.isUrl(dataString);
-            final String url = isSearch
-                    ? UrlUtils.createSearchUrl(context, dataString)
-                    : dataString;
-            createSession(Source.SHARE, url);
-        }
     }
 
     /**

--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -74,7 +74,7 @@ public class SessionManager {
                 return; // If there's no URL in the Intent then we can't create a session.
             }
 
-            createSession(context, Source.VIEW, intent, intent.getDataString());
+            createSession(Source.VIEW, intent.getDataString());
         } else if (Intent.ACTION_SEND.equals(action)) {
             final String dataString = intent.getStringExtra(Intent.EXTRA_TEXT);
             if (TextUtils.isEmpty(dataString)) {
@@ -169,11 +169,6 @@ public class SessionManager {
     public void createSearchSession(@NonNull Source source, @NonNull String url, String searchTerms) {
         final Session session = new Session(source, url);
         session.setSearchTerms(searchTerms);
-        addSession(session);
-    }
-
-    private void createSession(Context context, Source source, SafeIntent intent, String url) {
-        final Session session = new Session(source, url);
         addSession(session);
     }
 

--- a/app/src/main/java/org/mozilla/focus/session/SessionManager.java
+++ b/app/src/main/java/org/mozilla/focus/session/SessionManager.java
@@ -177,12 +177,6 @@ public class SessionManager {
         addSession(session);
     }
 
-    private void createSession(Context context, Source source, SafeIntent intent, String url, boolean blockingEnabled) {
-        final Session session = new Session(source, url);
-        session.setBlockingEnabled(blockingEnabled);
-        addSession(session);
-    }
-
     private void addSession(Session session) {
         currentSessionUUID = session.getUUID();
 
@@ -190,17 +184,6 @@ public class SessionManager {
         sessions.add(session);
 
         this.sessions.setValue(Collections.unmodifiableList(sessions));
-    }
-
-    public void selectSession(Session session) {
-        if (session.getUUID().equals(currentSessionUUID)) {
-            // This is already the selected session.
-            return;
-        }
-
-        currentSessionUUID = session.getUUID();
-
-        this.sessions.setValue(this.sessions.getValue());
     }
 
     /**

--- a/app/src/test/java/org/mozilla/focus/IntentValidatorTest.kt
+++ b/app/src/test/java/org/mozilla/focus/IntentValidatorTest.kt
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus
+
+import android.content.Intent
+import android.graphics.Color
+import android.net.Uri
+import android.os.Bundle
+import android.support.customtabs.CustomTabsIntent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.focus.ext.toSafeIntent
+import org.mozilla.focus.session.Source
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+private const val TEST_URL = "https://github.com/mozilla-mobile/focus-android"
+
+@RunWith(RobolectricTestRunner::class)
+class IntentValidatorTest {
+
+    @Test
+    fun testViewIntent() {
+        var isCalled = false
+        val expectedUrl = TEST_URL
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(expectedUrl)).toSafeIntent()
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { url, source ->
+            isCalled = true
+            assertEquals(expectedUrl, url)
+            assertEquals(Source.VIEW, source)
+        }
+
+        assertTrue("Expected intent to be valid", isCalled)
+    }
+
+    /** In production we see apps send VIEW intents without an URL. (Focus #1373) */
+    @Test
+    fun testViewIntentWithNullURL() {
+        val intent = Intent(Intent.ACTION_VIEW, null).toSafeIntent()
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { _, _ ->
+            fail("Null URL should not be valid")
+        }
+    }
+
+    @Test
+    fun testCustomTabIntent() {
+        val expectedUrl = TEST_URL
+        val intent = CustomTabsIntent.Builder()
+                .setToolbarColor(Color.GREEN)
+                .addDefaultShareMenuItem()
+                .build()
+                .intent
+                .setData(Uri.parse(expectedUrl))
+                .toSafeIntent()
+
+        var isCalled = false
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { url, source ->
+            isCalled = true
+            assertEquals(expectedUrl, url)
+            assertEquals(Source.VIEW, source)
+        }
+
+        assertTrue("Expected intent to be valid", isCalled)
+    }
+
+    @Test
+    fun testViewIntentFromHistoryIsIgnored() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(TEST_URL)).apply {
+            addFlags(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
+        }.toSafeIntent()
+
+        IntentValidator.validateOnCreate(RuntimeEnvironment.application, intent, null) { _, _ ->
+            fail("Intent from history should not be valid")
+        }
+    }
+
+    @Test
+    fun testIntentNotValidIfWeAreRestoring() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(TEST_URL)).toSafeIntent()
+        IntentValidator.validateOnCreate(RuntimeEnvironment.application, intent, Bundle()) { _, _ ->
+            fail("Intent from restore should not be valid")
+        }
+    }
+
+    @Test
+    fun testShareIntentViaNewIntent() {
+        val expectedUrl = TEST_URL
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            putExtra(Intent.EXTRA_TEXT, expectedUrl)
+        }.toSafeIntent()
+
+        var isCalled = false
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { url, source ->
+            isCalled = true
+            assertEquals(Source.SHARE, source)
+            assertEquals(expectedUrl, url)
+        }
+
+        assertTrue("Expected share intent to be valid", isCalled)
+    }
+
+    @Test
+    fun testShareIntentWithTextViaNewIntent() {
+        val expectedText = "Hello World Firefox TV"
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            putExtra(Intent.EXTRA_TEXT, expectedText)
+        }.toSafeIntent()
+
+        var isCalled = false
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { url, source ->
+            isCalled = true
+            assertEquals(Source.SHARE, source)
+            expectedText.split(" ").forEach {
+                assertTrue("Expected search url to contain $it", url.contains(it))
+            }
+        }
+
+        assertTrue("Expected share intent to be valid", isCalled)
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
+++ b/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
@@ -4,18 +4,10 @@
 
 package org.mozilla.focus.session;
 
-import android.content.Intent;
-import android.graphics.Color;
-import android.net.Uri;
-import android.os.Bundle;
-import android.support.customtabs.CustomTabsIntent;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mozilla.focus.utils.SafeIntent;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 
 import java.util.List;
 import java.util.UUID;
@@ -44,131 +36,6 @@ public class SessionManagerTest {
         assertNotNull(sessionManager.getSessions().getValue());
         assertEquals(0, sessionManager.getSessions().getValue().size());
         assertFalse(sessionManager.hasSession());
-    }
-
-    @Test
-    public void testViewIntent() {
-        final SessionManager sessionManager = SessionManager.getInstance();
-
-        final SafeIntent intent = new SafeIntent(new Intent(Intent.ACTION_VIEW, Uri.parse(TEST_URL)));
-        sessionManager.handleIntent(RuntimeEnvironment.application, intent, null);
-
-        final List<Session> sessions = sessionManager.getSessions().getValue();
-        assertNotNull(sessions);
-        assertEquals(1, sessions.size());
-
-        final Session session = sessions.get(0);
-        assertEquals(TEST_URL, session.getUrl().getValue());
-
-        assertTrue(sessionManager.hasSession());
-    }
-
-    /**
-     * In production we see apps send VIEW intents without an URL. (#1373)
-     */
-    @Test
-    public void testViewIntentWithNullURL() {
-        final SessionManager sessionManager = SessionManager.getInstance();
-        assertFalse(sessionManager.hasSession());
-
-        final SafeIntent intent = new SafeIntent(new Intent(Intent.ACTION_VIEW, null));
-        sessionManager.handleIntent(RuntimeEnvironment.application, intent, null);
-
-        // We ignored the Intent and no session has been created.
-        assertFalse(sessionManager.hasSession());
-    }
-
-    @Test
-    public void testCustomTabIntent() {
-        final SessionManager sessionManager = SessionManager.getInstance();
-
-        final SafeIntent intent = new SafeIntent(new CustomTabsIntent.Builder()
-                .setToolbarColor(Color.GREEN)
-                .addDefaultShareMenuItem()
-                .build()
-                .intent
-                .setData(Uri.parse(TEST_URL)));
-
-        sessionManager.handleIntent(RuntimeEnvironment.application, intent, null);
-
-        final List<Session> sessions = sessionManager.getSessions().getValue();
-        assertNotNull(sessions);
-        assertEquals(1, sessions.size());
-
-        final Session session = sessions.get(0);
-        assertEquals(TEST_URL, session.getUrl().getValue());
-
-        assertTrue(sessionManager.hasSession());
-    }
-
-    @Test
-    public void testViewIntentFromHistoryIsIgnored() {
-        final SessionManager sessionManager = SessionManager.getInstance();
-
-        final Intent unsafeIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(TEST_URL));
-        unsafeIntent.addFlags(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY);
-
-        final SafeIntent intent = new SafeIntent(unsafeIntent);
-        sessionManager.handleIntent(RuntimeEnvironment.application, intent, null);
-
-        final List<Session> sessions = sessionManager.getSessions().getValue();
-        assertNotNull(sessions);
-        assertEquals(0, sessions.size());
-
-        assertFalse(sessionManager.hasSession());
-    }
-
-    @Test
-    public void testNoSessionIsCreatedIfWeAreRestoring() {
-        final SessionManager sessionManager = SessionManager.getInstance();
-
-        final Bundle instanceState = new Bundle();
-
-        final SafeIntent intent = new SafeIntent(new Intent(Intent.ACTION_VIEW, Uri.parse(TEST_URL)));
-        sessionManager.handleIntent(RuntimeEnvironment.application, intent, instanceState);
-
-        final List<Session> sessions = sessionManager.getSessions().getValue();
-        assertNotNull(sessions);
-        assertEquals(0, sessions.size());
-
-        assertFalse(sessionManager.hasSession());
-    }
-
-    @Test
-    public void testShareIntentViaNewIntent() {
-        final SessionManager sessionManager = SessionManager.getInstance();
-
-        final Intent unsafeIntent = new Intent(Intent.ACTION_SEND);
-        unsafeIntent.putExtra(Intent.EXTRA_TEXT, TEST_URL);
-
-        sessionManager.handleNewIntent(RuntimeEnvironment.application, new SafeIntent(unsafeIntent));
-
-        final List<Session> sessions = sessionManager.getSessions().getValue();
-        assertNotNull(sessions);
-        assertEquals(1, sessions.size());
-
-        final Session session = sessions.get(0);
-        assertEquals(TEST_URL, session.getUrl().getValue());
-
-        assertTrue(sessionManager.hasSession());
-    }
-
-    public void testShareIntentWithTextViaNewIntent() {
-        final SessionManager sessionManager = SessionManager.getInstance();
-
-        final Intent unsafeIntent = new Intent(Intent.ACTION_SEND);
-        unsafeIntent.putExtra(Intent.EXTRA_TEXT, "Hello World Focus");
-
-        sessionManager.handleNewIntent(RuntimeEnvironment.application, new SafeIntent(unsafeIntent));
-
-        final List<Session> sessions = sessionManager.getSessions().getValue();
-        assertNotNull(sessions);
-        assertEquals(1, sessions.size());
-
-        final Session session = sessions.get(0);
-        assertEquals(TEST_URL, session.getUrl().getValue());
-
-        assertTrue(sessionManager.hasSession());
     }
 
     @Test(expected = IllegalAccessError.class)

--- a/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
+++ b/app/src/test/java/org/mozilla/focus/session/SessionManagerTest.java
@@ -148,7 +148,6 @@ public class SessionManagerTest {
         assertEquals(1, sessions.size());
 
         final Session session = sessions.get(0);
-        assertFalse(session.isSearch());
         assertEquals(TEST_URL, session.getUrl().getValue());
 
         assertTrue(sessionManager.hasSession());
@@ -167,8 +166,6 @@ public class SessionManagerTest {
         assertEquals(1, sessions.size());
 
         final Session session = sessions.get(0);
-        assertTrue(session.isSearch());
-        assertEquals("Hello World Focus", session.getSearchTerms());
         assertEquals(TEST_URL, session.getUrl().getValue());
 
         assertTrue(sessionManager.hasSession());

--- a/app/src/test/java/org/mozilla/focus/session/SessionTest.java
+++ b/app/src/test/java/org/mozilla/focus/session/SessionTest.java
@@ -128,24 +128,6 @@ public class SessionTest {
     }
 
     @Test
-    public void testIsSearch() {
-        final Session session = new Session(Source.VIEW, TEST_URL);
-        assertFalse(session.isSearch());
-
-        session.setSearchTerms("hello world");
-        assertTrue(session.isSearch());
-
-        session.clearSearchTerms();
-        assertFalse(session.isSearch());
-
-        session.setSearchTerms(null);
-        assertFalse(session.isSearch());
-
-        session.setSearchTerms("");
-        assertFalse(session.isSearch());
-    }
-
-    @Test
     public void testIsRecorded() {
         final Session session = new Session(Source.VIEW, TEST_URL);
         assertFalse(session.isRecorded());


### PR DESCRIPTION
*edit:* I've tested it successfully: see below.

I think this is the fix ~~**but I need to do further testing**~~, tomorrow morning. Note:
- The extended commit summary on the final commit explains why this fixed the issue
- A lot of the commits are removing unused code that simplifies the code so that I can make the later refactors I do, i.e. not much actually changes in this patch
- This change uncovered a lot of cruft in the way we handle sessions (i.e. we can create more than one), the browser fragment and session (it was really hard to load a URL from outside the browserFragment), state restoration, and intent handling. I'll file some follow-up bugs.

---

Here's the behavior after the bug from the final commit summary:
    We used to create a new session every time we receive an intent, which
    would add the existing BrowserFragment/WebView to the back and stack
    causing redundant WebViews and resource usage.

    At the end of this patch series, when we receive an intent, the behavior is:
    - If BrowserFragment is visible, we re-use it
    - If BF is not visible, we'll create a new Session, which creates a new
    BrowserFragment. This could cause multiple WebViews if BF was in the
    back stack but this is unlikely with the current code (only when
    Settings is shown)
    - Since we create and destroy many BF/WebView instances (e.g. home is
    shown so we destroy and when a site is clicked, we recreate it), we're
    relying on GC to ensure there is only one WebView instance at a time.
    Curiously, force GC in the debugger does not seem to always remove inactive
    WebView instances: either there's a bug in force GC or someone is
    holding a reference to it and it only gets cleaned up after several GC.
    It would likely be most resource efficient (assuming WebView is resource
    intense even when it's inactive) to  re-use a single BrowserFragment/WebView.

    This change uncovered a lot of cruft in the way we handle sessions (i.e.
    we can create more than one), the browser fragment and session (it was
    really hard to load a URL from outside the browserFragment), state
    restoration, and intent handling.

Notably, this patch series won't always stop us from recreating the WebView, but it will ensure we should only have one (as long as GC behaves).