### PR TITLE
browser-engine integration follow-up II

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -66,16 +66,7 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
 
     private val mediaSessionHolder get() = activity as MediaSessionHolder? // null when not attached.
 
-    /**
-     * The current URL.
-     *
-     * Use this instead of the WebView's URL which can return null, return a null URL, or return
-     * data: URLs (for error pages).
-     */
-    var url: String? = null
-        private set
-
-    val isUrlEqualToHomepage: Boolean get() = url == APP_URL_HOME
+    val isUrlEqualToHomepage: Boolean get() = session.url == APP_URL_HOME
 
     /**
      * Encapsulates the cursor's components. If this value is null, the Cursor is not attached
@@ -102,8 +93,6 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
     }
 
     override fun onUrlChanged(session: Session, url: String) {
-        this.url = url
-
         if (url == APP_URL_HOME) {
             browserOverlay?.visibility = View.VISIBLE
         }
@@ -132,7 +121,7 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
             }
             NavigationEvent.POCKET -> ScreenController.showPocketScreen(fragmentManager!!)
             NavigationEvent.PIN_ACTION -> {
-                this@BrowserFragment.url?.let { url ->
+                this@BrowserFragment.session.url.let { url ->
                     when (value) {
                         NavigationEvent.VAL_CHECKED -> {
                             CustomTilesManager.getInstance(context!!).pinSite(context!!, url,
@@ -332,8 +321,8 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
         override fun isForwardEnabled() = session.canGoForward
         override fun isPinEnabled() = !isUrlEqualToHomepage
         override fun isRefreshEnabled() = !isUrlEqualToHomepage
-        override fun getCurrentUrl() = url
-        override fun isURLPinned() = url.toUri()?.let {
+        override fun getCurrentUrl() = session.url
+        override fun isURLPinned() = session.url.toUri()?.let {
             // TODO: #569 fix CustomTilesManager to use Uri too
             CustomTilesManager.getInstance(context!!).isURLPinned(it.toString()) ||
                     BundledTilesManager.getInstance(context!!).isURLPinned(it) } ?: false

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -257,8 +257,20 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
             }
             else -> {
                 context!!.components.sessionManager.remove()
-                // Delete session, but we allow the parent to handle back behavior.
-                return false
+
+                // We can get into this state in two situations:
+                // - (1) The user is on the "home page" and the overlay is visible. In this situation we just want to
+                //       let the activity handle the back press (and leave the app).
+                // - (2) The overlay is not visible and we are on a website and can't go back further. In this case
+                //       "back" should show the overlay (the next back press closes the app). In this situation we
+                //       cannot look at the URL. We just removed the session and the new session may not be loaded yet.
+                if (!browserOverlay.isVisible) {
+                    // If the browser overlay is not visible then we show it now immediately. Depending on the loading
+                    // state of the page we m
+                    setOverlayVisible(true)
+                } else {
+                    return false
+                }
             }
         }
         return true

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -266,7 +266,15 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
 
     fun loadUrl(url: String) {
         if (url.isNotEmpty()) {
-            requireComponents.sessionUseCases.loadUrl.invoke(url)
+            val session = requireComponents.sessionManager.selectedSession
+
+            if (session != null) {
+                // We already have an active session, let's just load the URL.
+                requireComponents.sessionUseCases.loadUrl.invoke(url)
+            } else {
+                // There's no session (anymore). Let's create a new one.
+                requireComponents.sessionManager.add(Session(url), selected = true)
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
@@ -56,6 +56,8 @@ class InfoFragment : EngineViewLifecycleFragment(), Session.Observer {
     override fun onLoadingStateChanged(session: Session, loading: Boolean) {
         if (loading) {
             progressView?.announceForAccessibility(getString(R.string.accessibility_announcement_loading))
+        } else {
+            progressView?.announceForAccessibility(getString(R.string.accessibility_announcement_loading_finished))
         }
 
         progressView?.visibility = if (loading) {


### PR DESCRIPTION
Part II. :)

Those patches fix some of the back/forward behavior and a crash if we start loading a URL after removing the session.

The whole cycle of how we create new sessions, destroy them and re-create fragments is very complex and I spend quite some time debugging it. Tomorrow I'm meeting with @aminalhazwani to understand how this is supposed to work and will try to simplify (and add tests) that behavior. For now that's the best I can come up with.