### PR TITLE
Issue #1173 - Update release taskcluster docker image to match PRs

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -111,7 +111,7 @@ tasks:
     payload:
       maxRunTime: 3600
       deadline: "{{ '2 hours' | $fromNow }}"
-      image: 'mozillamobile/firefox-tv'
+      image: 'mozillamobile/firefox-tv:2.0'
       command:
         - /bin/bash
         - '--login'


### PR DESCRIPTION
Unclear why in #833 the release images didn't also get updated like the PR images, but they should probably be the same (and would solve the licenses problem).
no tests or changelog needed, taskcluster change with nothing to test, not user-facing
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
