### PR TITLE
String import 20190127-121058

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
   <string name="firefox_tv_brand_name">Firefox TV</string>
+  <string name="firefox_tv_brand_name_short">Firefox</string>
   <string name="pocket_brand_name">Pocket</string>
   <string name="action_cancel">Annulla</string>
   <string name="action_ok">OK</string>
@@ -64,4 +65,5 @@
   <string name="notification_request_desktop_site">Versione desktop richiesta</string>
   <string name="notification_request_non_desktop_site">Versione desktop disattivata</string>
   <string name="youtube_casting_onboarding_toast">Guarda i video YouTube dal cellulare o dal tablet. Apri YouTube nel dispositivo e tocca %s per iniziare.</string>
+  <string name="exit_firefox_a11y">Esci da %1$s</string>
 </resources>


### PR DESCRIPTION

Automated import 20190127-121058

Log:
```
 [unchanged] app/src/main/res/values-fr/strings.xml
 [unchanged] app/src/main/res/values-de/strings.xml
   [updated] app/src/main/res/values-it/strings.xml
     [mkdir] app/src/main/res/values-zh-CN
   [created] app/src/main/res/values-zh-CN/strings.xml
     [mkdir] app/src/main/res/values-pt-BR
   [created] app/src/main/res/values-pt-BR/strings.xml
     [mkdir] app/src/main/res/values-es-ES
   [created] app/src/main/res/values-es-ES/strings.xml
 [unchanged] app/src/main/res/values-ja/strings.xml
Fixing ./values-zh-CN -> ./values-zh-rCN
Fixing ./values-pt-BR -> ./values-pt-rBR
Fixing ./values-es-ES -> ./values-es-rES
Checking for placeholders in translation files...
Warning: * [values-tr/strings.xml] number of placeholders not matching, key: your_rights_content5

```
