### PR TITLE
Closes #1365: Grant WRITE_EXTERNAL_STORAGE when running screenshot te…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,6 +146,7 @@ dependencies {
     androidTestImplementation "com.android.support.test.espresso:espresso-web:$espresso_version", {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
+    androidTestImplementation "com.android.support.test:rules:1.0.2"
 
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/screenshots/ScreenshotTest.java
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/screenshots/ScreenshotTest.java
@@ -1,10 +1,12 @@
 package org.mozilla.tv.firefox.ui.screenshots;
 
+import android.Manifest;
 import android.app.Instrumentation;
 import android.content.Context;
 import android.support.annotation.StringRes;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.IdlingRegistry;
+import android.support.test.rule.GrantPermissionRule;
 import android.support.test.uiautomator.UiDevice;
 import android.text.format.DateUtils;
 
@@ -29,6 +31,9 @@ abstract class ScreenshotTest {
     private SessionLoadedIdlingResource loadingIdlingResource;
 
     UiDevice device;
+
+    @Rule
+    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
     @Rule
     public TestRule screenshotOnFailureRule = new TestWatcher() {


### PR DESCRIPTION
…sts.

This allows the tests to pass as part of the UI test suite but running this way,
without the script, they may not take screenshots correctly.

After this fix, there are still a few UI test failures for other reasons:
- ClearDataTest
- PageLoadTest
- PinnedTileTests
- PinTileTests (screenshots)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Test fix
- [x] This PR includes a **CHANGELOG entry** or does not need one
