### PR TITLE
No Issue: Fix Assert.kt warning as error

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/Assert.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/Assert.kt
@@ -6,7 +6,7 @@ package org.mozilla.focus
 
 import android.graphics.Bitmap
 import android.graphics.Color
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 
 /**
  * Asserts the two bitmaps are the same by ensuring their dimensions, config, and


### PR DESCRIPTION
Swap junit.framework.Assert.assertEquals (deprecated) to org.junit.Assert.assertEquals