### PR TITLE
Closes #1111: Add link to expose Pocket megatile error screen

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -55,6 +55,7 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
         const val FRAGMENT_TAG = "browser"
         const val APP_URL_PREFIX = "firefox:"
         const val APP_URL_HOME = "${APP_URL_PREFIX}home"
+        const val APP_URL_POCKET_ERROR = "${APP_URL_PREFIX}error:pocketconnection"
 
         @JvmStatic
         fun createForSession(session: Session) = BrowserFragment().apply {
@@ -93,8 +94,13 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
     }
 
     override fun onUrlChanged(session: Session, url: String) {
-        if (url == APP_URL_HOME) {
-            browserOverlay?.visibility = View.VISIBLE
+        when (url) {
+            APP_URL_HOME -> browserOverlay?.visibility = View.VISIBLE
+            APP_URL_POCKET_ERROR -> {
+                browserOverlay?.showMegaTileError()
+                browserOverlay?.visibility = View.VISIBLE
+            }
+            else -> Unit
         }
 
         updateOverlayIfVisible()

--- a/app/src/main/java/org/mozilla/focus/engine/CustomContentRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/focus/engine/CustomContentRequestInterceptor.kt
@@ -27,7 +27,7 @@ class CustomContentRequestInterceptor(
         currentPageURL = uri
 
         return when (uri) {
-            BrowserFragment.APP_URL_HOME -> RequestInterceptor.InterceptionResponse("<html></html>")
+            BrowserFragment.APP_URL_HOME, BrowserFragment.APP_URL_POCKET_ERROR -> RequestInterceptor.InterceptionResponse("<html></html>")
 
             LocalizedContent.URL_ABOUT -> RequestInterceptor.InterceptionResponse(
                 LocalizedContent.generateAboutPage(context))

--- a/app/src/main/res/layout/pocket_video_mega_tile.xml
+++ b/app/src/main/res/layout/pocket_video_mega_tile.xml
@@ -90,6 +90,7 @@
                 android:textAllCaps="false"
                 android:fontFamily="@string/font_roboto_regular"
                 android:textSize="14sp"
+                android:nextFocusDown="@+id/tileContainer"
                 />
 
         </LinearLayout>


### PR DESCRIPTION
Navigate to `firefox:error:pocketconnection` to show the Pocket megatile error screen. 