### PR TITLE
Closes #831: Use new versionCodeOverride API to fix dynamic versionCo…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -206,7 +206,9 @@ android.applicationVariants.all { variant ->
     def isBetaOrRelease = buildType == "release" || buildType == "beta"
 
     if (isBetaOrRelease) {
-        variant.mergedFlavor.versionCode = generatedVersionCode
+        variant.outputs.all { output ->
+            setVersionCodeOverride(generatedVersionCode)
+        }
     }
 
     println("Build type: " + buildType + " (versionCode = " + variant.mergedFlavor.versionCode + ")")


### PR DESCRIPTION
…des.

This broke when we updated the Android gradle plugin. This code is
inspired by Focus: https://github.com/mozilla-mobile/focus-android/pull/2371

I confirmed this worked by looking at the contents of the
app/build/outputs/apk/amazonWebview/release/output.json file to verify
the versionCode was no longer 11.

---

We'll need to land this on `releases/v2.1` too.