### PR TITLE
Issue #1173 - Add script to accept sdk licenses

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -120,6 +120,7 @@ tasks:
           git fetch origin --tags
           && git config advice.detachedHead false
           && git checkout {{ event.version }}
+          && sh tools/taskcluster/accept-licenses.sh
           && python tools/taskcluster/get-sentry-token.py
           && python tools/taskcluster/get-pocket-token.py
           && ./gradlew --no-daemon clean test assembleRelease

--- a/tools/taskcluster/accept-licenses.sh
+++ b/tools/taskcluster/accept-licenses.sh
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+yes | sdkmanager --licenses


### PR DESCRIPTION
On the Docker image we use `sdkmanager` - this script will accept all the licenses.

Need to land this in order to have it run on TC.

no tests for TC, no changelog needed
### Pull Request checklist, no changelog needed
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
