### PR TITLE
Issue #918: Update outdated dependencies and use new artifact names (telemetry and kotlin stdlib).

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -145,7 +145,7 @@ dependencies {
     implementation "com.android.support:cardview-v7:$support_libraries_version"
     implementation "com.android.support:recyclerview-v7:$support_libraries_version"
     implementation "com.android.support:leanback-v17:$support_libraries_version"
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation "com.android.support.constraint:constraint-layout:$constrained_layout_version"
 
     implementation "android.arch.lifecycle:extensions:$architecture_components_version"
 
@@ -165,12 +165,12 @@ dependencies {
         transitive = false
     }
 
-    implementation 'org.mozilla.telemetry:telemetry:1.2.0'
+    implementation "org.mozilla.components:telemetry:$moz_components_version"
     implementation "org.mozilla.photon:colors:$moz_components_version"
     implementation "org.mozilla.photon:fonts:$moz_components_version"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.19.3"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
 
     geckoImplementation(name: 'geckoview-latest', ext: 'aar')
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,12 @@
 
 buildscript {
     ext.support_libraries_version = '26.1.0'
-    ext.architecture_components_version = '1.0.0'
+    ext.architecture_components_version = '1.1.1'
     ext.espresso_version = '3.0.1'
-    ext.kotlin_version = '1.2.0'
-    ext.moz_components_version = '0.4'
+    ext.kotlin_version = '1.2.41'
+    ext.moz_components_version = '0.7'
+    ext.constrained_layout_version = '1.1.0'
+    ext.kotlin_coroutines_version = '0.22.5'
 
     repositories {
         jcenter()
@@ -13,7 +15,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.3'
 
         classpath 'org.ajoberstar:grgit:1.5.0'


### PR DESCRIPTION
I was only planning to update the telemetry library, but Gradle was warning about outdated dependencies and it couldn't resolve the runtime dependency of android.arch.*. 

So I updated some of the other dependencies too and did a quick run of the app to make sure it still works.