### PR TITLE
Closes #1101: Upgrade sentry to 1.7.9.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,7 +108,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.sentry:sentry-android:1.7.5'
+    implementation 'io.sentry:sentry-android:1.7.9'
 
     implementation "com.android.support:appcompat-v7:$support_libraries_version"
     implementation "com.android.support:cardview-v7:$support_libraries_version"


### PR DESCRIPTION
This release improves startup times: see the issue.