### PR TITLE
Closes #975: Remove redundant methods in gecko config.

### DIFF
--- a/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
+++ b/app/src/gecko/java/org/mozilla/focus/iwebview/WebViewProvider.java
@@ -78,16 +78,6 @@ public class WebViewProvider {
         }
 
         @Override
-        public void onStop() {
-
-        }
-
-        @Override
-        public void onStart() {
-
-        }
-
-        @Override
         public void pauseTimers() {
 
         }


### PR DESCRIPTION
This is a regression from #936,
5f3b0179d980ac74b88511274c429d0cca00350c. This does not affect
up/master.