### PR TITLE
Closes #1107: Add null check for overlay.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -107,7 +107,7 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
         updateOverlayIfVisible()
 
     private fun updateOverlayIfVisible() {
-        if (browserOverlay.isVisible) {
+        if (browserOverlay?.isVisible == true) {
             browserOverlay.updateOverlayForCurrentState()
         }
     }


### PR DESCRIPTION
Null checks required for UI elements in non lifecycle methods that depend on UI inflation