### PR TITLE
Update changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Add feature to cast from YouTube mobile app (on phone, tablet)
+- Feature to cast videos from YouTube mobile app (on phone, tablet)
 
 ### Changed
 - Hide Pocket video tile on non-EN locales
     - Pocket does not yet provide content for other languages
-
 - Sentry crash reports include a UUID to distinguish users so we can determine if it's 1 user crashing 100 times or 100 users crashing 1 time each. This identifier is only used for Sentry and can not be correlated with telemetry interaction data. See [fire TV Sentry docs](https://github.com/mozilla-mobile/firefox-tv/wiki/Crash-reporting-with-Sentry) for more details. (#817)
 
 ### Fixed
@@ -20,11 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Infrequent crash caused by initialization logic (#1159)
 
 ## [3.0.2] - 2018-10-30
-Version-bump only, released adding *Stick Gen 1 & 2* in addition to *Fire TV (Gen 1, 2, 3), Cube, Element 4k (pendant)*
+*Version-bump only: Released v3.0+ for the first time to Stick Gen 1 & 2 in addition to Fire TV (Gen 1, 2, 3), Cube, Element 4k (pendant), which already had v3.0+.*
 
 ## [3.0.1] - RC candidate, did not release
 ### Fixed
-Issue that would cause browsing history to be lost when navigating to device home screen
+- Issue that would cause browsing history to be lost when navigating to device home screen (#1256)
 
 ## [3.0] - 2018-10-16
 *Released to Fire TV Cube and Fire TV 4K.*
@@ -57,7 +56,7 @@ play/pause/rewind/fast-forward/restart/next/previous"
 The CHANGELOG entries for the releases listed below this were added retroactively and may be incomplete.
 
 ## [2.1.2] 2018-10-30
-Version-bump only for *Fire TV Stick 4k*
+*Version-bump only for Fire TV Stick 4k*
 
 ## [2.1] - 2018-?-?
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Blank screen when pressing back from a full-screened video
 - Infrequent crash caused by initialization logic (#1159)
 
+## [3.0.2] - 2018-10-30
+Version-bump only, released adding *Stick Gen 1 & 2* in addition to *Fire TV (Gen 1, 2, 3), Cube, Element 4k (pendant)*
+
+## [3.0.1] - RC candidate, did not release
+### Fixed
+Issue that would cause browsing history to be lost when navigating to device home screen
+
 ## [3.0] - 2018-10-16
 *Released to Fire TV Cube and Fire TV 4K.*
 
@@ -44,6 +51,9 @@ play/pause/rewind/fast-forward/restart/next/previous"
 
 ## Note on releases below
 The CHANGELOG entries for the releases listed below this were added retroactively and may be incomplete.
+
+## [2.1.2] 2018-10-30
+Version-bump only for *Fire TV Stick 4k*
 
 ## [2.1] - 2018-?-?
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Add feature to cast from YouTube mobile app (on phone, tablet)
 
 ### Changed
+- Hide Pocket video tile on non-EN locales
+    - Pocket does not yet provide content for other languages
+
 - Sentry crash reports include a UUID to distinguish users so we can determine if it's 1 user crashing 100 times or 100 users crashing 1 time each. This identifier is only used for Sentry and can not be correlated with telemetry interaction data. See [fire TV Sentry docs](https://github.com/mozilla-mobile/firefox-tv/wiki/Crash-reporting-with-Sentry) for more details. (#817)
 
 ### Fixed


### PR DESCRIPTION
IS CHANGELOG CHANGES

Question: in the future, do we want to add LATs to the changelog too?
* Would make it easier to not get out of date, if we have multiple LATs (though changelogs will still be added to the releases page)
* Would need to duplicate changelog entries, because a LAT is not a release (and those features would get released officially later)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
