### PR TITLE
Closes #940: sync play/pause playback state between JS and Java

### DIFF
--- a/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
@@ -225,6 +225,16 @@ public class WebViewProvider {
         }
 
         @Override
+        public void addJavascriptInterface(@Nullable Object obj, @Nullable String interfaceName) {
+
+        }
+
+        @Override
+        public void removeJavascriptInterface(@Nullable String interfaceName) {
+
+        }
+
+        @Override
         public void restoreWebViewState(Session session) {
             // TODO: restore navigation history, and reopen previously opened page
         }

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -37,13 +37,17 @@ import org.mozilla.focus.utils.ViewUtils
 import org.mozilla.focus.utils.publicsuffix.PublicSuffix
 import org.mozilla.focus.widget.InlineAutocompleteEditText
 
-class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener {
+interface MediaSessionHolder {
+    val videoVoiceCommandMediaSession: VideoVoiceCommandMediaSession
+}
+
+class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, MediaSessionHolder {
 
     private val sessionManager = SessionManager.getInstance()
 
     // There should be at most one MediaSession per process, hence it's in MainActivity.
     // We crash if we init MediaSession at init time, hence lateinit.
-    private lateinit var videoVoiceCommandMediaSession: VideoVoiceCommandMediaSession
+    override lateinit var videoVoiceCommandMediaSession: VideoVoiceCommandMediaSession
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -146,9 +146,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
     }
 
     private fun initMediaSession() {
-        videoVoiceCommandMediaSession = VideoVoiceCommandMediaSession(this) {
-            (supportFragmentManager.findFragmentByTag(BrowserFragment.FRAGMENT_TAG) as BrowserFragment?)?.webView
-        }
+        videoVoiceCommandMediaSession = VideoVoiceCommandMediaSession(this)
         lifecycle.addObserver(videoVoiceCommandMediaSession)
     }
 

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.experimental.CancellationException
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import org.mozilla.focus.MainActivity
+import org.mozilla.focus.MediaSessionHolder
 import org.mozilla.focus.R
 import org.mozilla.focus.ScreenController
 import org.mozilla.focus.architecture.NonNullObserver
@@ -68,6 +69,8 @@ class BrowserFragment : IWebViewLifecycleFragment() {
     override lateinit var session: Session
     override val initialUrl get() = session.url.value
     override val iWebViewCallback get() = SessionCallbackProxy(session, BrowserIWebViewCallback(this))
+
+    private val mediaSessionHolder get() = activity as MediaSessionHolder? // null when not attached.
 
     /**
      * The current URL.

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -190,6 +190,11 @@ class BrowserFragment : IWebViewLifecycleFragment() {
 
         layout.progressBar.initialize(this)
 
+        // We break encapsulation here: we should use the super.webView reference but it's not init until
+        // onViewCreated. However, overriding both onCreateView and onViewCreated in a single class
+        // is confusing so I'd rather break encapsulation than confuse devs.
+        mediaSessionHolder?.videoVoiceCommandMediaSession?.onCreateWebView(layout.webview, session)
+
         return layout
     }
 
@@ -212,6 +217,8 @@ class BrowserFragment : IWebViewLifecycleFragment() {
     }
 
     override fun onDestroyView() {
+        mediaSessionHolder?.videoVoiceCommandMediaSession?.onDestroyWebView(webView!!, session)
+
         super.onDestroyView()
 
         lifecycle.removeObserver(cursor!!)

--- a/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
+++ b/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
@@ -39,6 +39,9 @@ interface IWebView {
     fun canGoForward(): Boolean
     fun canGoBack(): Boolean
 
+    fun addJavascriptInterface(obj: Any?, interfaceName: String?)
+    fun removeJavascriptInterface(interfaceName: String?)
+
     /**
      * Scrolls the page but clamps it to the page dimensions, unlike [View.scrollBy].
      *


### PR DESCRIPTION
Testing on older devices now. This is the required part; the more optional part is #941.