### PR TITLE
String import 20180914-121428

### DIFF
--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -88,4 +88,5 @@
   <string name="google_search_tile_title">Pesquisar com o Google</string>
   <string name="google_search_hint_text">Pesquise com o Google ou insira o endereço</string>
   <string name="blank_tile_title">Adicionar site</string>
+  <string name="dialog_clear_cookies_title">Limpar os Cookies?</string>
 </resources>


### PR DESCRIPTION

Automated import 20180914-121428

Log:
```
 [unchanged] app/src/main/res/values-fr/strings.xml
 [unchanged] app/src/main/res/values-de/strings.xml
 [unchanged] app/src/main/res/values-it/strings.xml
     [mkdir] app/src/main/res/values-zh-CN
   [created] app/src/main/res/values-zh-CN/strings.xml
     [mkdir] app/src/main/res/values-pt-BR
   [created] app/src/main/res/values-pt-BR/strings.xml
     [mkdir] app/src/main/res/values-es-ES
   [created] app/src/main/res/values-es-ES/strings.xml
 [unchanged] app/src/main/res/values-ja/strings.xml
Fixing ./values-es-ES -> ./values-es-rES
Fixing ./values-zh-CN -> ./values-zh-rCN
Fixing ./values-pt-BR -> ./values-pt-rBR
Checking for placeholders in translation files...
Warning: * [values-tr/strings.xml] number of placeholders not matching, key: your_rights_content5

```
