### PR TITLE
String import 20180608-120948

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
+  <string name="firefox_tv_brand_name">Firefox TV</string>
   <string name="pocket_brand_name">Pocket</string>
   <string name="action_cancel">Annulla</string>
   <string name="action_ok">OK</string>
@@ -71,6 +72,8 @@
   <string name="homescreen_unpin_a11y">Rimuovi dalla bacheca</string>
   <string name="homescreen_title">Schermata principale</string>
   <string name="pin_label">Fissa alla schermata principale</string>
+  <string name="notification_pinned_general2">Fissato alla schermata di %1$s</string>
+  <string name="notification_unpinned_general2">Rimosso dalla schermata di %1$s</string>
   <string name="notification_pinned_site">Fissato alla schermata principale di Firefox TV</string>
   <string name="notification_unpinned_site">Rimosso dalla schermata principale di Firefox TV</string>
   <string name="pocket_home_tutorial_title">Ti presentiamo i video consigliati da %1$s</string>


### PR DESCRIPTION

Automated import 20180608-120948

Log:
```
 [unchanged] app/src/main/res/values-fr/strings.xml
 [unchanged] app/src/main/res/values-de/strings.xml
   [updated] app/src/main/res/values-it/strings.xml
     [mkdir] app/src/main/res/values-zh-CN
   [created] app/src/main/res/values-zh-CN/strings.xml
     [mkdir] app/src/main/res/values-pt-BR
   [created] app/src/main/res/values-pt-BR/strings.xml
     [mkdir] app/src/main/res/values-es-ES
   [created] app/src/main/res/values-es-ES/strings.xml
 [unchanged] app/src/main/res/values-ja/strings.xml
Fixing ./values-zh-CN -> ./values-zh-rCN
Fixing ./values-pt-BR -> ./values-pt-rBR
Fixing ./values-es-ES -> ./values-es-rES
Checking for placeholders in translation files...
Warning: * [values-tr/strings.xml] number of placeholders not matching, key: your_rights_content5

```
