### PR TITLE
Issue #878: Fix accessibility on overlay

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
@@ -40,7 +40,6 @@ import org.mozilla.focus.widget.InlineAutocompleteEditText
 import kotlin.properties.Delegates
 import org.mozilla.focus.ext.isVoiceViewEnabled
 
-
 private const val NAVIGATION_BUTTON_ENABLED_ALPHA = 1.0f
 private const val NAVIGATION_BUTTON_DISABLED_ALPHA = 0.3f
 
@@ -69,7 +68,7 @@ enum class NavigationEvent {
         const val VAL_UNCHECKED = "unchecked"
     }
 }
-
+@Suppress("LargeClass")
 class BrowserNavigationOverlay @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -169,8 +168,7 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
                 // is finished. This adds a short delay to the display of the toast so it will always be announced
                 if (context.isVoiceViewEnabled())
                     uiHandler.postDelayed(
-                        { Toast.makeText(context, R.string.homescreen_unpin_tutorial_toast, Toast.LENGTH_LONG).show() }
-                        , 1500)
+                        { Toast.makeText(context, R.string.homescreen_unpin_tutorial_toast, Toast.LENGTH_LONG).show() }, 1500)
 
                 canShowUpinToast = false
             }
@@ -200,6 +198,9 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
         pocketErrorContainer.visibility = View.VISIBLE
         pocketMegaTileLoadError.text = resources.getString(R.string.pocket_video_feed_failed_to_load,
                 resources.getString(R.string.pocket_brand_name))
+        megaTileTryAgainButton.contentDescription = resources.getString(R.string.pocket_video_feed_failed_to_load,
+                resources.getString(R.string.pocket_brand_name)) + " " + resources.getString(R.string.pocket_video_feed_reload_button)
+
         megaTileTryAgainButton.setOnClickListener { _ ->
             pocketVideos = Pocket.getRecommendedVideos()
             initMegaTile()

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
@@ -45,7 +45,7 @@ private const val NAVIGATION_BUTTON_ENABLED_ALPHA = 1.0f
 private const val NAVIGATION_BUTTON_DISABLED_ALPHA = 0.3f
 
 private const val SHOW_UNPIN_TOAST_COUNTER_PREF = "show_upin_toast_counter"
-private const val MAX_UNPIN_TOAST_COUNT = 100
+private const val MAX_UNPIN_TOAST_COUNT = 3
 
 private const val COL_COUNT = 5
 private val uiHandler = Handler(Looper.getMainLooper())
@@ -166,8 +166,8 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
                         .apply()
 
                 val contextReference = WeakReference(context)
-                val showToast = postDelayed@{
-                    val context = contextReference.get() ?: return@postDelayed
+                val showToast = showToast@{
+                    val context = contextReference.get() ?: return@showToast
                     Toast.makeText(context, R.string.homescreen_unpin_tutorial_toast, Toast.LENGTH_LONG).show()
                 }
                 if (context.isVoiceViewEnabled()) uiHandler.postDelayed(showToast, 1500)

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
@@ -7,6 +7,8 @@ package org.mozilla.focus.browser
 import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
+import android.os.Handler
+import android.os.Looper
 import android.preference.PreferenceManager
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.GridLayoutManager
@@ -36,6 +38,8 @@ import org.mozilla.focus.utils.TurboMode
 import org.mozilla.focus.widget.IgnoreFocusMovementMethod
 import org.mozilla.focus.widget.InlineAutocompleteEditText
 import kotlin.properties.Delegates
+import org.mozilla.focus.ext.isVoiceViewEnabled
+
 
 private const val NAVIGATION_BUTTON_ENABLED_ALPHA = 1.0f
 private const val NAVIGATION_BUTTON_DISABLED_ALPHA = 0.3f
@@ -44,6 +48,7 @@ private const val SHOW_UNPIN_TOAST_COUNTER_PREF = "show_upin_toast_counter"
 private const val MAX_UNPIN_TOAST_COUNT = 3
 
 private const val COL_COUNT = 5
+private val uiHandler = Handler(Looper.getMainLooper())
 
 enum class NavigationEvent {
     SETTINGS, BACK, FORWARD, RELOAD, LOAD_URL, LOAD_TILE, TURBO, PIN_ACTION, POCKET;
@@ -159,7 +164,14 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
                         .edit()
                         .putInt(SHOW_UNPIN_TOAST_COUNTER_PREF, prefInt + 1)
                         .apply()
-                Toast.makeText(context, R.string.homescreen_unpin_tutorial_toast, Toast.LENGTH_LONG).show()
+
+                // With VoiceView enabled, the toast is not announced if it disappears before the home tile description
+                // is finished. This adds a short delay to the display of the toast so it will always be announced
+                if (context.isVoiceViewEnabled())
+                    uiHandler.postDelayed(
+                        { Toast.makeText(context, R.string.homescreen_unpin_tutorial_toast, Toast.LENGTH_LONG).show() }
+                        , 1500)
+
                 canShowUpinToast = false
             }
         })


### PR DESCRIPTION
- Fix 'Press and hold SELECT...' toast not being announced 
    - Added a short delay for displaying the toast when VoiceView is enabled. This ensures that it doesn't disappear before VoiceView gets around to announcing it.
- Fix Pocket megatile error message not being announced
    - Now, the error message will be announced first followed by the 'Try again' button.
