### PR TITLE
Closes #1178, #1249: make empty tile container unfocusable

### DIFF
--- a/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserNavigationOverlay.kt
@@ -335,6 +335,11 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
             else -> R.id.turboButton
         }
 
+        pocketVideoMegaTileView.nextFocusDownId = when {
+            tileContainer.adapter.itemCount == 0 -> R.id.pocketVideoMegaTileView
+            else -> R.id.tileContainer
+        }
+
         // We may have lost focus when disabling the focused view above.
         val isFocusLost = focusedView != null && findFocus() == null
         if (isFocusLost) {
@@ -388,11 +393,13 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
     fun refreshTilesForInsertion() {
         val adapter = tileContainer.adapter as HomeTileAdapter
         adapter.updateAdapterSingleInsertion(HomeTilesManager.getTilesCache(context))
+        updateOverlayForCurrentState()
     }
 
     fun removePinnedSiteFromTiles(tileId: String) {
         val adapter = tileContainer.adapter as HomeTileAdapter
         adapter.removeTile(tileId)
+        updateOverlayForCurrentState()
     }
 
     /**
@@ -406,6 +413,7 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
                 megaTileTryAgainButton.requestFocus()
             }
         }
+        updateOverlayForCurrentState()
     }
 
     inner class HomeTileManager(

--- a/app/src/main/res/layout/browser_overlay.xml
+++ b/app/src/main/res/layout/browser_overlay.xml
@@ -73,8 +73,7 @@
                 android:layout_marginBottom="24dp"
                 android:background="@drawable/pocket_video_mega_tile_background"
                 android:focusable="true"
-                android:nextFocusUp="@id/navUrlInput"
-                android:nextFocusDown="@+id/tileContainer" />
+                android:nextFocusUp="@id/navUrlInput" />
 
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/tileContainer"


### PR DESCRIPTION
- Also fixes 1249, which at times led to the unpin icon from being out of sync with the state