### PR TITLE
Fixes i1108: fixes blank WebView after Pocket carousel

### DIFF
--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -96,9 +96,10 @@ object ScreenController {
         }
     }
 
-    fun showPocketScreen(fragmentManager: FragmentManager) {
+    fun showPocketScreen(fragmentManager: FragmentManager, browserFragment: BrowserFragment) {
         fragmentManager.beginTransaction()
-                .replace(R.id.container, PocketVideoFragment.create(Pocket.getRecommendedVideos()))
+                .hide(browserFragment)
+                .add(R.id.container, PocketVideoFragment.create(Pocket.getRecommendedVideos()))
                 .addToBackStack(null)
                 .commit()
     }

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.browser_overlay.*
 import kotlinx.android.synthetic.main.browser_overlay.view.*
+import kotlinx.android.synthetic.main.firefox_progress_bar.*
 import kotlinx.android.synthetic.main.fragment_browser.*
 import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.experimental.CancellationException
@@ -126,7 +127,7 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
                 (activity as MainActivity).onNonTextInputUrlEntered(value!!)
                 setOverlayVisible(false)
             }
-            NavigationEvent.POCKET -> ScreenController.showPocketScreen(fragmentManager!!)
+            NavigationEvent.POCKET -> ScreenController.showPocketScreen(fragmentManager!!, this)
             NavigationEvent.PIN_ACTION -> {
                 this@BrowserFragment.session.url.let { url ->
                     when (value) {
@@ -207,6 +208,11 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
         super.onStop()
 
         sessionFeature?.stop()
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        super.onHiddenChanged(hidden)
+        if (!hidden) navUrlInput?.requestFocus()
     }
 
     override fun onContextItemSelected(item: MenuItem): Boolean {


### PR DESCRIPTION
Root cause:
- BrowserFragment was replaced with PocketVideoFragment when Pocket screen was shown
- This destroyed the BrowserFragment instance
- Our session was up to date, but when we returned to the BrowserFragment it was with a fresh WebView

@liuche I have a deep fear of messing with Fragment transactions.  If you have a better solution to this, please let me know.