### PR TITLE
Fixes #1517: clear data now clears data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - On a fresh install, focus would once skip past the Pocket megatile
 - A crash that could occur when backing out of the Pocket screen
 - DRM content not playing: this is now supported for some DRM videos
+- Fixed bug where clearing data would not clear state from the current session
 
 ## [3.0.2] - 2018-10-30
 *Version-bump only: Released v3.0+ for the first time to Stick Gen 1 & 2 in addition to Fire TV (Gen 1, 2, 3), Cube, Element 4k (pendant), which already had v3.0+.*

--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -19,7 +19,6 @@ import mozilla.components.concept.engine.EngineView
 import org.mozilla.tv.firefox.webrender.WebRenderFragment
 import org.mozilla.tv.firefox.webrender.WebRenderFragment.Companion.APP_URL_HOME
 import org.mozilla.tv.firefox.navigationoverlay.BrowserNavigationOverlay
-import org.mozilla.tv.firefox.webrender.WebViewCache
 import org.mozilla.tv.firefox.webrender.VideoVoiceCommandMediaSession
 import org.mozilla.tv.firefox.ext.webRenderComponents
 import org.mozilla.tv.firefox.ext.serviceLocator
@@ -49,7 +48,6 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
     // There should be at most one MediaSession per process, hence it's in MainActivity.
     // We crash if we init MediaSession at init time, hence lateinit.
     override lateinit var videoVoiceCommandMediaSession: VideoVoiceCommandMediaSession
-    private lateinit var webViewCache: WebViewCache
     private val ONBOARDING_REQ_CODE = 1
 
     private val sessionObserver by lazy {
@@ -87,7 +85,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         SentryIntegration.init(this)
         PublicSuffix.init(this) // Used by Pocket Video feed & custom home tiles.
         initMediaSession()
-        initWebViewCache()
+        lifecycle.addObserver(serviceLocator.webViewCache)
 
         val intent = SafeIntent(intent)
 
@@ -173,7 +171,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
 
     override fun onCreateView(name: String, context: Context, attrs: AttributeSet): View? {
         return if (name == EngineView::class.java.name) {
-            webViewCache.getWebView(context, attrs) {
+            context.serviceLocator.webViewCache.getWebView(context, attrs) {
                 setupForApp()
             }
         } else super.onCreateView(name, context, attrs)
@@ -218,11 +216,6 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
     private fun initMediaSession() {
         videoVoiceCommandMediaSession = VideoVoiceCommandMediaSession(this)
         lifecycle.addObserver(videoVoiceCommandMediaSession)
-    }
-
-    private fun initWebViewCache() {
-        webViewCache = WebViewCache()
-        lifecycle.addObserver(webViewCache)
     }
 
     override fun onNonTextInputUrlEntered(urlStr: String) {

--- a/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
@@ -17,6 +17,7 @@ import org.mozilla.tv.firefox.ext.deleteData
 import org.mozilla.tv.firefox.ext.getAccessibilityManager
 import org.mozilla.tv.firefox.ext.isVoiceViewEnabled
 import org.mozilla.tv.firefox.ext.requireWebRenderComponents
+import org.mozilla.tv.firefox.ext.serviceLocator
 import org.mozilla.tv.firefox.telemetry.DataUploadPreference
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 
@@ -61,6 +62,7 @@ class SettingsFragment : Fragment() {
                     // navigation history) and Activity. This implementation will need to change
                     // if/when we add session restoration logic.
                     // See https://github.com/mozilla-mobile/firefox-tv/issues/1192
+                    serviceLocator.webViewCache.doNotPersist()
                     activity?.recreate()
                     TelemetryIntegration.INSTANCE.clearDataEvent()
                 }

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -12,6 +12,7 @@ import org.mozilla.tv.firefox.pocket.PocketEndpoint
 import org.mozilla.tv.firefox.pocket.PocketFeedStateMachine
 import org.mozilla.tv.firefox.pocket.PocketRepoCache
 import org.mozilla.tv.firefox.pocket.PocketVideoRepo
+import org.mozilla.tv.firefox.webrender.WebViewCache
 
 /**
  * Implementation of the Service Locator pattern. Use this class to provide dependencies without
@@ -53,6 +54,7 @@ open class ServiceLocator(val app: Application) {
     val pocketRepoCache by lazy { PocketRepoCache(pocketRepo).apply { unfreeze() } }
     val viewModelFactory by lazy { ViewModelFactory(this, app) }
     val screenController by lazy { ScreenController() }
+    val webViewCache by lazy { WebViewCache() }
 
     open val pinnedTileRepo by lazy { PinnedTileRepo(app) }
     open val pocketRepo = PocketVideoRepo(pocketEndpoint, pocketFeedStateMachine, buildConfigDerivables).apply {

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebViewCache.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebViewCache.kt
@@ -46,6 +46,7 @@ class WebViewCache : LifecycleObserver {
     }
 
     private var cachedView: SystemEngineView? = null
+    private var shouldPersist = true
 
     fun getWebView(
         context: Context,
@@ -70,10 +71,22 @@ class WebViewCache : LifecycleObserver {
         return cachedView ?: createAndCacheEngineView()
     }
 
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    private fun onCreate() {
+        shouldPersist = true
+    }
+
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     private fun onDestroy() {
-        state = cachedView?.saveState()
+        state = when (shouldPersist) {
+            true -> cachedView?.saveState()
+            false -> null
+        }
         cachedView?.onDestroy()
         cachedView = null
+    }
+
+    fun doNotPersist() {
+        shouldPersist = false
     }
 }


### PR DESCRIPTION
Root cause:
We are persisting WebView state between instances, so when we destroyed the View during a cache clear that information was still retained.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
