### PR TITLE
String import 20190129-120647

### DIFF
--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
   <string name="firefox_tv_brand_name">Firefox TV</string>
+  <string name="firefox_tv_brand_name_short">Firefox</string>
   <string name="pocket_brand_name">Pocket</string>
   <string name="action_cancel">Cancelar</string>
   <string name="action_ok">Aceptar</string>
@@ -64,4 +65,5 @@
   <string name="notification_request_desktop_site">Se ha pedido la versión de escritorio</string>
   <string name="notification_request_non_desktop_site">Se vuelve a la versión predeterminada</string>
   <string name="youtube_casting_onboarding_toast">Transmite vídeos de YouTube desde tu móvil o tableta. Abre YouTube en tu dispositivo y pulsa %s para comenzar.</string>
+  <string name="exit_firefox_a11y">Salir de %1$s</string>
 </resources>


### PR DESCRIPTION

Automated import 20190129-120647

Log:
```
 [unchanged] app/src/main/res/values-fr/strings.xml
 [unchanged] app/src/main/res/values-de/strings.xml
 [unchanged] app/src/main/res/values-it/strings.xml
     [mkdir] app/src/main/res/values-zh-CN
   [created] app/src/main/res/values-zh-CN/strings.xml
     [mkdir] app/src/main/res/values-pt-BR
   [created] app/src/main/res/values-pt-BR/strings.xml
     [mkdir] app/src/main/res/values-es-ES
   [created] app/src/main/res/values-es-ES/strings.xml
 [unchanged] app/src/main/res/values-ja/strings.xml
Fixing ./values-pt-BR -> ./values-pt-rBR
Fixing ./values-es-ES -> ./values-es-rES
Fixing ./values-zh-CN -> ./values-zh-rCN
Checking for placeholders in translation files...
Warning: * [values-tr/strings.xml] number of placeholders not matching, key: your_rights_content5

```
