### PR TITLE
Closes #904: Simplify webView focus change code.

### DIFF
--- a/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
@@ -100,14 +100,6 @@ public class WebViewProvider {
         }
 
         @Override
-        public void onStart() {
-        }
-
-        @Override
-        public void onStop() {
-        }
-
-        @Override
         public void scrollByClamped(int vx, int vy) {
 
         }

--- a/app/src/main/java/org/mozilla/focus/ext/ViewGroup.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/ViewGroup.kt
@@ -7,8 +7,6 @@ package org.mozilla.focus.ext
 import android.view.View
 import android.view.ViewGroup
 
-fun ViewGroup.hasChild(childToCheck: View?) = childToCheck != null && indexOfChild(childToCheck) != -1
-
 inline fun ViewGroup.forEachChild(functionBlock: (View) -> Unit) {
     for (i in 0 until childCount) {
         functionBlock(getChildAt(i))

--- a/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
+++ b/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
@@ -25,8 +25,6 @@ interface IWebView {
 
     fun onPause()
     fun onResume()
-    fun onStart()
-    fun onStop()
 
     fun pauseTimers()
     fun resumeTimers()

--- a/app/src/main/java/org/mozilla/focus/iwebview/IWebViewLifecycleFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/iwebview/IWebViewLifecycleFragment.kt
@@ -79,16 +79,6 @@ abstract class IWebViewLifecycleFragment : LocaleAwareFragment() {
         super.onResume()
     }
 
-    override fun onStart() {
-        super.onStart()
-        webView!!.onStart()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        webView!!.onStop()
-    }
-
     override fun onDestroy() {
         super.onDestroy()
 


### PR DESCRIPTION
The old code used a fragile global focus change listener when we were
actually just listening for focus change events on the delegate.