### PR TITLE
Fixes #1099: retains WebView between fragments

### DIFF
--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -21,6 +21,7 @@ import org.mozilla.focus.browser.BrowserNavigationOverlay
 import org.mozilla.focus.browser.WebViewCache
 import org.mozilla.focus.browser.VideoVoiceCommandMediaSession
 import org.mozilla.focus.ext.components
+import org.mozilla.focus.ext.setupForApp
 import org.mozilla.focus.ext.toSafeIntent
 import org.mozilla.focus.home.pocket.Pocket
 import org.mozilla.focus.home.pocket.PocketOnboardingActivity
@@ -45,6 +46,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
     // There should be at most one MediaSession per process, hence it's in MainActivity.
     // We crash if we init MediaSession at init time, hence lateinit.
     override lateinit var videoVoiceCommandMediaSession: VideoVoiceCommandMediaSession
+    private lateinit var webViewCache: WebViewCache
 
     private val sessionObserver = object : SessionManager.Observer {
         override fun onSessionSelected(session: Session) {
@@ -75,6 +77,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         Pocket.init()
         PublicSuffix.init(this) // Used by Pocket Video feed & custom home tiles.
         initMediaSession()
+        webViewCache = WebViewCache()
 
         val intent = SafeIntent(intent)
 
@@ -139,14 +142,11 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         TelemetryWrapper.stopMainActivity()
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        WebViewCache.clear()
-    }
-
     override fun onCreateView(name: String, context: Context, attrs: AttributeSet): View? {
         return if (name == EngineView::class.java.name) {
-            return WebViewCache.getWebView(context, attrs)
+            webViewCache.getWebView(context, attrs) {
+                setupForApp(context)
+            }
         } else super.onCreateView(name, context, attrs)
     }
 

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -12,16 +12,15 @@ import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.View
 import kotlinx.android.synthetic.main.activity_main.*
-import mozilla.components.browser.engine.system.SystemEngineView
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineView
 import org.mozilla.focus.browser.BrowserFragment
 import org.mozilla.focus.browser.BrowserFragment.Companion.APP_URL_HOME
 import org.mozilla.focus.browser.BrowserNavigationOverlay
+import org.mozilla.focus.browser.WebViewCache
 import org.mozilla.focus.browser.VideoVoiceCommandMediaSession
 import org.mozilla.focus.ext.components
-import org.mozilla.focus.ext.setupForApp
 import org.mozilla.focus.ext.toSafeIntent
 import org.mozilla.focus.home.pocket.Pocket
 import org.mozilla.focus.home.pocket.PocketOnboardingActivity
@@ -140,11 +139,14 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         TelemetryWrapper.stopMainActivity()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        WebViewCache.clear()
+    }
+
     override fun onCreateView(name: String, context: Context, attrs: AttributeSet): View? {
         return if (name == EngineView::class.java.name) {
-            SystemEngineView(context, attrs).apply {
-                setupForApp(context)
-            }
+            return WebViewCache.getWebView(context, attrs)
         } else super.onCreateView(name, context, attrs)
     }
 

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -225,11 +225,6 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
 
         if (session.url == APP_URL_HOME) {
             browserOverlay?.visibility = View.VISIBLE
-        } else {
-            // TODO #1132: This is a workaround to prevent us from losing all browser state
-            // when the fragment is destroyed.  It should be replaced by us not destroying
-            // the fragment at all
-            webView.asView().post { loadUrl(session.url) }
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/browser/WebViewCache.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/WebViewCache.kt
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.browser
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import mozilla.components.browser.engine.system.SystemEngineView
+import org.mozilla.focus.ext.setupForApp
+
+/**
+ * Caches a [SystemEngineView], which internally maintains a [WebView].
+ *
+ * This allows us to maintain [WebView] state when the view would otherwise
+ * be destroyed
+ */
+object WebViewCache {
+
+    @SuppressLint("StaticFieldLeak")
+    private var cachedView: SystemEngineView? = null
+
+    fun getWebView(context: Context, attrs: AttributeSet): SystemEngineView {
+        fun View?.removeFromParentIfAble() {
+            (this?.parent as? ViewGroup)?.removeView(cachedView)
+        }
+        fun createAndCacheEngineView(): SystemEngineView {
+            return SystemEngineView(context, attrs).apply {
+                setupForApp(context)
+            }.also { cachedView = it }
+        }
+
+        cachedView?.removeFromParentIfAble()
+        return cachedView ?: createAndCacheEngineView()
+    }
+
+    /**
+     * After [WebView.destroy] is called that instance will be unusable and most
+     * method calls on it will throw exceptions.  It is important that we clear
+     * the cache on destroy, so that future requests receive a new instance.
+     */
+    fun clear() {
+        cachedView = null
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/browser/WebViewCacheTest.kt
+++ b/app/src/test/java/org/mozilla/focus/browser/WebViewCacheTest.kt
@@ -1,10 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.browser
 
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import mozilla.components.browser.engine.system.SystemEngineView
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -14,33 +19,35 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class WebViewCacheTest {
 
+    private lateinit var webViewCache: WebViewCache
+
+    @Before
+    fun setup() {
+        webViewCache = WebViewCache()
+    }
+
     @Test
     fun `WHEN getWebView is called multiple times THEN the same WebView is returned`() {
-        val cachRefs = List(5) { getWebView() }
-        cachRefs.forEach { assertEquals(cachRefs.first(), it) }
+        val webView = getWebView()
+        val message = "Expected saved webView to equal retrieved WebView"
+        assertTrue(message, webView === getWebView())
+        assertTrue(message, webView === getWebView())
+        assertTrue(message, webView === getWebView())
     }
 
     @Test
     fun `GIVEN cached WebView has a parent WHEN WebView is returned THEN WebView should be removed from parent`() {
-        for (i in 0..5) {
-            val webView = getWebView()
-            assertEquals(null, webView.parent)
-            val parent = FrameLayout(RuntimeEnvironment.application)
-            parent.addView(webView)
-            assertEquals(parent, webView.parent)
-        }
-    }
-
-    @Test
-    fun `GIVEN cache has been cleared WHEN WebView is retrieved from cache THEN it should be a different instance`() {
+        // Setup
         val webView = getWebView()
-        assertEquals(webView, getWebView())
+        assertEquals(null, webView.parent)
+        val parent = FrameLayout(RuntimeEnvironment.application)
+        parent.addView(webView)
+        assertEquals(parent, webView.parent)
 
-        WebViewCache.clear()
-
-        assertNotEquals(webView, getWebView())
+        // Test
+        assertEquals(null, getWebView().parent)
     }
 
     private fun getWebView(): SystemEngineView =
-            WebViewCache.getWebView(RuntimeEnvironment.application, mock(AttributeSet::class.java))
+            webViewCache.getWebView(RuntimeEnvironment.application, mock(AttributeSet::class.java)) {}
 }

--- a/app/src/test/java/org/mozilla/focus/browser/WebViewCacheTest.kt
+++ b/app/src/test/java/org/mozilla/focus/browser/WebViewCacheTest.kt
@@ -1,0 +1,46 @@
+package org.mozilla.focus.browser
+
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import mozilla.components.browser.engine.system.SystemEngineView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class WebViewCacheTest {
+
+    @Test
+    fun `WHEN getWebView is called multiple times THEN the same WebView is returned`() {
+        val cachRefs = List(5) { getWebView() }
+        cachRefs.forEach { assertEquals(cachRefs.first(), it) }
+    }
+
+    @Test
+    fun `GIVEN cached WebView has a parent WHEN WebView is returned THEN WebView should be removed from parent`() {
+        for (i in 0..5) {
+            val webView = getWebView()
+            assertEquals(null, webView.parent)
+            val parent = FrameLayout(RuntimeEnvironment.application)
+            parent.addView(webView)
+            assertEquals(parent, webView.parent)
+        }
+    }
+
+    @Test
+    fun `GIVEN cache has been cleared WHEN WebView is retrieved from cache THEN it should be a different instance`() {
+        val webView = getWebView()
+        assertEquals(webView, getWebView())
+
+        WebViewCache.clear()
+
+        assertNotEquals(webView, getWebView())
+    }
+
+    private fun getWebView(): SystemEngineView =
+            WebViewCache.getWebView(RuntimeEnvironment.application, mock(AttributeSet::class.java))
+}


### PR DESCRIPTION
- Creates WebViewCache to store SystemEngineView instances
- Updates MainActivity#onCreateView to retrieve from WebViewCache instead of creating an instance