### PR TITLE
Closes #1007: Remove beta build variant.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,13 +45,6 @@ android {
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-        beta {
-            initWith debug
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            applicationIdSuffix ".beta"
-        }
         debug {
             applicationIdSuffix ".debug"
         }
@@ -186,9 +179,7 @@ dependencies {
 
 android.applicationVariants.all { variant ->
     def buildType = variant.buildType.name
-    def isBetaOrRelease = buildType == "release" || buildType == "beta"
-
-    if (isBetaOrRelease) {
+    if (buildType == "release") {
         variant.outputs.all { output ->
             setVersionCodeOverride(generatedVersionCode)
         }
@@ -239,7 +230,7 @@ def addSecretToBuildConfig(variant, fieldName, fileBaseName) {
     def fileSuffix
     if (variantName.contains("debug")) {
         fileSuffix = "debug"
-    } else if (variantName.contains("beta") || variantName.contains("release")) {
+    } else if (variantName.contains("release")) {
         fileSuffix = "release"
     } else if (variantName.contains("coverage")) {
         // We never want to bundle API keys with Coverage.

--- a/app/src/main/java/org/mozilla/focus/telemetry/SentryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/SentryWrapper.kt
@@ -14,7 +14,7 @@ import org.mozilla.focus.BuildConfig
  * An interface to the Sentry crash reporting SDK. All code that touches the Sentry APIs
  * directly should go in here (like TelemetryWrapper).
  *
- * With the current implementation, to enable Sentry on Beta/Release builds, add a
+ * With the current implementation, to enable Sentry on Release builds, add a
  * <project-dir>/.sentry_dsn_release file with your key. To enable Sentry on Debug
  * builds, add a .sentry_dsn_debug key and replace the [DataUploadPreference.isEnabled]
  * value with true (upload is disabled by default in dev builds). These keys are available

--- a/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConstants.java
@@ -9,7 +9,6 @@ import org.mozilla.focus.BuildConfig;
 
 public final class AppConstants {
     private static final String BUILD_TYPE_DEBUG = "debug";
-    private static final String BUILD_TYPE_BETA = "beta";
     private static final String BUILD_TYPE_RELEASE = "release";
 
     private AppConstants() {}
@@ -21,9 +20,4 @@ public final class AppConstants {
     public static boolean isReleaseBuild() {
         return BUILD_TYPE_RELEASE.equals(BuildConfig.BUILD_TYPE);
     }
-
-    public static boolean isBetaBuild() {
-        return BUILD_TYPE_BETA.equals(BuildConfig.BUILD_TYPE);
-    }
-
 }


### PR DESCRIPTION
We don't use it so it takes up visual space and adds unnecessary build time.