### PR TITLE
Fixes #1453: fixes KNPE in voice media session

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/VideoVoiceCommandMediaSession.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/VideoVoiceCommandMediaSession.kt
@@ -120,8 +120,8 @@ class VideoVoiceCommandMediaSession @UiThread constructor(
         this.sessionIsLoadingObserver = sessionIsLoadingObserver
     }
 
-    fun onDestroyWebView(webView: EngineView, session: Session) {
-        webView.removeJavascriptInterface(JS_INTERFACE_IDENTIFIER)
+    fun onDestroyWebView(webView: EngineView?, session: Session) {
+        webView?.removeJavascriptInterface(JS_INTERFACE_IDENTIFIER)
         this.webView = null
 
         session.unregister(sessionIsLoadingObserver!!)

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -276,7 +276,7 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
     }
 
     override fun onDestroyView() {
-        mediaSessionHolder?.videoVoiceCommandMediaSession?.onDestroyWebView(webView!!, session)
+        mediaSessionHolder?.videoVoiceCommandMediaSession?.onDestroyWebView(webView, session)
 
         super.onDestroyView()
 


### PR DESCRIPTION
For RCA, see issue

It seems strange to me that the WebView has occasionally been nulled out before `WebRenderFragment#onDestroyView` is called, but if the view has already been destroyed I think we can safey skip cleaning it up.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
Trivial change
- [X] This PR includes a **CHANGELOG entry** or does not need one
Not user-facing
