### PR TITLE
Closes #817: re-enable Sentry affected users metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Sentry crash reports include a UUID to distinguish users so we can determine if it's 1 user crashing 100 times or 100 users crashing 1 time each. This identifier is only used for Sentry and can not be correlated with telemetry interaction data. See [fire TV Sentry docs](https://github.com/mozilla-mobile/firefox-tv/wiki/Crash-reporting-with-Sentry) for more details. (#817)
 
 ### Fixed
 - Blank screen when pressing back from a full-screened video

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/SentryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/SentryIntegration.kt
@@ -7,7 +7,6 @@ package org.mozilla.tv.firefox.telemetry
 import android.content.Context
 import io.sentry.Sentry
 import io.sentry.android.AndroidSentryClientFactory
-import io.sentry.event.User
 import org.mozilla.tv.firefox.BuildConfig
 
 /**
@@ -45,21 +44,9 @@ object SentryIntegration {
         // disabling the client: https://github.com/getsentry/sentry-java/issues/574#issuecomment-378406105
         val sentryDsn = if (isEnabled) BuildConfig.SENTRY_DSN else null
         Sentry.init(sentryDsn, AndroidSentryClientFactory(context.applicationContext))
-
-        // By default, Sentry creates UUIDs for users and we don't want to upload them:
-        // they're personally identifiable information.
-        Sentry.getContext().user = SentryUnknownUser()
     }
 
     fun capture(exception: Exception) {
         Sentry.capture(exception)
     }
 }
-
-/**
- * A Sentry user that does not contain identifiable information like UUID.
- *
- * Use this instead of [io.sentry.context.Context.clearUser] because that
- * will just clear any user we set and use a Sentry-generated UUID instead.
- */
-private class SentryUnknownUser : User(null, null, null, null)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - We don't currently have Sentry tests; seems weird to add them to restore behavior we overrode in their API