### PR TITLE
String import 20180803-180012

### DIFF
--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -57,11 +57,14 @@
   <string name="your_rights_content4"><![CDATA[\"Otras \"<a xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" href="%2$s">licencias</a>\" de código abierto y gratuitas también incluyen código fuente adicional para %1$s.\"]]></string>
   <string name="your_rights_content5"><![CDATA[\"%1$s también utiliza las listas de bloqueo de DIsconnect, Inc. como trabajos separados e independientes bajo la \"<a xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" href="%2$s">Licencia P&amp;#250;blica General de GNU v3</a>\" y que puedes encontrar \"<a xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2" href="%3$s">aqu&amp;#237;</a>.]]></string>
   <string name="settings_cookies_dialog_title">Limpiar todas las cookies y datos del sitio</string>
+  <string name="settings_cookies_dialog_content2">Esta acción eliminará todas las cookies y los datos de sitios. Eliminar esta información puede cerrar tu sesión de algunos sitios web y borrar el contenido web almacenado sin conexión.</string>
   <string name="turbo_mode">Modo turbo</string>
   <string name="turbo_mode_enabled_toast">Se activó el modo Turbo</string>
   <string name="turbo_mode_disabled_toast">Se desactivó el modo Turbo</string>
   <string name="onboarding_turbo_mode_title">El modo turbo te ayuda a navegar más rápido</string>
   <string name="onboarding_turbo_mode_body">El modo turbo bloquea automáticamente rastreadores y anuncios para ayudarte a llegar más rápido a donde vas. Si hay un bache de velocidad, como un sitio que no se comporta como esperabas, solo tienes que desactivar el modo turbo.</string>
+  <string name="button_turbo_mode_keep_enabled">Mantener activado</string>
+  <string name="button_turbo_mode_turn_off">Desactivar</string>
   <string name="turbo_mode_disable_a11y">Desactivar el modo turbo</string>
   <string name="turbo_mode_enable_a11y">Activar el modo turbo</string>
   <string name="homescreen_unpin_tutorial_toast">Mantén presionado SELECT para desanclarlo de la pantalla de inicio</string>


### PR DESCRIPTION

Automated import 20180803-180012

Log:
```
 [unchanged] app/src/main/res/values-fr/strings.xml
 [unchanged] app/src/main/res/values-de/strings.xml
 [unchanged] app/src/main/res/values-it/strings.xml
     [mkdir] app/src/main/res/values-zh-CN
   [created] app/src/main/res/values-zh-CN/strings.xml
     [mkdir] app/src/main/res/values-pt-BR
   [created] app/src/main/res/values-pt-BR/strings.xml
     [mkdir] app/src/main/res/values-es-ES
   [created] app/src/main/res/values-es-ES/strings.xml
 [unchanged] app/src/main/res/values-ja/strings.xml
Fixing ./values-es-ES -> ./values-es-rES
Fixing ./values-pt-BR -> ./values-pt-rBR
Fixing ./values-zh-CN -> ./values-zh-rCN
Checking for placeholders in translation files...
Warning: * [values-tr/strings.xml] number of placeholders not matching, key: your_rights_content5

```
