### PR TITLE
Closes #1125 - Add content description to Pocket "help" button.

### DIFF
--- a/app/src/main/res/layout/fragment_pocket_video.xml
+++ b/app/src/main/res/layout/fragment_pocket_video.xml
@@ -67,7 +67,7 @@
 
     <ImageView
         android:id="@+id/pocketHelpButton"
-        tools:ignore="ContentDescription"
+        android:contentDescription="@string/pocket_info_a11y"
         android:layout_marginStart="830dp"
         android:focusable="true"
         style="@style/NavigationButton"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,10 @@ be temporary, and you can try again later.</li>
          Pocket video recommendations feed.
     %1$s will be replaced with the Pocket brand name. -->
     <string name="pocket_home_a11y_tile_focused">Video recommendation by %1$s</string>
+    <!-- Spoken by screen reader when they focus the "?" button on the Pocket Video feed screen,
+    which will shows the Pocket tutorial again -->
+    <string name="pocket_info_a11y">About Pocket</string>
+
 
     <string name="pocket_video_feed_recommended_videos_title">Recommended videos</string>
     <!-- Text displayed when the Pocket video recommendations feed failed to load.


### PR DESCRIPTION
a11y change, no tests needed for adding missing ContentDescription
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
