### PR TITLE
Issue #1557 - Add pref to TelemetryConfiguration!!

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryFactory.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryFactory.kt
@@ -35,7 +35,8 @@ object TelemetryFactory {
                 .setPreferencesImportantForTelemetry(
                         Settings.TRACKING_PROTECTION_ENABLED_PREF,
                         TelemetrySettingsProvider.PREF_CUSTOM_HOME_TILE_COUNT,
-                        TelemetrySettingsProvider.PREF_TOTAL_HOME_TILE_COUNT
+                        TelemetrySettingsProvider.PREF_TOTAL_HOME_TILE_COUNT,
+                        TelemetrySettingsProvider.APP_ID
                 )
                 .setSettingsProvider(TelemetrySettingsProvider(context))
                 .setCollectionEnabled(telemetryEnabled)


### PR DESCRIPTION
I noticed we're missing actually adding the APP_ID to the TelemetryConfiguration - that's my bad for not mentioning it earlier, but it's a quick fix.