### PR TITLE
No issue: sdkmanager accept license for sdk28 on release builds

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -122,6 +122,7 @@ tasks:
           git fetch origin --tags
           && git config advice.detachedHead false
           && git checkout {{ event.version }}
+          && yes | sdkmanager --licenses
           && python tools/taskcluster/get-sentry-token.py
           && python tools/taskcluster/get-pocket-token.py
           && ./gradlew --no-daemon clean test assembleRelease


### PR DESCRIPTION
Also need this to fix TC builds for release.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
