### PR TITLE
Clean up BrowserFragment back behavior

### DIFF
--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -65,11 +65,11 @@ object ScreenController {
             return
         }
 
+        // BrowserFragment is the base fragment, so don't add a backstack transaction.
         fragmentManager
                 .beginTransaction()
                 .replace(R.id.container,
                         BrowserFragment.createForSession(currentSession), BrowserFragment.FRAGMENT_TAG)
-                .addToBackStack(null)
                 .commit()
     }
 

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -229,10 +229,11 @@ class BrowserFragment : IWebViewLifecycleFragment() {
                 webView?.goBack()
                 TelemetryWrapper.browserBackControllerEvent()
             }
-            browserOverlay.isVisible -> setOverlayVisibleByUser(false)
+            browserOverlay.isVisible && !isUrlEqualToHomepage -> setOverlayVisibleByUser(false)
             else -> {
-                fragmentManager.popBackStack()
                 SessionManager.getInstance().removeCurrentSession()
+                // Delete session, but we allow the parent to handle back behavior.
+                return false
             }
         }
         return true

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -225,11 +225,11 @@ class BrowserFragment : IWebViewLifecycleFragment() {
 
     fun onBackPressed(): Boolean {
         when {
+            browserOverlay.isVisible && !isUrlEqualToHomepage -> setOverlayVisibleByUser(false)
             webView?.canGoBack() ?: false -> {
                 webView?.goBack()
                 TelemetryWrapper.browserBackControllerEvent()
             }
-            browserOverlay.isVisible && !isUrlEqualToHomepage -> setOverlayVisibleByUser(false)
             else -> {
                 SessionManager.getInstance().removeCurrentSession()
                 // Delete session, but we allow the parent to handle back behavior.
@@ -259,12 +259,9 @@ class BrowserFragment : IWebViewLifecycleFragment() {
     }
 
     private fun handleSpecialKeyEvent(event: KeyEvent): Boolean {
-        val keyCodeIsMenu = event.keyCode == KeyEvent.KEYCODE_MENU
-        val keyCodeIsBack = event.keyCode == KeyEvent.KEYCODE_BACK
         val actionIsDown = event.action == KeyEvent.ACTION_DOWN
-        val isOverlayToggleKey = (keyCodeIsMenu || (keyCodeIsBack && browserOverlay.isVisible))
 
-        if (isOverlayToggleKey && !isUrlEqualToHomepage) {
+        if (event.keyCode == KeyEvent.KEYCODE_MENU) {
             if (actionIsDown) {
                 val toShow = !browserOverlay.isVisible
                 setOverlayVisibleByUser(toShow)


### PR DESCRIPTION
We removed the HomeFragment, and now only BrowserFragment and MainActivity have non-trivial back behavior.

This doesn't fix multiple sessions, multiple webviews (as described in #795).