### PR TITLE
Clean up licenses ordering, add missing licenses

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -140,11 +140,11 @@ dependencies {
     implementation 'io.sentry:sentry-android:1.7.2'
 
     implementation "com.android.support:appcompat-v7:$support_libraries_version"
+    implementation "com.android.support:cardview-v7:$support_libraries_version"
     implementation "com.android.support:customtabs:$support_libraries_version"
     implementation "com.android.support:design:$support_libraries_version"
-    implementation "com.android.support:cardview-v7:$support_libraries_version"
-    implementation "com.android.support:recyclerview-v7:$support_libraries_version"
     implementation "com.android.support:leanback-v17:$support_libraries_version"
+    implementation "com.android.support:recyclerview-v7:$support_libraries_version"
     implementation "com.android.support.constraint:constraint-layout:$constrained_layout_version"
 
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -145,7 +145,7 @@ dependencies {
     implementation "com.android.support:design:$support_libraries_version"
     implementation "com.android.support:leanback-v17:$support_libraries_version"
     implementation "com.android.support:recyclerview-v7:$support_libraries_version"
-    implementation "com.android.support.constraint:constraint-layout:$constrained_layout_version"
+    implementation "com.android.support.constraint:constraint-layout:1.1.2"
 
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'com.squareup.picasso:picasso:2.71828', {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,7 +137,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.sentry:sentry-android:1.7.2'
+    implementation 'io.sentry:sentry-android:1.7.5'
 
     implementation "com.android.support:appcompat-v7:$support_libraries_version"
     implementation "com.android.support:cardview-v7:$support_libraries_version"

--- a/app/src/main/assets/licenses.html
+++ b/app/src/main/assets/licenses.html
@@ -186,6 +186,8 @@
 	<li>com.android.support.constraint : constraint-layout</li>
 	<li>org.jetbrains.kotlin : kotlin-stdlib-jdk7</li>
 	<li>org.jetbrains.kotlin : kotlinx-coroutines-android</li>
+	<li>com.squareup.okhttp3 : okhttp:3.11.0</li>
+	<li>com.squareup.picasso : picasso:2.71828</li>
 </ul>
 
 	<p><strong><a name="definitions">1. Definitions</a></strong>.</p>

--- a/app/src/main/assets/licenses.html
+++ b/app/src/main/assets/licenses.html
@@ -174,32 +174,17 @@
 <h2><a name="apache2">Apache License 2.0</a></h2>
 
 <ul>
-	<li>android.arch.core : common</li>
-	<li>android.arch.core : runtime</li>
-	<li>android.arch.lifecycle : common</li>
-	<li>android.arch.lifecycle : extensions</li>
-	<li>android.arch.lifecycle : runtime</li>
-	<li>com.android.support : animated-vector-drawable</li>
 	<li>com.android.support : appcompat-v7</li>
 	<li>com.android.support : cardview-v7</li>
 	<li>com.android.support : customtabs</li>
 	<li>com.android.support : design</li>
+	<li>com.android.support : leanback-v17</li>
 	<li>com.android.support : recyclerview-v7</li>
-	<li>com.android.support : support-annotations</li>
-	<li>com.android.support : support-compat</li>
-	<li>com.android.support : support-core-ui</li>
-	<li>com.android.support : support-core-utils</li>
 	<li>com.android.support : support-fragment</li>
-	<li>com.android.support : support-media-compat</li>
 	<li>com.android.support : support-v4</li>
-	<li>com.android.support : support-vector-drawable</li>
-	<li>com.android.support : transition</li>
 	<li>com.android.support.constraint : constraint-layout</li>
-	<li>org.jetbrains : annotations</li>
-	<li>org.jetbrains.kotlin : kotlin-stdlib</li>
-	<li>org.jetbrains.kotlin : kotlin-stdlib-jre7</li>
+	<li>org.jetbrains.kotlin : kotlin-stdlib-jdk7</li>
 	<li>org.jetbrains.kotlin : kotlinx-coroutines-android</li>
-	<li>org.jetbrains.kotlin : kotlinx-coroutines-core</li>
 </ul>
 
 	<p><strong><a name="definitions">1. Definitions</a></strong>.</p>

--- a/app/src/main/assets/licenses.html
+++ b/app/src/main/assets/licenses.html
@@ -25,6 +25,7 @@
 <ul>
 	<li><a href="#mpl2">Mozilla Public License 2.0</a></li>
 	<li><a href="#apache2">Apache License 2.0</a></li>
+	<li><a href="#sentry">Sentry License</a></li>
 	<li><a href="#lgpl21">GNU Lesser General Public License 2.1</a></li>
 </ul>
 
@@ -338,6 +339,46 @@
 	Contributor by reason of your accepting any such warranty or additional
 	liability.</p>
 	<p>END OF TERMS AND CONDITIONS</p>
+
+<!-- ****************************************************************************************************************************** -->
+<!-- ****************************************************************************************************************************** -->
+<!-- ****************************************************************************************************************************** -->
+
+<h2><a name="sentry">Sentry License</a></h2>
+
+<ul>
+	<li>io.sentry : sentry-android</li>
+</ul>
+
+<p>Copyright (c) 2017 Functional Software, Inc and individual contributors.
+	All rights reserved.</p>
+<p>Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are
+	met:</p>
+<ol>
+	<li>Redistributions of source code must retain the above copyright notice,
+		this list of conditions and the following disclaimer.
+	</li>
+	<li>Redistributions in binary form must reproduce the above copyright
+		notice, this list of conditions and the following disclaimer in the
+		documentation and/or other materials provided with the distribution.
+	</li>
+	<li>Neither the name of the Sentry nor the names of its contributors may
+		be used to endorse or promote products derived from this software
+		without specific prior written permission.
+	</li>
+</ol>
+<p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS
+	IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+	THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+	PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+	CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+	EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+	PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+	PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+	LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+	NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
 <!-- ****************************************************************************************************************************** -->
 <!-- ****************************************************************************************************************************** -->

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     ext.espresso_version = '3.0.1'
     ext.kotlin_version = '1.2.41'
     ext.moz_components_version = '0.20'
-    ext.constrained_layout_version = '1.1.0'
     ext.kotlin_coroutines_version = '0.22.5'
 
     repositories {


### PR DESCRIPTION
We had a bunch of extraneous non-top-level dependency licenses so I removed them (and reordered them to match `<dependencies>`).

Were missing Sentry, okhttp, and picasso, so I added them.