### PR TITLE
Closes #1037: fix unable to click pocket videos

### DIFF
--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -92,7 +92,7 @@ object ScreenController {
             browserFragment.loadUrl(url)
         } else {
             val session = Session(url, source = source)
-            context.components.sessionManager.add(session)
+            context.components.sessionManager.add(session, selected = true)
         }
     }
 


### PR DESCRIPTION
Root cause:
- Browser screen fragment transaction is started from a SessionManager.Observer#onSessionSelected callback, defined in MainActivity
- ScreenController#showBrowserScreenForUrl added a session, but 'selected' defaulted to false. This caused the above callback to not be triggered