### PR TITLE
browser-engine integration follow-up

### DIFF
--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -4,17 +4,24 @@
 
 package org.mozilla.focus
 
+import android.content.Context
 import mozilla.components.browser.engine.system.SystemEngine
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.session.SessionUseCases
+import org.mozilla.focus.engine.CustomContentRequestInterceptor
 
 /**
  * Helper class for lazily instantiating and keeping references to components needed by the
  * application.
  */
-class Components {
-    val engine: Engine by lazy { SystemEngine() }
+class Components(applicationContext: Context) {
+    val engine: Engine by lazy {
+        SystemEngine(DefaultSettings(
+            requestInterceptor = CustomContentRequestInterceptor(applicationContext)
+        ))
+    }
 
     val sessionManager by lazy { SessionManager(engine) }
 

--- a/app/src/main/java/org/mozilla/focus/Components.kt
+++ b/app/src/main/java/org/mozilla/focus/Components.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.session.SessionUseCases
 import org.mozilla.focus.engine.CustomContentRequestInterceptor
+import org.mozilla.focus.utils.Settings
 
 /**
  * Helper class for lazily instantiating and keeping references to components needed by the
@@ -19,6 +20,7 @@ import org.mozilla.focus.engine.CustomContentRequestInterceptor
 class Components(applicationContext: Context) {
     val engine: Engine by lazy {
         SystemEngine(DefaultSettings(
+            trackingProtectionPolicy = Settings.getInstance(applicationContext).trackingProtectionPolicy,
             requestInterceptor = CustomContentRequestInterceptor(applicationContext)
         ))
     }

--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -26,7 +26,7 @@ class FocusApplication : LocaleAwareApplication() {
      * first). Therefore we delay the creation so that the components can access and use the
      * application context at the time they get created.
      */
-    val components by lazy { Components() }
+    val components by lazy { Components(this) }
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -35,7 +35,7 @@ import org.mozilla.focus.ext.toUri
 import org.mozilla.focus.home.BundledTilesManager
 import org.mozilla.focus.home.CustomTilesManager
 import org.mozilla.focus.home.HomeTilesManager
-import org.mozilla.focus.iwebview.EngineViewLifecycleFragment
+import org.mozilla.focus.engine.EngineViewLifecycleFragment
 import org.mozilla.focus.session.NullSession
 import org.mozilla.focus.telemetry.MenuInteractionMonitor
 import org.mozilla.focus.telemetry.TelemetryWrapper

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import org.mozilla.focus.R
 import org.mozilla.focus.autocomplete.UrlAutoCompleteFilter
+import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.forEachChild
 import org.mozilla.focus.ext.updateLayoutParams
 import org.mozilla.focus.home.HomeTilesManager
@@ -109,7 +110,15 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
     private var isTurboEnabled: Boolean
         get() = Settings.getInstance(context).isBlockingEnabled
         set(value) {
-            Settings.getInstance(context).isBlockingEnabled = value
+            val settings = Settings.getInstance(context)
+            settings.isBlockingEnabled = value
+
+            val engineSession = context.components.sessionManager.getOrCreateEngineSession()
+            if (value) {
+                engineSession.enableTrackingProtection(settings.trackingProtectionPolicy)
+            } else {
+                engineSession.disableTrackingProtection()
+            }
         }
 
     private val pocketVideos = Pocket.getRecommendedVideos()

--- a/app/src/main/java/org/mozilla/focus/browser/FocusedDOMElementCache.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/FocusedDOMElementCache.kt
@@ -6,7 +6,7 @@ package org.mozilla.focus.browser
 
 import mozilla.components.concept.engine.EngineView
 import org.mozilla.focus.ext.evalJS
-import org.mozilla.focus.iwebview.FocusedDOMElementCache
+import org.mozilla.focus.engine.FocusedDOMElementCache
 
 private const val CACHE_VAR = "_firefoxForFireTvPreviouslyFocusedElement"
 private const val CACHE_JS = "var $CACHE_VAR = document.activeElement;"

--- a/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
@@ -33,7 +33,19 @@ class InfoFragment : EngineViewLifecycleFragment(), Session.Observer {
         session.register(this, owner = this)
 
         val engineSession = requireComponents.sessionManager.getOrCreateEngineSession(session)
+
+        // We explicitly disable tracking protection for the InfoFragment in order to:
+        // - Not break linked pages (like support articles)
+        // - Not count trackers that have been blocked *outside* of the actual browsing session
+        //
+        // This decision was originally made in Focus:
+        // https://github.com/mozilla-mobile/focus-android/issues/717
+        //
+        // I assume this may no longer be needed as we have fully separated [Session]s now. There was only *one* global
+        // state in the first version of Focus (Single tab). So other loads could have influenced this single state
+        // (e.g. wrong tracker count). However disabling tracking protection here shouldn't have any negative effects.
         engineSession.disableTrackingProtection()
+
         webView!!.render(engineSession)
     }
 

--- a/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
@@ -32,7 +32,9 @@ class InfoFragment : EngineViewLifecycleFragment(), Session.Observer {
         val session = Session(arguments!!.getString(ARGUMENT_URL))
         session.register(this, owner = this)
 
-        webView!!.render(requireComponents.sessionManager.getOrCreateEngineSession(session))
+        val engineSession = requireComponents.sessionManager.getOrCreateEngineSession(session)
+        engineSession.disableTrackingProtection()
+        webView!!.render(engineSession)
     }
 
     override fun onProgress(session: Session, progress: Int) {

--- a/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
@@ -12,7 +12,7 @@ import android.widget.ProgressBar
 import mozilla.components.browser.session.Session
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.requireComponents
-import org.mozilla.focus.iwebview.EngineViewLifecycleFragment
+import org.mozilla.focus.engine.EngineViewLifecycleFragment
 
 class InfoFragment : EngineViewLifecycleFragment(), Session.Observer {
     private var progressView: ProgressBar? = null

--- a/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
@@ -40,6 +40,10 @@ class InfoFragment : EngineViewLifecycleFragment(), Session.Observer {
     }
 
     override fun onLoadingStateChanged(session: Session, loading: Boolean) {
+        if (loading) {
+            progressView?.announceForAccessibility(getString(R.string.accessibility_announcement_loading))
+        }
+
         progressView?.visibility = if (loading) {
             View.VISIBLE
         } else {

--- a/app/src/main/java/org/mozilla/focus/browser/LocalizedContent.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/LocalizedContent.kt
@@ -4,12 +4,10 @@
 
 package org.mozilla.focus.browser
 
+import android.content.Context
 import android.content.pm.PackageManager
 import android.support.v4.util.ArrayMap
-import android.support.v4.view.ViewCompat
 import android.view.View
-import android.webkit.WebView
-
 import org.mozilla.focus.R
 import org.mozilla.focus.locale.Locales
 import org.mozilla.focus.utils.HtmlLoader
@@ -19,21 +17,11 @@ object LocalizedContent {
     // a custom scheme.
     const val URL_ABOUT = "firefox:about"
 
-    @JvmStatic
-    fun handleInternalContent(url: String, webView: WebView): Boolean {
-        if (URL_ABOUT == url) {
-            loadAbout(webView)
-            return true
-        }
-        return false
-    }
-
     /**
-     * Load the content for focus:about
+     * Load the content for firefox:about
      */
     @Suppress("LongMethod") // This doesn't change much.
-    private fun loadAbout(webView: WebView) {
-        val context = webView.context
+    fun generateAboutPage(context: Context): String {
         val resources = Locales.getLocalizedResources(context)
 
         val substitutionMap = ArrayMap<String, String>()
@@ -76,27 +64,13 @@ object LocalizedContent {
         val content5 = resources.getString(R.string.your_rights_content5, appName, gplUrl, trackingProtectionUrl)
         substitutionMap["%your-rights-content5%"] = content5
 
-        putLayoutDirectionIntoMap(webView, substitutionMap)
-
-        val data = HtmlLoader.loadResourceFile(context, R.raw.about, substitutionMap)
-        // We use a file:/// base URL so that we have the right origin to load file:/// css and image resources.
-        webView.loadDataWithBaseURL("file:///android_asset/about.html", data, "text/html", "UTF-8", null)
-    }
-
-    private fun putLayoutDirectionIntoMap(webView: WebView, substitutionMap: MutableMap<String, String>) {
-        ViewCompat.setLayoutDirection(webView, View.LAYOUT_DIRECTION_LOCALE)
-        val layoutDirection = ViewCompat.getLayoutDirection(webView)
-
-        val direction: String
-
-        if (layoutDirection == View.LAYOUT_DIRECTION_LTR) {
-            direction = "ltr"
-        } else if (layoutDirection == View.LAYOUT_DIRECTION_RTL) {
-            direction = "rtl"
-        } else {
-            direction = "auto"
+        substitutionMap["%dir%"] = when (context.resources.configuration.layoutDirection) {
+            View.LAYOUT_DIRECTION_LTR -> "ltr"
+            View.LAYOUT_DIRECTION_RTL -> "rtl"
+            else -> "auto"
         }
 
-        substitutionMap["%dir%"] = direction
+        // We use a file:/// base URL so that we have the right origin to load file:/// css and image resources.
+        return HtmlLoader.loadResourceFile(context, R.raw.about, substitutionMap)
     }
 }

--- a/app/src/main/java/org/mozilla/focus/engine/CustomContentRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/focus/engine/CustomContentRequestInterceptor.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.engine
+
+import android.content.Context
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.request.RequestInterceptor
+import org.mozilla.focus.browser.BrowserFragment
+import org.mozilla.focus.browser.LocalizedContent
+
+/**
+ * [RequestInterceptor] implementation to inject custom content for firefox:* pages.
+ */
+class CustomContentRequestInterceptor(
+    private val context: Context
+) : RequestInterceptor {
+    override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
+        return when (uri) {
+            BrowserFragment.APP_URL_HOME -> RequestInterceptor.InterceptionResponse("<html></html>")
+
+            LocalizedContent.URL_ABOUT -> RequestInterceptor.InterceptionResponse(
+                LocalizedContent.generateAboutPage(context))
+
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/engine/EngineViewLifecycleFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/engine/EngineViewLifecycleFragment.kt
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.focus.iwebview
+package org.mozilla.focus.engine
 
 import android.os.Bundle
 import android.support.annotation.UiThread

--- a/app/src/main/java/org/mozilla/focus/engine/FocusedDOMElementCache.kt
+++ b/app/src/main/java/org/mozilla/focus/engine/FocusedDOMElementCache.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.focus.iwebview
+package org.mozilla.focus.engine
 
 /**
  * When using spatial navigation (i.e. no Cursor) and the WebView loses and regains focus,

--- a/app/src/main/java/org/mozilla/focus/home/pocket/Pocket.kt
+++ b/app/src/main/java/org/mozilla/focus/home/pocket/Pocket.kt
@@ -52,6 +52,7 @@ object Pocket {
     fun init() {
         // We set this now, rather than waiting for the background updates, to ensure the first
         // caller gets a Deferred they can wait on, rather than null (which they can't wait on).
+        @Suppress("SENSELESS_COMPARISON") // Values of BuildConfig can change but the compiler doesn't know that..
         videosCache = if (BuildConfig.POCKET_KEY != null) getRecommendedVideosNoCacheAsync()
         else getPlaceholderVideos()
         lastUpdateMillis = SystemClock.elapsedRealtime()

--- a/app/src/main/java/org/mozilla/focus/home/pocket/PocketVideoMegaTile.kt
+++ b/app/src/main/java/org/mozilla/focus/home/pocket/PocketVideoMegaTile.kt
@@ -26,6 +26,7 @@ class PocketVideoMegaTile(
 
     var pocketVideos by Delegates.observable<List<PocketVideo>?>(null) { _, _, newVideos ->
         // When no Pocket API key is provided, show placeholder tiles (developer ergonomics)
+        @Suppress("SENSELESS_COMPARISON") // Values of BuildConfig can change but the compiler doesn't know that..
         val thumbnails = if (BuildConfig.POCKET_KEY == null) {
             Toast.makeText(context, "Pocket API key was not found.", Toast.LENGTH_LONG).show()
             (0 until thumbnailViews.size)

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Resources
 import android.preference.PreferenceManager
+import mozilla.components.concept.engine.EngineSession
 import org.mozilla.focus.OnboardingActivity
 import org.mozilla.focus.R
 import org.mozilla.focus.home.pocket.PocketOnboardingActivity
@@ -60,4 +61,20 @@ class Settings private constructor(context: Context) {
         get() = preferences.getBoolean(Settings.TRACKING_PROTECTION_ENABLED_PREF,
                 TRACKING_PROTECTION_ENABLED_DEFAULT)
         set(value) = preferences.edit().putBoolean(TRACKING_PROTECTION_ENABLED_PREF, value).apply()
+
+    /**
+     * Get the tracking protection policy which is a combination of tracker categories that should be blocked.
+     */
+    val trackingProtectionPolicy: EngineSession.TrackingProtectionPolicy
+        get() {
+            return if (isBlockingEnabled) {
+                EngineSession.TrackingProtectionPolicy.select(
+                    EngineSession.TrackingProtectionPolicy.AD,
+                    EngineSession.TrackingProtectionPolicy.ANALYTICS,
+                    EngineSession.TrackingProtectionPolicy.SOCIAL
+                )
+            } else {
+                EngineSession.TrackingProtectionPolicy.none()
+            }
+        }
 }

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Resources
 import android.preference.PreferenceManager
+import android.support.annotation.VisibleForTesting
 import mozilla.components.concept.engine.EngineSession
 import org.mozilla.focus.OnboardingActivity
 import org.mozilla.focus.R
@@ -32,6 +33,10 @@ class Settings private constructor(context: Context) {
 
         const val TRACKING_PROTECTION_ENABLED_PREF = "tracking_protection_enabled"
         const val TRACKING_PROTECTION_ENABLED_DEFAULT = true
+
+        @VisibleForTesting internal fun reset() {
+            instance = null
+        }
     }
 
     val preferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -57,7 +62,8 @@ class Settings private constructor(context: Context) {
     private fun getPreferenceKey(resourceId: Int): String =
             resources.getString(resourceId)
 
-    var isBlockingEnabled: Boolean // Delegates to shared prefs; could be custom delegate.
+    // Accessible via TurboMode.isEnabled()
+    internal var isBlockingEnabled: Boolean // Delegates to shared prefs; could be custom delegate.
         get() = preferences.getBoolean(Settings.TRACKING_PROTECTION_ENABLED_PREF,
                 TRACKING_PROTECTION_ENABLED_DEFAULT)
         set(value) = preferences.edit().putBoolean(TRACKING_PROTECTION_ENABLED_PREF, value).apply()

--- a/app/src/main/java/org/mozilla/focus/utils/TurboMode.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/TurboMode.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils
+
+import android.content.Context
+import org.mozilla.focus.ext.components
+
+/**
+ * Facade hiding the ceremony needed to toggle Turbo Mode.
+ *
+ * We are trying to keep our setting and the state of the engine synchronized.
+ */
+object TurboMode {
+    /**
+     * Is Turbo Mode enabled?
+     */
+    fun isEnabled(context: Context) = Settings.getInstance(context).isBlockingEnabled
+
+    /**
+     * Toggle turbo mode on or off. This will update the setting and the engine at the same time.
+     */
+    fun toggle(context: Context, enabled: Boolean) {
+        val settings = Settings.getInstance(context)
+        settings.isBlockingEnabled = enabled
+
+        val engineSession = context.components.sessionManager.getOrCreateEngineSession()
+        if (enabled) {
+            engineSession.enableTrackingProtection(settings.trackingProtectionPolicy)
+        } else {
+            engineSession.disableTrackingProtection()
+        }
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/engine/CustomContentRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/focus/engine/CustomContentRequestInterceptorTest.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.engine
+
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.request.RequestInterceptor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class CustomContentRequestInterceptorTest {
+    @Test
+    fun `Interceptor should return content for firefox-home`() {
+        val result = testInterceptor("firefox:home")
+
+        assertNotNull(result)
+        assertEquals("<html></html>", result!!.data)
+        assertEquals("text/html", result.mimeType)
+        assertEquals("UTF-8", result.encoding)
+    }
+
+    @Test
+    fun `Interceptor should return content for firefox-about`() {
+        val result = testInterceptor("firefox:about")
+
+        assertNotNull(result)
+        assertTrue(result!!.data.isNotEmpty())
+        assertEquals("text/html", result.mimeType)
+        assertEquals("UTF-8", result.encoding)
+    }
+
+    @Test
+    fun `Interceptor should not intercept normal URLs`() {
+        assertNull(testInterceptor("https://www.mozilla.org"))
+        assertNull(testInterceptor("https://youtube.com/tv"))
+    }
+
+    private fun testInterceptor(url: String): RequestInterceptor.InterceptionResponse? {
+        val interceptor = CustomContentRequestInterceptor(RuntimeEnvironment.application)
+        return interceptor.onLoadRequest(mock(EngineSession::class.java), url)
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/engine/CustomContentRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/focus/engine/CustomContentRequestInterceptorTest.kt
@@ -7,6 +7,7 @@ package org.mozilla.focus.engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.request.RequestInterceptor
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -42,6 +43,16 @@ class CustomContentRequestInterceptorTest {
     fun `Interceptor should not intercept normal URLs`() {
         assertNull(testInterceptor("https://www.mozilla.org"))
         assertNull(testInterceptor("https://youtube.com/tv"))
+    }
+
+    @Test
+    fun `Interceptor should return different content for firefox-home and firefox-about`() {
+        val firefoxAbout = testInterceptor("firefox:about")
+        val firefoxHome = testInterceptor("firefox:home")
+
+        assertEquals(firefoxAbout!!.mimeType, firefoxHome!!.mimeType)
+        assertEquals(firefoxAbout.encoding, firefoxHome.encoding)
+        assertNotEquals(firefoxAbout.data, firefoxHome.data)
     }
 
     private fun testInterceptor(url: String): RequestInterceptor.InterceptionResponse? {

--- a/app/src/test/java/org/mozilla/focus/utils/TurboModeTest.kt
+++ b/app/src/test/java/org/mozilla/focus/utils/TurboModeTest.kt
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils
+
+import android.content.Context
+import android.preference.PreferenceManager
+import mozilla.components.browser.session.Session
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.focus.ext.components
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class TurboModeTest {
+    private val context: Context
+        get() = RuntimeEnvironment.application
+
+    private lateinit var session: Session
+
+    @Before
+    fun setUp() {
+        // Avoid [Settings] from keeping a references to a shared preference instance from a previous test run.
+        Settings.reset()
+
+        // Clear all settings to always start fresh
+        PreferenceManager
+            .getDefaultSharedPreferences(context)
+            .edit()
+            .clear()
+            .apply()
+
+        // Add a session so that we can verify the state of it
+        session = Session("about:blank")
+        context.components.sessionManager.add(session)
+    }
+
+    @Test
+    fun `Turbo Mode should be enabled by default`() {
+        assertTrue(TurboMode.isEnabled(context))
+
+        assertTrue(Settings.getInstance(context).isBlockingEnabled)
+    }
+
+    @Test
+    fun `Turbo Mode should be disabled after toggling`() {
+        TurboMode.toggle(context, false)
+
+        assertFalse(TurboMode.isEnabled(context))
+
+        assertFalse(Settings.getInstance(context).isBlockingEnabled)
+        assertFalse(session.trackerBlockingEnabled)
+    }
+
+    @Test
+    fun `Turbo Mode should be enabled after toggling again`() {
+        TurboMode.toggle(context, false)
+        TurboMode.toggle(context, true)
+
+        assertTrue(TurboMode.isEnabled(context))
+
+        assertTrue(Settings.getInstance(context).isBlockingEnabled)
+        assertTrue(session.trackerBlockingEnabled)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.architecture_components_version = '1.1.1'
     ext.espresso_version = '3.0.1'
     ext.kotlin_version = '1.2.41'
-    ext.moz_components_version = '0.20'
+    ext.moz_components_version = '0.21'
     ext.kotlin_coroutines_version = '0.22.5'
 
     repositories {


### PR DESCRIPTION
This fixes a bunch of follow-up items from the list in #1063.

The Pocket patch is an odd one. I didn't change that code but AS started to complain about the condition being always `true`. This depends on the local configuration and the compiler obviously doesn't know about that... so I just suppressed the warning.