### PR TITLE
Fixes #1195, Fixes #1193: updates A-C to 25

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -340,14 +340,7 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
 
         if (event.keyCode == KeyEvent.KEYCODE_DPAD_CENTER && actionIsDown) MenuInteractionMonitor.selectPressed()
 
-        /**
-         * [Session.url] is currently set late in the loading process, so while loading the first
-         * site of a session [isUrlEqualToHomepage] will return true for some time (often several
-         * seconds).  We check [Session.loading] to prevent the menu button from being unresponsive
-         * during that time
-         */
-        val overlayCanBeInvisible = !isUrlEqualToHomepage || session.loading
-        if (event.keyCode == KeyEvent.KEYCODE_MENU && overlayCanBeInvisible) {
+        if (event.keyCode == KeyEvent.KEYCODE_MENU && !isUrlEqualToHomepage) {
             if (actionIsDown) {
                 val toShow = !browserOverlay.isVisible
                 setOverlayVisible(toShow)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.architecture_components_version = '1.1.1'
     ext.espresso_version = '3.0.1'
     ext.kotlin_version = '1.2.41'
-    ext.moz_components_version = '0.23'
+    ext.moz_components_version = '0.25'
     ext.kotlin_coroutines_version = '0.22.5'
 
     repositories {


### PR DESCRIPTION
- 1195: Fixes crash when user inputs bad URI
- 1193: Fixes URL field being filled with data on error
- A-C #825: Fixes URL field/ProgressBar URL not being updated until a page has almost finished loading