### PR TITLE
Closes #864: adds loading state to Pocket megatile

### DIFF
--- a/app/src/main/java/org/mozilla/focus/home/pocket/PocketVideoMegaTile.kt
+++ b/app/src/main/java/org/mozilla/focus/home/pocket/PocketVideoMegaTile.kt
@@ -35,6 +35,7 @@ class PocketVideoMegaTile(
 
         thumbnailViews.forEachIndexed { i, thumbnailView ->
             PicassoWrapper.client.load(thumbnails[i])
+                    .placeholder(R.drawable.pocket_placeholder)
                     .transform(roundCornerTransformation)
                     .into(thumbnailView)
         }

--- a/app/src/main/res/drawable/pocket_placeholder.xml
+++ b/app/src/main/res/drawable/pocket_placeholder.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/black_10_percent_opacity"/>
+    <corners android:radius="@dimen/home_tile_corner_radius"/>
+</shape>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -40,4 +40,6 @@
 
     <!-- via https://github.com/mozilla-mobile/firefox-tv/issues/759#issuecomment-381702769 -->
     <color name="pocket_coral">#EF4056</color>
+
+    <color name="black_10_percent_opacity">#1A000000</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -86,6 +86,7 @@
         <item name="android:layout_height">84.375dp</item>
         <item name="android:layout_marginStart">12dp</item>
         <item name="android:layout_marginEnd">12dp</item>
+        <item name="android:src">@drawable/pocket_placeholder</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This seems to be just as effective as defining a crossfade using two ImageViews, but is less work and easier to read.

![tv-loading](https://user-images.githubusercontent.com/13170306/45329932-bc21b100-b517-11e8-9e3b-13d8f5a5ee96.png)
