### PR TITLE
Fixes #1442: ProgressBar lingers after page load

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/FirefoxProgressBar.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/FirefoxProgressBar.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 
 private const val HIDE_MESSAGE_ID = 0
 private const val HIDE_ANIMATION_DURATION_MILLIS = 250L
-private val HIDE_AFTER_MILLIS = TimeUnit.SECONDS.toMillis(3)
+private val HIDE_AFTER_MILLIS = TimeUnit.SECONDS.toMillis(1)
 
 class FirefoxProgressBar @JvmOverloads constructor(
     context: Context,


### PR DESCRIPTION
As suggested by @Baron-Severin we hide the the progress bar after 1 second (after load completion) instead of after 3. 
