### PR TITLE
Cherry-pick firefox:home history fix

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -359,8 +359,14 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
                 TelemetryIntegration.INSTANCE.browserBackControllerEvent()
             }
             else -> {
+                val components = requireWebRenderComponents
                 context!!.webRenderComponents.sessionManager.remove()
-                context!!.serviceLocator.webViewCache.doNotPersist()
+                context!!.serviceLocator.webViewCache.doNotPersist(doAfterRecreate = {
+                    // Sessions must be removed prior to MainActivity being recreated, in order for initialization
+                    // logic to be called. However, the URL is set before the new WebView is created, causing it to
+                    // be out of sync with the Session. Removing all sessions puts them back into sync
+                    components.sessionManager.removeAll()
+                })
                 return false
             }
         }

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebViewCache.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebViewCache.kt
@@ -47,6 +47,7 @@ class WebViewCache : LifecycleObserver {
 
     private var cachedView: SystemEngineView? = null
     private var shouldPersist = true
+    private var doAfterRecreate: (() -> Unit)? = null
 
     fun getWebView(
         context: Context,
@@ -64,7 +65,11 @@ class WebViewCache : LifecycleObserver {
             return SystemEngineView(context, attrs).apply {
                 state?.let { this.restoreState(it) }
                 initialize()
-            }.also { cachedView = it }
+            }.also {
+                cachedView = it
+                doAfterRecreate?.invoke()
+                doAfterRecreate = null
+            }
         }
 
         cachedView?.removeFromParentIfAble()
@@ -86,7 +91,8 @@ class WebViewCache : LifecycleObserver {
         cachedView = null
     }
 
-    fun doNotPersist() {
+    fun doNotPersist(doAfterRecreate: () -> Unit) {
         shouldPersist = false
+        this.doAfterRecreate = doAfterRecreate
     }
 }


### PR DESCRIPTION
This cherry-picks the fix for a missing `firefox:home` after clearing sessions, which we now do after exiting the app on "back".