### PR TITLE
Closes #1491: Update bundled tiles urls

### DIFF
--- a/app/src/main/assets/bundled/bundled_tiles.json
+++ b/app/src/main/assets/bundled/bundled_tiles.json
@@ -14,7 +14,7 @@
     },
     {
         "id": "imdb",
-        "url": "https://imdb.com/",
+        "url": "https://m.imdb.com/",
         "title": "IMDB",
         "img": "tile_imdb.png"
     },
@@ -26,37 +26,37 @@
     },
     {
         "id": "metacritic",
-        "url": "http://metacritic.com/",
+        "url": "https://www.metacritic.com/",
         "title": "metacritic",
         "img": "tile_metacritic.png"
     },
     {
         "id": "fandango",
-        "url": "https://www.fandango.com/",
+        "url": "https://www.mobile.fandango.com/",
         "title": "Fandango",
         "img": "tile_fandango.png"
     },
     {
         "id": "hollywoodReporter",
-        "url": "https://hollywoodreporter.com/",
+        "url": "https://www.hollywoodreporter.com/",
         "title": "Hollywood Reporter",
         "img": "tile_hollywood_reporter.png"
     },
     {
         "id": "flickr",
-        "url": "https://flickr.com/",
+        "url": "https://www.flickr.com/",
         "title": "Flickr",
         "img": "tile_flickr.png"
     },
     {
         "id": "instagram",
-        "url": "https://instagram.com/",
+        "url": "https://www.instagram.com/",
         "title": "Instagram",
         "img": "tile_instagram.png"
     },
     {
         "id": "pinterest",
-        "url": "https://pinterest.com/",
+        "url": "https://www.pinterest.com/",
         "title": "Pinterest",
         "img": "tile_pinterest.png"
     }

--- a/app/src/test/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileRepoTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileRepoTest.kt
@@ -68,7 +68,7 @@ class PinnedTileRepoTest {
 
         pinnedTileRepo.getPinnedTiles().observeForever(observerSpy)
         assertEquals(10, pinnedTileRepo.bundledTilesSize)
-        pinnedTileRepo.removePinnedTile("https://pinterest.com/")
+        pinnedTileRepo.removePinnedTile("https://www.pinterest.com/")
         assertEquals(9, pinnedTileRepo.bundledTilesSize)
 
         verify(observerSpy, times(2)).onChanged(any())

--- a/app/src/test/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/pinnedtile/PinnedTileViewModelTest.kt
@@ -62,7 +62,7 @@ class PinnedTileViewModelTest {
         })
 
         pinnedTileViewModel.getTileList().observeForever(observerSpy)
-        pinnedTileViewModel.unpin("https://instagram.com/")
+        pinnedTileViewModel.unpin("https://www.instagram.com/")
 
         Mockito.verify(observerSpy, Mockito.times(2)).onChanged(ArgumentMatchers.any())
     }


### PR DESCRIPTION
Updates bundled tiles urls so they accurately show as pinned in overlay.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
