### PR TITLE
Closes #991: Update Target SDK to 28.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.3
+    - android-28
     - extra-google-google_play_services
     - extra-google-m2repository
     - extra-android-m2repository
@@ -16,7 +16,7 @@ android:
 sudo: false
 
 before_install:
-  - yes | sdkmanager "platforms;android-27"
+  - yes | sdkmanager "platforms;android-28" "build-tools;28.0.3"
   - touch local.properties
 
 script:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,12 +9,12 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootDir/tools/gradle/versionCode.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "org.mozilla.tv.firefox"
         minSdkVersion 22
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
         // override this with a generated versionCode at build time.
         versionName "3.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ apply from: "$project.rootDir/tools/gradle/versionCode.gradle"
 
 android {
     compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "org.mozilla.tv.firefox"
@@ -119,7 +120,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
 
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:3.8"
+    testImplementation "org.robolectric:robolectric:4.0-alpha-3" // required for SDK 28
     testImplementation 'org.mockito:mockito-core:2.21.0'
 
     androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'

--- a/app/src/androidTest/java/org/mozilla/focus/screenshots/TVScreenshots.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screenshots/TVScreenshots.java
@@ -170,7 +170,7 @@ public class TVScreenshots extends ScreenshotTest {
         // capture a screenshot of the clear data dialog
         clearButton.perform(click());
 
-        onView(allOf(withText(R.string.settings_cookies_dialog_content), isDisplayed())).inRoot(isDialog());
+        onView(allOf(withText(R.string.settings_cookies_dialog_content2), isDisplayed())).inRoot(isDialog());
 
         Screengrab.screenshot("clear-all-data");
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.software.leanback" android:required="true" />
 
+    <!-- Attribute usesCleartextTraffic requires API 23+, tools:ignore="UnusedAttribute" for lint check-->
     <application
         android:allowBackup="false"
         android:banner="@mipmap/app_banner"
@@ -25,7 +26,9 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:name=".FocusApplication">
+        android:name=".FocusApplication"
+        android:usesCleartextTraffic="true"
+        tools:ignore="UnusedAttribute">
 
         <provider
             android:name="android.support.v4.content.FileProvider"

--- a/app/src/main/java/org/mozilla/focus/autocomplete/UrlAutoCompleteFilter.kt
+++ b/app/src/main/java/org/mozilla/focus/autocomplete/UrlAutoCompleteFilter.kt
@@ -108,7 +108,7 @@ class UrlAutoCompleteFilter : InlineAutocompleteEditText.OnFilterListener {
         val assetManager = context.assets
 
         try {
-            availableDomains.addAll(assetManager.list("domains"))
+            availableDomains.addAll(assetManager.list("domains")!!)
         } catch (e: IOException) {
             Log.w(LOG_TAG, "Could not list domain list directory")
         }

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -38,7 +38,6 @@ import org.mozilla.focus.ext.requireComponents
 import org.mozilla.focus.ext.toUri
 import org.mozilla.focus.ext.isYoutubeTV
 import org.mozilla.focus.ext.focusedDOMElement
-import org.mozilla.focus.ext.takeScreenshot
 import org.mozilla.focus.session.NullSession
 import org.mozilla.focus.telemetry.MenuInteractionMonitor
 import org.mozilla.focus.telemetry.TelemetryWrapper
@@ -150,7 +149,7 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
                     when (value) {
                         NavigationEvent.VAL_CHECKED -> {
                             CustomTilesManager.getInstance(context!!).pinSite(context!!, url,
-                                    webView?.takeScreenshot())
+                                    context!!.components.sessionManager.selectedSession?.thumbnail)
                             browserOverlay.refreshTilesForInsertion()
                             showCenteredTopToast(context, R.string.notification_pinned_site, 0, TOAST_Y_OFFSET)
                         }

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -361,7 +361,7 @@ class BrowserFragment : EngineViewLifecycleFragment(), Session.Observer {
         if (!browserOverlay.isVisible && session.isYoutubeTV &&
                 event.keyCode == KeyEvent.KEYCODE_BACK) {
             val escKeyEvent = KeyEvent(event.action, KeyEvent.KEYCODE_ESCAPE)
-            activity?.dispatchKeyEvent(escKeyEvent)
+            (activity as MainActivity).dispatchKeyEvent(escKeyEvent)
             return true
         }
         return false

--- a/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/InfoFragment.kt
@@ -29,7 +29,7 @@ class InfoFragment : EngineViewLifecycleFragment(), Session.Observer {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val session = Session(arguments!!.getString(ARGUMENT_URL))
+        val session = Session(arguments!!.getString(ARGUMENT_URL)!!)
         session.register(this, owner = this)
 
         val engineSession = requireComponents.sessionManager.getOrCreateEngineSession(session)

--- a/app/src/main/java/org/mozilla/focus/ext/EngineView.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/EngineView.kt
@@ -71,7 +71,7 @@ fun EngineView.addJavascriptInterface(obj: Any, name: String) {
 /**
  * This functionality is not supported by browser-engine-system yet. See [EngineView.evalJS] comment for details.
  */
-fun EngineView.removeJavascriptInterface(interfaceName: String?) {
+fun EngineView.removeJavascriptInterface(interfaceName: String) {
     webView.removeJavascriptInterface(interfaceName)
 }
 

--- a/app/src/main/java/org/mozilla/focus/ext/EngineView.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/EngineView.kt
@@ -5,7 +5,6 @@
 package org.mozilla.focus.ext
 
 import android.annotation.SuppressLint
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -73,21 +72,6 @@ fun EngineView.addJavascriptInterface(obj: Any, name: String) {
  */
 fun EngineView.removeJavascriptInterface(interfaceName: String) {
     webView.removeJavascriptInterface(interfaceName)
-}
-
-/**
- * Creating a screenshot (thumbnail) of the currently visible page.
- *
- * Component upstream issue:
- * https://github.com/mozilla-mobile/android-components/issues/495
- */
-fun EngineView.takeScreenshot(): Bitmap {
-    return with(webView) {
-        buildDrawingCache()
-        val outBitmap = Bitmap.createBitmap(webView.drawingCache)
-        destroyDrawingCache()
-        outBitmap
-    }
 }
 
 fun EngineView.scrollByClamped(vx: Int, vy: Int) {

--- a/app/src/main/java/org/mozilla/focus/ext/String.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/String.kt
@@ -46,7 +46,7 @@ fun String.beautifyUrl(): String {
     val query = uri.query
     if (!query.isNullOrEmpty()) {
         beautifulUrl.append("?")
-        beautifulUrl.append(query.split("&").first())
+        beautifulUrl.append(query!!.split("&").first())
     }
 
     // We always append a fragment if there's one

--- a/app/src/main/java/org/mozilla/focus/ext/Uri.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/Uri.kt
@@ -30,7 +30,7 @@ fun Uri.truncatedHost(): String? {
     //   www.tomshardware.co.uk -> tomshardware.co.uk
     // * If there's no host then just remove the URL as is.
 
-    val hostSegments = host.split(".")
+    val hostSegments = host!!.split(".")
     val usedHostSegments = mutableListOf<String>()
 
     for (segment in hostSegments.reversed()) {

--- a/app/src/main/java/org/mozilla/focus/home/HomeTilesManager.kt
+++ b/app/src/main/java/org/mozilla/focus/home/HomeTilesManager.kt
@@ -110,7 +110,7 @@ class BundledTilesManager private constructor(context: Context) {
     }
 
     private fun loadBlacklist(context: Context): MutableSet<String> {
-        return context.getSharedPreferences(PREF_HOME_TILES, MODE_PRIVATE).getStringSet(BUNDLED_SITES_ID_BLACKLIST, mutableSetOf())
+        return context.getSharedPreferences(PREF_HOME_TILES, MODE_PRIVATE).getStringSet(BUNDLED_SITES_ID_BLACKLIST, mutableSetOf())!!
     }
 
     @UiThread

--- a/app/src/main/java/org/mozilla/focus/home/pocket/Pocket.kt
+++ b/app/src/main/java/org/mozilla/focus/home/pocket/Pocket.kt
@@ -137,7 +137,7 @@ data class PocketVideo(
 
 fun ImageView.setImageDrawableAsPocketWordmark() {
     // We want to set SVGs in code because they can produce artifacts otherwise.
-    setImageDrawable(context.getDrawable(R.drawable.ic_pocket_and_wordmark).apply {
+    setImageDrawable(context.getDrawable(R.drawable.ic_pocket_and_wordmark)!!.apply {
         setTint(ContextCompat.getColor(context, R.color.photonGrey10))
     })
 }

--- a/app/src/main/res/layout/browser_overlay.xml
+++ b/app/src/main/res/layout/browser_overlay.xml
@@ -2,6 +2,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <org.mozilla.focus.browser.BrowserNavigationOverlayScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/overlayScrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -39,7 +40,9 @@
             </LinearLayout>
 
             <!-- An explicit nextFocusUp seems necessary to make up work consistently.
-            Drawable tinted in code (XML needs API 23+). -->
+            Drawable tinted in code (XML needs API 23+).
+
+            android:importantForAutofill (XML needs API 26+) requires tools:ignore="UnusedAttribute" for lint check -->
             <org.mozilla.focus.widget.InlineAutocompleteEditText
                 android:id="@+id/navUrlInput"
                 android:layout_width="498dp"
@@ -53,6 +56,7 @@
                 android:hint="@string/urlbar_hint"
                 android:imeOptions="actionGo|flagNoExtractUi|flagNoFullscreen"
                 android:importantForAutofill="no"
+                tools:ignore="UnusedAttribute"
                 android:inputType="textUri"
                 android:lines="1"
                 android:nextFocusRight="@id/navUrlInput"

--- a/app/src/test/java/org/mozilla/focus/TestResource.kt
+++ b/app/src/test/java/org/mozilla/focus/TestResource.kt
@@ -10,5 +10,5 @@ private const val POCKET_DIR = "pocket"
 enum class TestResource(private val path: String) {
     POCKET_VIDEO_RECOMMENDATION("$POCKET_DIR/video_recommendations.json");
 
-    fun get(): String = this::class.java.classLoader.getResource(path).readText()
+    fun get(): String = this::class.java.classLoader!!.getResource(path)!!.readText()
 }

--- a/app/src/test/java/org/mozilla/focus/autocomplete/UrlAutoCompleteFilterTest.kt
+++ b/app/src/test/java/org/mozilla/focus/autocomplete/UrlAutoCompleteFilterTest.kt
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.mozilla.focus.BuildConfig
 import org.mozilla.focus.R
 import org.mozilla.focus.widget.InlineAutocompleteEditText
 import org.mozilla.focus.widget.InlineAutocompleteEditText.AutocompleteResult
@@ -24,7 +23,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, packageName = "org.mozilla.focus")
+@Config(packageName = "org.mozilla.focus")
 class UrlAutoCompleteFilterTest {
     @After
     fun tearDown() {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.support_libraries_version = '27.1.1'
+    ext.support_libraries_version = '28.0.0'
     ext.architecture_components_version = '1.1.1'
     ext.espresso_version = '3.0.1'
     ext.kotlin_version = '1.2.71'


### PR DESCRIPTION
Summary
- Upgraded SDK to 28 & buildTools to 28.0.3
- android:usesCleartextTraffic="true" requires minSDK >=23
- `buildDrawingCache()` deprecated => use a-c's session thumbnails for screenshots
- Updated CI scripts
- Updated JUnit test (Robolectric 4.0-alpha-3) 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
