### PR TITLE
Closes #1413 and closes #787: Upgrade a-c to 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Infrequent crash caused by initialization logic (#1159)
 - On a fresh install, focus would once skip past the Pocket megatile
 - A crash that could occur when backing out of the Pocket screen
+- DRM videos not playing
 
 ## [3.0.2] - 2018-10-30
 *Version-bump only: Released v3.0+ for the first time to Stick Gen 1 & 2 in addition to Fire TV (Gen 1, 2, 3), Cube, Element 4k (pendant), which already had v3.0+.*

--- a/app/src/main/java/org/mozilla/tv/firefox/components/UrlAutoCompleteFilter.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/components/UrlAutoCompleteFilter.kt
@@ -6,8 +6,8 @@ package org.mozilla.tv.firefox.components
 
 import android.content.Context
 import android.util.Log
-import kotlinx.coroutines.experimental.CommonPool
-import kotlinx.coroutines.experimental.android.UI
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.launch
 import org.mozilla.tv.firefox.components.locale.Locales
@@ -78,8 +78,8 @@ class UrlAutoCompleteFilter : InlineAutocompleteEditText.OnFilterListener {
         settings = Settings.getInstance(context)
 
         if (loadDomainsFromDisk) {
-            launch(UI) {
-                val domains = async(CommonPool) { loadDomains(context) }
+            GlobalScope.launch(Dispatchers.Main) {
+                val domains = async(Dispatchers.Default) { loadDomains(context) }
 
                 onDomainsLoaded(domains.await())
             }

--- a/app/src/main/java/org/mozilla/tv/firefox/components/UrlAutoCompleteFilter.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/components/UrlAutoCompleteFilter.kt
@@ -31,8 +31,6 @@ class UrlAutoCompleteFilter : InlineAutocompleteEditText.OnFilterListener {
 
     private var preInstalledDomains: List<String> = emptyList()
 
-    private var uiScope: CoroutineScope? = null
-
     override fun onFilter(rawSearchText: String, view: InlineAutocompleteEditText?) {
         if (view == null) {
             return
@@ -78,11 +76,11 @@ class UrlAutoCompleteFilter : InlineAutocompleteEditText.OnFilterListener {
     }
 
     fun load(context: Context, uiLifecycleCancelJob: Job, loadDomainsFromDisk: Boolean = true) {
+        val uiScope = CoroutineScope(Dispatchers.Main + uiLifecycleCancelJob)
         settings = Settings.getInstance(context)
-        uiScope = CoroutineScope(Dispatchers.Main + uiLifecycleCancelJob)
         if (loadDomainsFromDisk) {
-            uiScope!!.launch {
-                val domains = async(Dispatchers.Default) { loadDomains(context) }
+            uiScope.launch {
+                val domains = async { loadDomains(context) }
 
                 onDomainsLoaded(domains.await())
             }

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/BrowserNavigationOverlay.kt
@@ -27,7 +27,10 @@ import android.widget.Toast
 import kotlinx.android.synthetic.main.browser_overlay.view.*
 import kotlinx.android.synthetic.main.browser_overlay_top_nav.view.*
 import kotlinx.android.synthetic.main.pocket_video_mega_tile.view.*
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.Job
+import kotlinx.coroutines.experimental.launch
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.components.UrlAutoCompleteFilter
@@ -241,6 +244,7 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
     private fun initMegaTile() {
         pocketVideoMegaTileView.setOnClickListener(this)
     }
+
 
     fun observeForMegaTile(fragment: Fragment) {
         // TODO remove this

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/BrowserNavigationOverlay.kt
@@ -27,10 +27,9 @@ import android.widget.Toast
 import kotlinx.android.synthetic.main.browser_overlay.view.*
 import kotlinx.android.synthetic.main.browser_overlay_top_nav.view.*
 import kotlinx.android.synthetic.main.pocket_video_mega_tile.view.*
+import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Dispatchers
-import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.Job
-import kotlinx.coroutines.experimental.launch
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.components.UrlAutoCompleteFilter
@@ -113,6 +112,8 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
      */
     var uiLifecycleCancelJob: Job
 
+    private val uiScope: CoroutineScope
+
     // We need this in order to show the unpin toast, at max, once per
     // instantiation of the BrowserNavigationOverlay
     var canShowUpinToast: Boolean = false
@@ -155,6 +156,7 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
         }
 
         uiLifecycleCancelJob = Job()
+        uiScope = CoroutineScope(Dispatchers.Main + uiLifecycleCancelJob)
 
         initMegaTile()
         setupUrlInput()
@@ -245,7 +247,6 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
         pocketVideoMegaTileView.setOnClickListener(this)
     }
 
-
     fun observeForMegaTile(fragment: Fragment) {
         // TODO remove this
         // This function is necessary because BrowserNavigationOverlay is not a LifecycleOwner,
@@ -289,7 +290,7 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
         }
         this.movementMethod = IgnoreFocusMovementMethod()
         val autocompleteFilter = UrlAutoCompleteFilter()
-        autocompleteFilter.load(context.applicationContext)
+        autocompleteFilter.load(context.applicationContext, uiLifecycleCancelJob)
         setOnFilterListener { searchText, view -> autocompleteFilter.onFilter(searchText, view) }
 
         setOnUserInputListener { hasUserChangedURLSinceEditTextFocused = true }

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/BrowserNavigationOverlay.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/BrowserNavigationOverlay.kt
@@ -27,8 +27,6 @@ import android.widget.Toast
 import kotlinx.android.synthetic.main.browser_overlay.view.*
 import kotlinx.android.synthetic.main.browser_overlay_top_nav.view.*
 import kotlinx.android.synthetic.main.pocket_video_mega_tile.view.*
-import kotlinx.coroutines.experimental.CoroutineScope
-import kotlinx.coroutines.experimental.Dispatchers
 import kotlinx.coroutines.experimental.Job
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.tv.firefox.R
@@ -112,8 +110,6 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
      */
     var uiLifecycleCancelJob: Job
 
-    private val uiScope: CoroutineScope
-
     // We need this in order to show the unpin toast, at max, once per
     // instantiation of the BrowserNavigationOverlay
     var canShowUpinToast: Boolean = false
@@ -156,7 +152,6 @@ class BrowserNavigationOverlay @JvmOverloads constructor(
         }
 
         uiLifecycleCancelJob = Job()
-        uiScope = CoroutineScope(Dispatchers.Main + uiLifecycleCancelJob)
 
         initMegaTile()
         setupUrlInput()

--- a/app/src/main/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileAdapter.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileAdapter.kt
@@ -60,7 +60,7 @@ class PinnedTileAdapter(
                 setIconLayoutMarginParams(iconView, R.dimen.bundled_home_tile_margin_value)
             }
             is CustomPinnedTile -> {
-                onBindCustomHomeTile(uiLifecycleCancelJob, uiScope, holder, item)
+                onBindCustomHomeTile(uiScope, holder, item)
                 setIconLayoutMarginParams(iconView, R.dimen.custom_home_tile_margin_value)
             }
         }.forceExhaustive
@@ -147,12 +147,11 @@ private fun onBindBundledHomeTile(holder: TileViewHolder, tile: BundledPinnedTil
 }
 
 private fun onBindCustomHomeTile(
-    uiLifecycleCancelJob: Job,
     uiScope: CoroutineScope,
     holder: TileViewHolder,
     item: CustomPinnedTile
 ) = with(holder) {
-    uiScope.launch(uiLifecycleCancelJob + Dispatchers.Main, CoroutineStart.UNDISPATCHED) {
+    uiScope.launch(start = CoroutineStart.UNDISPATCHED) {
         val validUri = item.url.toJavaURI()
 
         val screenshotDeferred = async {

--- a/app/src/main/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileAdapter.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileAdapter.kt
@@ -17,8 +17,9 @@ import android.view.animation.DecelerateInterpolator
 import kotlinx.android.synthetic.main.home_tile.view.*
 import kotlinx.coroutines.experimental.CompletableDeferred
 import kotlinx.coroutines.experimental.CoroutineStart
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.Job
-import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.launch
 import org.mozilla.tv.firefox.R
@@ -144,7 +145,7 @@ private fun onBindBundledHomeTile(holder: TileViewHolder, tile: BundledPinnedTil
 }
 
 private fun onBindCustomHomeTile(uiLifecycleCancelJob: Job, holder: TileViewHolder, item: CustomPinnedTile) = with(holder) {
-    launch(uiLifecycleCancelJob + UI, CoroutineStart.UNDISPATCHED) {
+    GlobalScope.launch(uiLifecycleCancelJob + Dispatchers.Main, CoroutineStart.UNDISPATCHED) {
         val validUri = item.url.toJavaURI()
 
         val screenshotDeferred = async {

--- a/app/src/main/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileScreenshotStore.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileScreenshotStore.kt
@@ -10,6 +10,7 @@ import android.graphics.BitmapFactory
 import android.support.annotation.AnyThread
 import android.support.annotation.VisibleForTesting
 import android.support.annotation.WorkerThread
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.sync.Mutex
 import kotlinx.coroutines.experimental.sync.withLock
@@ -95,7 +96,7 @@ object PinnedTileScreenshotStore {
 
     /** @param uuid a unique identifier for this screenshot. */
     @AnyThread
-    fun saveAsync(context: Context, uuid: UUID, screenshot: Bitmap) = launch {
+    fun saveAsync(context: Context, uuid: UUID, screenshot: Bitmap) = GlobalScope.launch {
         if (!isScreenshotAcceptableAsHomeTile(screenshot)) {
             // We won't save this image, meaning we'll return null when we try to read it.
             // At the time of writing, this will fall back to placeholders.
@@ -115,7 +116,7 @@ object PinnedTileScreenshotStore {
 
     /** @param a unique identifier for this screenshot. */
     @AnyThread
-    fun removeAsync(context: Context, uuid: UUID) = launch {
+    fun removeAsync(context: Context, uuid: UUID) = GlobalScope.launch {
         getMutex(uuid).withLock {
             getFileForUUID(context, uuid).delete()
         }

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoRepo.kt
@@ -9,6 +9,7 @@ import android.arch.lifecycle.MutableLiveData
 import android.os.SystemClock
 import android.support.annotation.UiThread
 import kotlinx.coroutines.experimental.CancellationException
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.delay
 import kotlinx.coroutines.experimental.launch
@@ -54,7 +55,7 @@ open class PocketVideoRepo(
 
     fun update() {
         retryDelayMillis = BASE_RETRY_TIME
-        launch { updateInner() }
+        GlobalScope.launch { updateInner() }
     }
 
     @UiThread // update backgroundUpdates.
@@ -111,7 +112,7 @@ open class PocketVideoRepo(
         postState(response.toRepoState())
     }
 
-    private fun startBackgroundUpdatesInner() = launch {
+    private fun startBackgroundUpdatesInner() = GlobalScope.launch {
         while (true) {
             val nextScheduledUpdateMillis = lastUpdateAttemptMillis + CACHE_UPDATE_FREQUENCY_MILLIS
             val nextRetryUpdateMillis = lastUpdateAttemptMillis + retryDelayMillis
@@ -123,7 +124,7 @@ open class PocketVideoRepo(
 
             val delayForMillis = nextUpdateMillis - SystemClock.elapsedRealtime()
             if (delayForMillis > 0) {
-                delay(delayForMillis, TimeUnit.MILLISECONDS)
+                delay(delayForMillis)
             }
             updateInner()
         }

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/publicsuffix/PublicSuffixKt.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/publicsuffix/PublicSuffixKt.kt
@@ -5,6 +5,7 @@
 package org.mozilla.tv.firefox.utils.publicsuffix
 
 import android.content.Context
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.launch
 
 /** A helper to allow [PublicSuffix] to call Kotlin code: converting the whole file didn't seem right. */
@@ -16,6 +17,6 @@ internal object PublicSuffixKt {
     @JvmStatic
     fun init(context: Context) {
         // We don't care for the result: we just want to call this method so it caches the file from disk.
-        launch { PublicSuffixPatterns.getExactSet(context) }
+        GlobalScope.launch { PublicSuffixPatterns.getExactSet(context) }
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/CustomContentRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/CustomContentRequestInterceptor.kt
@@ -18,14 +18,14 @@ class CustomContentRequestInterceptor(
 
     private var currentPageURL = ""
 
-    override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse? {
+    override fun onLoadRequest(session: EngineSession, uri: String): RequestInterceptor.InterceptionResponse.Content? {
         currentPageURL = uri
 
         return when (uri) {
             WebRenderFragment.APP_URL_HOME, WebRenderFragment.APP_URL_POCKET_ERROR ->
-                RequestInterceptor.InterceptionResponse("<html></html>")
+                RequestInterceptor.InterceptionResponse.Content("<html></html>")
 
-            LocalizedContent.URL_ABOUT -> RequestInterceptor.InterceptionResponse(
+            LocalizedContent.URL_ABOUT -> RequestInterceptor.InterceptionResponse.Content(
                 LocalizedContent.generateAboutPage(context))
 
             else -> null

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/VideoVoiceCommandMediaSession.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/VideoVoiceCommandMediaSession.kt
@@ -34,7 +34,8 @@ import android.view.KeyEvent.KEYCODE_MEDIA_PLAY
 import android.view.KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE
 import android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS
 import android.webkit.JavascriptInterface
-import kotlinx.coroutines.experimental.android.UI
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineView
@@ -240,7 +241,7 @@ class VideoVoiceCommandMediaSession @UiThread constructor(
                 playbackSpeed = 0f
             }
 
-            launch(UI) { // mediaSession and cachedPlaybackState is on UI thread only.
+            GlobalScope.launch(Dispatchers.Main) { // mediaSession and cachedPlaybackState is on UI thread only.
                 val playbackState = cachedPlaybackStateBuilder
                         .setState(playbackStateInt, positionMillis, playbackSpeed)
                         .build()

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/cursor/CursorController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/cursor/CursorController.kt
@@ -93,7 +93,6 @@ class CursorController(
         webRenderFragment.context?.getAccessibilityManager()?.removeTouchExplorationStateChangeListener(this)
 
         webRenderFragment.session.unregister(isLoadingObserver)
-        uiLifecycleCancelJob.cancel()
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
@@ -105,6 +104,11 @@ class CursorController(
     @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     fun onResume() {
         view.startUpdates()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    fun onDestroy() {
+        uiLifecycleCancelJob.cancel()
     }
 
     override fun onTouchExplorationStateChanged(isEnabled: Boolean) {

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/cursor/CursorViewModel.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/cursor/CursorViewModel.kt
@@ -10,13 +10,14 @@ import android.support.annotation.UiThread
 import android.support.v4.math.MathUtils
 import android.view.MotionEvent
 import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.android.UI
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.delay
+import kotlinx.coroutines.experimental.isActive
 import org.mozilla.tv.firefox.ext.use
 import org.mozilla.tv.firefox.utils.Direction
 import java.util.EnumSet
-import java.util.concurrent.TimeUnit
 import kotlin.properties.Delegates
 
 private const val UPDATE_DELAY_MILLIS = 17L // ~60 FPS.
@@ -134,14 +135,14 @@ class CursorViewModel(
     }
 
     // TODO: stop when new views (e.g. overlay) are opened.
-    private fun asyncStartUpdates() = async(UI) { // Use UI to avoid synchronization.
+    private fun asyncStartUpdates() = GlobalScope.async(Dispatchers.Main) { // Use UI to avoid synchronization.
         var currentFrameMillis = SystemClock.uptimeMillis() // duped in loop.
         var prevFrameMillis: Long
         var deltaMillis = UPDATE_DELAY_MILLIS // Move ~1 frame to start.
         while (isActive) {
             update(deltaMillis)
 
-            delay(UPDATE_DELAY_MILLIS, TimeUnit.MILLISECONDS)
+            delay(UPDATE_DELAY_MILLIS)
 
             prevFrameMillis = currentFrameMillis
             currentFrameMillis = SystemClock.uptimeMillis() // duped in init.

--- a/app/src/test/java/org/mozilla/tv/firefox/autocomplete/UrlAutoCompleteFilterTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/autocomplete/UrlAutoCompleteFilterTest.kt
@@ -8,6 +8,7 @@ package org.mozilla.tv.firefox.autocomplete
 import android.app.Application
 import android.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.experimental.Job
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -45,8 +46,9 @@ class UrlAutoCompleteFilterTest {
 
     @Test
     fun testAutocompletion() {
+        var job = Job()
         val filter = UrlAutoCompleteFilter()
-        filter.load(appContext, false)
+        filter.load(appContext, job, false)
 
         val domains = listOf("mozilla.org", "google.com", "facebook.com")
         filter.onDomainsLoaded(domains)
@@ -62,6 +64,8 @@ class UrlAutoCompleteFilterTest {
 
         assertNoAutocompletion(filter, "wwww")
         assertNoAutocompletion(filter, "yahoo")
+
+        job.cancel()
     }
 
 //    @Test
@@ -73,8 +77,9 @@ class UrlAutoCompleteFilterTest {
 
         val domains = listOf("facebook.com", "google.com", "mozilla.org")
 
+        val job = Job()
         val filter = UrlAutoCompleteFilter()
-        filter.load(appContext, false)
+        filter.load(appContext, job, false)
         filter.onDomainsLoaded(domains)
 
         assertAutocompletion(filter, "f", "fanfiction.com")
@@ -89,6 +94,8 @@ class UrlAutoCompleteFilterTest {
         assertAutocompletion(filter, "mo", "mobile.de")
         assertAutocompletion(filter, "mob", "mobile.de")
         assertAutocompletion(filter, "moz", "mozilla.org")
+
+        job.cancel()
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/tv/firefox/engine/CustomContentRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/engine/CustomContentRequestInterceptorTest.kt
@@ -56,7 +56,8 @@ class CustomContentRequestInterceptorTest {
         assertNotEquals(firefoxAbout.data, firefoxHome.data)
     }
 
-    private fun testInterceptor(url: String): RequestInterceptor.InterceptionResponse? {
+
+    private fun testInterceptor(url: String): RequestInterceptor.InterceptionResponse.Content? {
         val interceptor = CustomContentRequestInterceptor(ApplicationProvider.getApplicationContext())
         return interceptor.onLoadRequest(mock(EngineSession::class.java), url)
     }

--- a/app/src/test/java/org/mozilla/tv/firefox/engine/CustomContentRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/engine/CustomContentRequestInterceptorTest.kt
@@ -56,7 +56,6 @@ class CustomContentRequestInterceptorTest {
         assertNotEquals(firefoxAbout.data, firefoxHome.data)
     }
 
-
     private fun testInterceptor(url: String): RequestInterceptor.InterceptionResponse.Content? {
         val interceptor = CustomContentRequestInterceptor(ApplicationProvider.getApplicationContext())
         return interceptor.onLoadRequest(mock(EngineSession::class.java), url)

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.architecture_components_version = '1.1.1'
     ext.espresso_version = '3.0.2'
     ext.kotlin_version = '1.2.71'
-    ext.moz_components_version = '0.27.0'
+    ext.moz_components_version = '0.29.0'
     ext.kotlin_coroutines_version = '0.22.5'
 
     repositories {


### PR DESCRIPTION
This upgrade is needed to fix #787.
- Fix deprecated kotlinx.coroutines methods
- Update `CustomContentRequestInterceptor` for API change





### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
Library upgrade, not needed.