### PR TITLE
No issue: add fullscreen pinch string for FFES.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,4 +261,9 @@ be temporary, and you can try again later.</li>
     %s will be replaced with the icon that matches the button in the YouTube app for this feature.
     Clicking on that button in the YouTube app will show YouTube's instructions on how to cast. -->
     <string name="youtube_casting_onboarding_toast">Cast YouTube videos from your phone or tablet. Open YouTube on your device and tap %s to get started.</string>
+
+    <!-- Text displayed in a toast when entering fullscreen mode: "pinch" refers
+         to the two-finger zoom out pinch gesture. This string will *only* be used on
+         Firefox for Echo Show where there is a touchscreen. -->
+    <string name="fullscreen_toast_pinch_to_exit">Pinch to exit fullscreen mode</string>
 </resources>


### PR DESCRIPTION
Localization for Echo Show is not set up yet so we still have to land
new strings in the Fire TV repository. :(

@athomasmoz When do you think we'd cut and release Firefox for Echo Show v1.2? This string would be used to introduce pinch-to-exit-fullscreen (as a workaround for the video not providing controls) but if we can't translate the string in time, I can removed the introduction, include the feature, and we can re-add the introduction in v1.3.

No tests or CL: just a string in a different product.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
