### PR TITLE
Fix focus caching to not break pages

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -168,11 +168,6 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
             onNavigationEvent = this@BrowserFragment.onNavigationEvent
             navigationStateProvider = NavigationStateProvider()
             visibility = overlayVisibleCached ?: View.GONE
-            onPreSetVisibilityListener = { isVisible ->
-                // The overlay can clear the DOM and a previous focused element cache (e.g. reload)
-                // so we need to do our own caching: see FocusedDOMElementCache for details.
-                if (!isVisible) { webView?.focusedDOMElement?.cache() }
-            }
 
             openHomeTileContextMenu = {
                 activity?.openContextMenu(browserOverlay.tileContainer)

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
@@ -103,8 +103,6 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
         autocompleteResult: InlineAutocompleteEditText.AutocompleteResult?
     ) -> Unit)? = null
     var navigationStateProvider: BrowserNavigationStateProvider? = null
-    /** Called inside [setVisibility] right before super.setVisibility is called. */
-    var onPreSetVisibilityListener: ((isVisible: Boolean) -> Unit)? = null
 
     private val pocketVideos = Pocket.getRecommendedVideos()
 
@@ -294,7 +292,6 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
     }
 
     override fun setVisibility(visibility: Int) {
-        onPreSetVisibilityListener?.invoke(visibility == View.VISIBLE)
         super.setVisibility(visibility)
 
         if (visibility == View.VISIBLE) {

--- a/app/src/main/java/org/mozilla/focus/ext/EngineView.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/EngineView.kt
@@ -106,7 +106,7 @@ fun EngineView.setupForApp(context: Context) {
  * requires JS injection to browser-engine-system.
  */
 fun EngineView.evalJS(javascript: String) {
-    webView.loadUrl("javascript:$javascript")
+    webView.evaluateJavascript(javascript, null)
 }
 
 /**


### PR DESCRIPTION
AC now handles webview focus change, so we can remove some extraneous handling we were doing. We needed to switch from `loadUrl` to `evaluateJavascript` so a blank page isn't loaded.