### PR TITLE
Closes #774: Set aspect ratio of Pocket thumbnails to 16:9.

### DIFF
--- a/app/src/main/res/layout/browser_overlay.xml
+++ b/app/src/main/res/layout/browser_overlay.xml
@@ -56,7 +56,7 @@
     <org.mozilla.focus.home.pocket.PocketVideoMegaTile
         android:id="@+id/pocketVideoMegaTileView"
         android:layout_width="match_parent"
-        android:layout_height="124dp"
+        android:layout_height="108dp"
         android:layout_marginStart="45dp"
         android:layout_marginEnd="45dp"
         android:layout_marginBottom="24dp"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -74,9 +74,11 @@
         <item name="android:tint">@color/tv_white</item>
     </style>
 
+    <!-- These images won't crop or change their aspect ratio so if you modify the dimensions,
+         they need to maintain a 16:9 aspect ratio or else there will be dead-space in the ImageView. -->
     <style name="PocketVideoMegaTileThumbnail">
         <item name="android:layout_width">150dp</item>
-        <item name="android:layout_height">100dp</item>
+        <item name="android:layout_height">84.375dp</item>
         <item name="android:layout_marginStart">12dp</item>
         <item name="android:layout_marginEnd">12dp</item>
     </style>


### PR DESCRIPTION
Before, we had dead-space since we didn't want to crop or change the
aspect-ratio.