### PR TITLE
Fixes #1408: megatile focus on fresh install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Blank screen when pressing back from a full-screened video
 - Infrequent crash caused by initialization logic (#1159)
+- On a fresh install, focus would once skip past the Pocket megatile
 
 ## [3.0.2] - 2018-10-30
 *Version-bump only: Released v3.0+ for the first time to Stick Gen 1 & 2 in addition to Fire TV (Gen 1, 2, 3), Cube, Element 4k (pendant), which already had v3.0+.*

--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -9,7 +9,6 @@ import android.preference.PreferenceManager
 import android.support.annotation.VisibleForTesting
 import android.webkit.WebSettings
 import org.mozilla.tv.firefox.components.locale.LocaleAwareApplication
-import org.mozilla.tv.firefox.components.locale.LocaleManager
 import org.mozilla.tv.firefox.components.search.SearchEngineManager
 import org.mozilla.tv.firefox.webrender.VisibilityLifeCycleCallback
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
@@ -43,7 +42,7 @@ open class FirefoxApplication : LocaleAwareApplication() {
 
         PreferenceManager.setDefaultValues(this, R.xml.settings, false)
 
-        initServiceLocator()
+        serviceLocator = ServiceLocator(this)
 
         enableStrictMode()
 
@@ -54,10 +53,6 @@ open class FirefoxApplication : LocaleAwareApplication() {
         visibilityLifeCycleCallback = VisibilityLifeCycleCallback(this).also {
             registerActivityLifecycleCallbacks(it)
         }
-    }
-
-    private fun initServiceLocator() {
-        serviceLocator = ServiceLocator(this)
     }
 
     private fun enableStrictMode() {

--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -9,6 +9,7 @@ import android.preference.PreferenceManager
 import android.support.annotation.VisibleForTesting
 import android.webkit.WebSettings
 import org.mozilla.tv.firefox.components.locale.LocaleAwareApplication
+import org.mozilla.tv.firefox.components.locale.LocaleManager
 import org.mozilla.tv.firefox.components.search.SearchEngineManager
 import org.mozilla.tv.firefox.webrender.VisibilityLifeCycleCallback
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
@@ -42,7 +43,7 @@ open class FirefoxApplication : LocaleAwareApplication() {
 
         PreferenceManager.setDefaultValues(this, R.xml.settings, false)
 
-        serviceLocator = ServiceLocator(this)
+        initServiceLocator()
 
         enableStrictMode()
 
@@ -53,6 +54,11 @@ open class FirefoxApplication : LocaleAwareApplication() {
         visibilityLifeCycleCallback = VisibilityLifeCycleCallback(this).also {
             registerActivityLifecycleCallbacks(it)
         }
+    }
+
+    private fun initServiceLocator() {
+        val getLanguage = { LocaleManager.getInstance().getCurrentLanguage(this) }
+        serviceLocator = ServiceLocator(this, getLanguage)
     }
 
     private fun enableStrictMode() {

--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -57,8 +57,7 @@ open class FirefoxApplication : LocaleAwareApplication() {
     }
 
     private fun initServiceLocator() {
-        val getLanguage = { LocaleManager.getInstance().getCurrentLanguage(this) }
-        serviceLocator = ServiceLocator(this, getLanguage)
+        serviceLocator = ServiceLocator(this)
     }
 
     private fun enableStrictMode() {

--- a/app/src/main/java/org/mozilla/tv/firefox/ViewModelFactory.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ViewModelFactory.kt
@@ -25,7 +25,7 @@ import org.mozilla.tv.firefox.utils.ServiceLocator
 class ViewModelFactory(private val serviceLocator: ServiceLocator, private val app: Application) :
     ViewModelProvider.Factory {
 
-    private val getLanguage = { LocaleManager.getInstance().getCurrentLanguage(app) }
+    private val getIsEnglishLocale = { LocaleManager.getInstance().currentLanguageIsEnglish(app) }
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
@@ -34,7 +34,7 @@ class ViewModelFactory(private val serviceLocator: ServiceLocator, private val a
             PinnedTileViewModel::class.java -> PinnedTileViewModel(serviceLocator.pinnedTileRepo) as T
             PocketViewModel::class.java -> PocketViewModel(
                 serviceLocator.pocketRepo,
-                getLanguage,
+                getIsEnglishLocale,
                 serviceLocator.pocketRepoCache
             ) as T
         // This class needs to either return a ViewModel or throw, so we have no good way of silently handling

--- a/app/src/main/java/org/mozilla/tv/firefox/ViewModelFactory.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ViewModelFactory.kt
@@ -4,9 +4,11 @@
 
 package org.mozilla.tv.firefox
 
+import android.app.Application
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
+import org.mozilla.tv.firefox.components.locale.LocaleManager
 import org.mozilla.tv.firefox.pinnedtile.PinnedTileViewModel
 import org.mozilla.tv.firefox.pocket.PocketViewModel
 import org.mozilla.tv.firefox.utils.ServiceLocator
@@ -20,15 +22,19 @@ import org.mozilla.tv.firefox.utils.ServiceLocator
  * val myViewModel = ViewModelProviders.of(this, factory).get(ExampleViewModel::class.java)
  * ```
  */
-class ViewModelFactory(private val serviceLocator: ServiceLocator, private val getCurrentLanguage: () -> String) :
+class ViewModelFactory(private val serviceLocator: ServiceLocator, private val app: Application) :
     ViewModelProvider.Factory {
+
+    private val getLanguage = { LocaleManager.getInstance().getCurrentLanguage(app) }
+
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        println(app)
         return when (modelClass) {
             PinnedTileViewModel::class.java -> PinnedTileViewModel(serviceLocator.pinnedTileRepo) as T
             PocketViewModel::class.java -> PocketViewModel(
                 serviceLocator.pocketRepo,
-                getCurrentLanguage,
+                getLanguage,
                 serviceLocator.pocketRepoCache
             ) as T
         // This class needs to either return a ViewModel or throw, so we have no good way of silently handling

--- a/app/src/main/java/org/mozilla/tv/firefox/ViewModelFactory.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ViewModelFactory.kt
@@ -20,17 +20,24 @@ import org.mozilla.tv.firefox.utils.ServiceLocator
  * val myViewModel = ViewModelProviders.of(this, factory).get(ExampleViewModel::class.java)
  * ```
  */
-class ViewModelFactory(private val serviceLocator: ServiceLocator) : ViewModelProvider.Factory {
+class ViewModelFactory(private val serviceLocator: ServiceLocator, private val getCurrentLanguage: () -> String) :
+    ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         return when (modelClass) {
             PinnedTileViewModel::class.java -> PinnedTileViewModel(serviceLocator.pinnedTileRepo) as T
-            PocketViewModel::class.java -> PocketViewModel(serviceLocator.pocketRepo, serviceLocator.pocketRepoCache) as T
-            // This class needs to either return a ViewModel or throw, so we have no good way of silently handling
-            // failures in production. However a failure could only occur if code requests a VM that we have not added
-            // to this factory, so any problems should be caught in dev.
-            else -> throw IllegalArgumentException("A class was passed to ViewModelFactory#create that it does not " +
-                "know how to handle\nClass name: ${modelClass.simpleName}")
+            PocketViewModel::class.java -> PocketViewModel(
+                serviceLocator.pocketRepo,
+                getCurrentLanguage,
+                serviceLocator.pocketRepoCache
+            ) as T
+        // This class needs to either return a ViewModel or throw, so we have no good way of silently handling
+        // failures in production. However a failure could only occur if code requests a VM that we have not added
+        // to this factory, so any problems should be caught in dev.
+            else -> throw IllegalArgumentException(
+                "A class was passed to ViewModelFactory#create that it does not " +
+                    "know how to handle\nClass name: ${modelClass.simpleName}"
+            )
         }
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/components/locale/LocaleManager.java
+++ b/app/src/main/java/org/mozilla/tv/firefox/components/locale/LocaleManager.java
@@ -284,13 +284,14 @@ public class LocaleManager {
     }
 
     @NonNull
-    public String getCurrentLanguage(@NonNull Context context) {
+    public Boolean currentLanguageIsEnglish(@NonNull Context context) {
         Locale current = getCurrentLocale(context);
         // If locale hasn't been updated (i.e., 'current' is null), use system default
         if (current == null) {
             current = context.getResources().getConfiguration().locale;
         }
-        return Locales.getLanguage(current);
+        String language = Locales.getLanguage(current);
+        return language.toLowerCase(current).startsWith("en");
     }
 
     /**

--- a/app/src/main/java/org/mozilla/tv/firefox/components/locale/LocaleManager.java
+++ b/app/src/main/java/org/mozilla/tv/firefox/components/locale/LocaleManager.java
@@ -283,14 +283,14 @@ public class LocaleManager {
         return currentLocale = Locales.parseLocaleCode(current);
     }
 
-    public boolean currentLanguageIsEnglish(@NonNull Context context) {
+    @NonNull
+    public String getCurrentLanguage(@NonNull Context context) {
         Locale current = getCurrentLocale(context);
         // If locale hasn't been updated (i.e., 'current' is null), use system default
         if (current == null) {
             current = context.getResources().getConfiguration().locale;
         }
-        String language = Locales.getLanguage(current);
-        return language.toLowerCase(current).contains("en");
+        return Locales.getLanguage(current);
     }
 
     /**

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
@@ -53,7 +53,9 @@ class PocketVideoFragment : Fragment() {
             when (state) {
                 is PocketViewModel.State.Error -> { /* TODO: #769: display error screen */ }
                 is PocketViewModel.State.Feed -> adapter.setVideos(state.feed)
-                is PocketViewModel.State.NotDisplayed -> { }
+                is PocketViewModel.State.NotDisplayed -> {
+                    throw IllegalStateException("PocketVideoFragment reached while PocketViewModel.State == NotDisplayed")
+                }
                 null -> { }
             }.forceExhaustive
         })

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
@@ -50,10 +50,11 @@ class PocketVideoFragment : Fragment() {
         val viewModel = ViewModelProviders.of(this, factory).get(PocketViewModel::class.java)
 
         viewModel.state.observe(viewLifecycleOwner, Observer<PocketViewModel.State> { state ->
-            state ?: return@Observer
             when (state) {
                 is PocketViewModel.State.Error -> { /* TODO: #769: display error screen */ }
                 is PocketViewModel.State.Feed -> adapter.setVideos(state.feed)
+                is PocketViewModel.State.NotDisplayed -> { }
+                null -> { }
             }.forceExhaustive
         })
         return layout

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketViewModel.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketViewModel.kt
@@ -22,7 +22,7 @@ const val POCKET_VIDEO_COUNT = 20
  */
 class PocketViewModel(
     private val pocketVideoRepo: PocketVideoRepo,
-    private val getCurrentLanguage: () -> String,
+    private val localeIsEnglish: () -> Boolean,
     pocketRepoCache: PocketRepoCache
 ) : ViewModel() {
 
@@ -56,7 +56,7 @@ class PocketViewModel(
                 is PocketVideoRepo.FeedState.FetchFailed -> State.Error
             }
         }.map {
-            if (getCurrentLanguage().toLowerCase().startsWith("en")) it
+            if (localeIsEnglish()) it
             // We only show the Pocket mega tile if the current language is English.
             // Otherwise, overwrite any state with NotDisplayed
             // See issue: https://github.com/mozilla-mobile/firefox-tv/issues/1283

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -44,13 +44,13 @@ import org.mozilla.tv.firefox.pocket.PocketVideoRepo
  *   open val telemetry: TelemetryInterface by lazy { SentryWrapper() }
  *   ```
  */
-open class ServiceLocator(val app: Application) {
+open class ServiceLocator(val app: Application, getCurrentLanguage: () -> String) {
     private val pocketEndpoint get() = PocketEndpoint
     private val buildConfigDerivables get() = BuildConfigDerivables()
     private val pocketFeedStateMachine get() = PocketFeedStateMachine()
 
     val pocketRepoCache by lazy { PocketRepoCache(pocketRepo).apply { unfreeze() } }
-    val viewModelFactory by lazy { ViewModelFactory(this) }
+    val viewModelFactory by lazy { ViewModelFactory(this, getCurrentLanguage) }
     val screenController by lazy { ScreenController() }
 
     open val pinnedTileRepo by lazy { PinnedTileRepo(app) }

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -44,13 +44,13 @@ import org.mozilla.tv.firefox.pocket.PocketVideoRepo
  *   open val telemetry: TelemetryInterface by lazy { SentryWrapper() }
  *   ```
  */
-open class ServiceLocator(val app: Application, getCurrentLanguage: () -> String) {
+open class ServiceLocator(val app: Application) {
     private val pocketEndpoint get() = PocketEndpoint
     private val buildConfigDerivables get() = BuildConfigDerivables()
     private val pocketFeedStateMachine get() = PocketFeedStateMachine()
 
     val pocketRepoCache by lazy { PocketRepoCache(pocketRepo).apply { unfreeze() } }
-    val viewModelFactory by lazy { ViewModelFactory(this, getCurrentLanguage) }
+    val viewModelFactory by lazy { ViewModelFactory(this, app) }
     val screenController by lazy { ScreenController() }
 
     open val pinnedTileRepo by lazy { PinnedTileRepo(app) }

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -27,7 +27,6 @@ import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.MainActivity.Companion.PARENT_FRAGMENT
 import org.mozilla.tv.firefox.MediaSessionHolder
 import org.mozilla.tv.firefox.R
-import org.mozilla.tv.firefox.ViewModelFactory
 import org.mozilla.tv.firefox.webrender.cursor.CursorController
 import org.mozilla.tv.firefox.ext.webRenderComponents
 import org.mozilla.tv.firefox.ext.isVisible
@@ -92,7 +91,7 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
         super.onCreate(savedInstanceState)
         initSession()
 
-        val factory = ViewModelFactory(context!!.serviceLocator)
+        val factory = serviceLocator.viewModelFactory
         pinnedTileViewModel = ViewModelProviders.of(this, factory).get(PinnedTileViewModel::class.java)
         serviceLocator = context!!.serviceLocator
     }

--- a/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketViewModelTest.kt
@@ -47,7 +47,7 @@ class PocketViewModelTest {
                 get() = repoCacheState
         }
 
-        viewModel = PocketViewModel(repo, { language }, repoCache)
+        viewModel = PocketViewModel(repo, { language.startsWith("en") }, repoCache)
         loadingPlaceholders = viewModel.loadingPlaceholders
         noKeyPlaceholders = viewModel.noKeyPlaceholders
     }


### PR DESCRIPTION
Root cause:
Previously, whether or not to set focus on the megatile was determined by checking view visibility. When onboarding is up, views that we would normally expect to be visible are not. The solution to this is to check based on VM state, rather than view state



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
