### PR TITLE
Closes #1589 - Don't unnecessarily clear WebViewCache, which breaks sessions!!

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -360,7 +360,6 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
             }
             else -> {
                 context!!.webRenderComponents.sessionManager.remove()
-                context!!.serviceLocator.webViewCache.doNotPersist()
                 return false
             }
         }


### PR DESCRIPTION
Don't clear the WebViewCache, because then we also need to clear the session.