### PR TITLE
Closes #998: compile ui tests on pre push

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -37,7 +37,7 @@ tasks:
           && git config advice.detachedHead false
           && git checkout {{event.head.sha}}
           && echo "--" > .adjust_token
-          && ./gradlew clean assemble lint checkstyle ktlint pmd detektCheck test
+          && ./gradlew clean assemble assembleAndroidTest lint checkstyle ktlint pmd detektCheck test
       artifacts:
         'public':
           type: 'directory'

--- a/quality/pre-push-recommended.sh
+++ b/quality/pre-push-recommended.sh
@@ -18,6 +18,7 @@
         ktlint \
         pmd \
         detektCheck \
+        assembleAndroidTest \
         testdebug
 
 # Tasks omitted because they take a long time to run:


### PR DESCRIPTION
- Comments out compilation errors in ui tests
- Adds assembly (but not running) of ui tests to pre push hook