### PR TITLE
Closes #1691: fixes inconsistent state assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fixed Pocket Crash issue for non-EN locales (#1684)
 - Crash when using unrecognized remote control (#1685)
+- Fixed mismatch between internal and display state after clearing data (#1691)
 
 ## [3.2.2] - 2019-01-15
 ### Fixed 

--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -8,7 +8,6 @@ package org.mozilla.tv.firefox
 import android.content.Context
 import android.support.v4.app.FragmentManager
 import android.text.TextUtils
-import io.sentry.Sentry
 import mozilla.components.browser.session.Session
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.ActiveScreen
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.Transition
@@ -49,12 +48,7 @@ class ScreenController {
             .hide(settingsFragment)
             .commitNow()
 
-        if (currentActiveScreen != ActiveScreen.NAVIGATION_OVERLAY) {
-            Sentry.capture(
-                    IllegalStateException("Inconsistent state, expected " +
-                            "${ActiveScreen.NAVIGATION_OVERLAY.name}," +
-                            " got ${currentActiveScreen.name}"))
-        }
+        currentActiveScreen = ActiveScreen.NAVIGATION_OVERLAY
     }
 
     /**


### PR DESCRIPTION
RCA:
When clearing data, the displayed screen was changed to NavigationOverlayFragment, however the ScreenController did not actually update its currentActiveScreen value. This caused a disconnect between expected and actual current state. At this time, no user impact has been noticed, but there could be strange transaction bugs related to this.

Fix:
Setting up fragments for a new session is guaranteed to display the NavigationOverlayFragment, so instead of asserting that state, the method now sets it.

Regressions:
To avoid regressions, we should work out a system for assertions that crash on debug and report to Sentry silently on release, then periodically assert app state throughout ScreenController to guarantee that no similar situations exist in the app.  Opened https://github.com/mozilla-mobile/firefox-tv/issues/1693



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
