### PR TITLE
Add UA with version for Pocket API call

### DIFF
--- a/app/src/androidTest/java/org/mozilla/tv/firefox/FirefoxTestApplication.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/FirefoxTestApplication.kt
@@ -15,7 +15,7 @@ import org.mozilla.tv.firefox.utils.ServiceLocator
 
 class FirefoxTestApplication : FirefoxApplication() {
 
-    private val pocketEndpoint = object : PocketEndpoint() {
+    private val pocketEndpoint = object : PocketEndpoint("VERSION") {
         override suspend fun getRecommendedVideos(): List<PocketViewModel.FeedItem.Video>? {
             return PocketViewModel.noKeyPlaceholders
         }

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketEndpoint.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketEndpoint.kt
@@ -34,12 +34,12 @@ private val GLOBAL_VIDEO_ENDPOINT = Uri.parse("https://getpocket.cdn.mozilla.net
  * The methods of this class call the endpoint directly and does not cache results or rate limit,
  * outside of the network layer (e.g. with OkHttp).
  */
-open class PocketEndpoint {
+open class PocketEndpoint(private val appVersion: String) {
 
     /** @return The global video recommendations or null on error; the list will never be empty. */
     @AnyThread // via PocketEndpointRaw.
     open suspend fun getRecommendedVideos(): List<PocketViewModel.FeedItem.Video>? {
-        val videosJSON = PocketEndpointRaw.getGlobalVideoRecommendations() ?: return null
+        val videosJSON = PocketEndpointRaw.getGlobalVideoRecommendations(appVersion) ?: return null
         return convertVideosJSON(videosJSON)
     }
 
@@ -61,9 +61,10 @@ private object PocketEndpointRaw {
 
     /** @return The global video recommendations as a raw JSON str or null on error. */
     @AnyThread // executeAndAwait hands off the request to the OkHttp dispatcher.
-    suspend fun getGlobalVideoRecommendations(): String? {
+    suspend fun getGlobalVideoRecommendations(version: String): String? {
         val req = Request.Builder()
                 .url(GLOBAL_VIDEO_ENDPOINT.toString())
+                .header("User-Agent", "FirefoxTV-$version")
                 .build()
 
         val res = try {

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -45,7 +45,8 @@ import org.mozilla.tv.firefox.pocket.PocketVideoRepo
  *   ```
  */
 open class ServiceLocator(val app: Application) {
-    private val pocketEndpoint get() = PocketEndpoint()
+    private val appVersion = app.packageManager.getPackageInfo(app.packageName, 0).versionName
+    private val pocketEndpoint get() = PocketEndpoint(appVersion)
     private val buildConfigDerivables get() = BuildConfigDerivables()
     private val pocketFeedStateMachine get() = PocketFeedStateMachine()
 

--- a/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketEndpointTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketEndpointTest.kt
@@ -15,6 +15,7 @@ import org.mozilla.tv.firefox.TestResource
 import org.robolectric.RobolectricTestRunner
 
 private const val KEY_INNER = "recommendations"
+private const val VERSION = "VERSION"
 
 @RunWith(RobolectricTestRunner::class)
 class PocketEndpointTest {
@@ -42,7 +43,7 @@ class PocketEndpointTest {
         )
 
         val pocketJSON = TestResource.POCKET_VIDEO_RECOMMENDATION.get()
-        val actualVideos = PocketEndpoint().convertVideosJSON(pocketJSON)
+        val actualVideos = PocketEndpoint(VERSION).convertVideosJSON(pocketJSON)
         if (actualVideos == null) { fail("Expected actualVideos to be non-null"); return }
 
         // We only test a subset of the data for developer sanity. :)
@@ -60,7 +61,7 @@ class PocketEndpointTest {
         assertNotNull(expectedFirstTitle)
 
         val pocketJSONWithNoTitleExceptFirst = removeTitleStartingAtIndex(1, pocketJSON)
-        val actualVideos = PocketEndpoint().convertVideosJSON(pocketJSONWithNoTitleExceptFirst)
+        val actualVideos = PocketEndpoint(VERSION).convertVideosJSON(pocketJSONWithNoTitleExceptFirst)
         if (actualVideos == null) { fail("Expected videos non-null"); return }
         assertEquals(1, actualVideos.size)
         assertEquals(expectedFirstTitle, actualVideos[0].title)
@@ -70,18 +71,18 @@ class PocketEndpointTest {
     fun `convert Videos JSON for videos with missing fields on all items`() {
         val pocketJSON = TestResource.POCKET_VIDEO_RECOMMENDATION.get()
         val pocketJSONWithNoTitles = removeTitleStartingAtIndex(0, pocketJSON)
-        val actualVideos = PocketEndpoint().convertVideosJSON(pocketJSONWithNoTitles)
+        val actualVideos = PocketEndpoint(VERSION).convertVideosJSON(pocketJSONWithNoTitles)
         assertNull(actualVideos)
     }
 
     @Test
     fun `convert Videos JSON for empty String`() {
-        assertNull(PocketEndpoint().convertVideosJSON(""))
+        assertNull(PocketEndpoint(VERSION).convertVideosJSON(""))
     }
 
     @Test
     fun `convert Videos JSON for invalid JSON`() {
-        assertNull(PocketEndpoint().convertVideosJSON("{!!}}"))
+        assertNull(PocketEndpoint(VERSION).convertVideosJSON("{!!}}"))
     }
 }
 


### PR DESCRIPTION
No changelog change, updates tests w/ new version - setting the header is basic okhttp functionality so writing a test to set and then test doesn't seem worth it.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
