### PR TITLE
String import 20181121-120547

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -81,6 +81,7 @@
   <string name="pocket_home_tutorial_description">网络上最有趣的视频。由 Mozilla 旗下 %1$s 为您推荐。</string>
   <string name="pocket_home_tutorial_dismiss_button">我明白了</string>
   <string name="pocket_home_a11y_tile_focused">由“%1$s”推荐的视频</string>
+  <string name="pocket_info_a11y">关于 Pocket</string>
   <string name="pocket_video_feed_recommended_videos_title">推荐视频</string>
   <string name="pocket_video_feed_failed_to_load">呃，我们在显示由“%1$s”推荐的视频时遇到一些问题。</string>
   <string name="pocket_video_feed_reload_button">重试</string>


### PR DESCRIPTION

Automated import 20181121-120547

Log:
```
 [unchanged] app/src/main/res/values-fr/strings.xml
 [unchanged] app/src/main/res/values-de/strings.xml
 [unchanged] app/src/main/res/values-it/strings.xml
     [mkdir] app/src/main/res/values-zh-CN
   [created] app/src/main/res/values-zh-CN/strings.xml
     [mkdir] app/src/main/res/values-pt-BR
   [created] app/src/main/res/values-pt-BR/strings.xml
     [mkdir] app/src/main/res/values-es-ES
   [created] app/src/main/res/values-es-ES/strings.xml
 [unchanged] app/src/main/res/values-ja/strings.xml
Fixing ./values-zh-CN -> ./values-zh-rCN
Fixing ./values-pt-BR -> ./values-pt-rBR
Fixing ./values-es-ES -> ./values-es-rES
Checking for placeholders in translation files...
Warning: * [values-tr/strings.xml] number of placeholders not matching, key: your_rights_content5

```
