### PR TITLE
Issue #1664: Pre-work: move toolbar code into ToolbarUiController

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/ViewModelFactory.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ViewModelFactory.kt
@@ -10,7 +10,7 @@ import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import org.mozilla.tv.firefox.pinnedtile.PinnedTileViewModel
 import org.mozilla.tv.firefox.pocket.PocketViewModel
-import org.mozilla.tv.firefox.toolbar.ToolbarViewModel
+import org.mozilla.tv.firefox.navigationoverlay.ToolbarViewModel
 import org.mozilla.tv.firefox.settings.SettingsViewModel
 import org.mozilla.tv.firefox.utils.ServiceLocator
 

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -149,8 +149,7 @@ class NavigationOverlayFragment : Fragment() {
         ToolbarUiController(
             toolbarViewModel,
             ::exitFirefox,
-            { currFocus },
-            ::updateFocusableViews,
+            { updateFocusableViews() },
             onNavigationEvent
         ).onCreateView(view, viewLifecycleOwner, fragmentManager!!)
 

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -74,7 +74,6 @@ enum class NavigationEvent {
     }
 }
 
-@Suppress("LargeClass") // TODO remove this. See https://github.com/mozilla-mobile/firefox-tv/issues/1187
 class NavigationOverlayFragment : Fragment() {
     companion object {
         const val FRAGMENT_TAG = "overlay"

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.Job
 import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.experiments.ExperimentConfig
-import org.mozilla.tv.firefox.ext.forEachChild
 import org.mozilla.tv.firefox.ext.forceExhaustive
 import org.mozilla.tv.firefox.ext.isEffectivelyVisible
 import org.mozilla.tv.firefox.ext.isVisible

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -128,7 +128,7 @@ class NavigationOverlayFragment : Fragment() {
     private lateinit var tileAdapter: PinnedTileAdapter
 
     // TODO: remove this when FocusRepo is in place #1395
-    var defaultFocusTag = NavigationOverlayFragment.FRAGMENT_TAG
+    private var defaultFocusTag = NavigationOverlayFragment.FRAGMENT_TAG
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -315,7 +315,7 @@ class NavigationOverlayFragment : Fragment() {
         }
     }
 
-    fun updateFocusableViews(focusedView: View? = currFocus) { // TODO this will be replaced when FocusRepo is introduced
+    private fun updateFocusableViews(focusedView: View? = currFocus) { // TODO this will be replaced when FocusRepo is introduced
         val toolbarState = toolbarViewModel.state.value
 
         // Prevent the focus from looping to the bottom row when reaching the last

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -49,7 +49,6 @@ import org.mozilla.tv.firefox.pocket.PocketViewModel
 import org.mozilla.tv.firefox.settings.SettingsFragment
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import org.mozilla.tv.firefox.telemetry.UrlTextInputLocation
-import org.mozilla.tv.firefox.toolbar.ToolbarViewModel
 import org.mozilla.tv.firefox.utils.ServiceLocator
 import org.mozilla.tv.firefox.utils.URLs
 import org.mozilla.tv.firefox.utils.ViewUtils

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarUiController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarUiController.kt
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.navigationoverlay
+
+import android.arch.lifecycle.LifecycleOwner
+import android.arch.lifecycle.Observer
+import android.support.v4.app.FragmentManager
+import android.view.View
+import android.widget.ImageButton
+import kotlinx.android.synthetic.main.browser_overlay.view.*
+import kotlinx.android.synthetic.main.browser_overlay_top_nav.view.*
+import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
+import mozilla.components.support.ktx.android.view.forEach
+import mozilla.components.support.ktx.android.view.hideKeyboard
+import org.mozilla.tv.firefox.ext.forceExhaustive
+import org.mozilla.tv.firefox.ext.serviceLocator
+import org.mozilla.tv.firefox.utils.URLs
+import org.mozilla.tv.firefox.utils.ViewUtils
+import org.mozilla.tv.firefox.widget.IgnoreFocusMovementMethod
+import org.mozilla.tv.firefox.widget.InlineAutocompleteEditText
+
+private const val NAVIGATION_BUTTON_ENABLED_ALPHA = 1.0f
+private const val NAVIGATION_BUTTON_DISABLED_ALPHA = 0.3f
+
+/**
+ * An encapsulation of the toolbar to set up and respond to UI operations.
+ */
+class ToolbarUiController(
+    private val toolbarViewModel: ToolbarViewModel,
+    private val exitFirefox: () -> Unit,
+    private val getCurrentFocus: () -> View?,
+    private val updateFocusableViews: (View?) -> Unit,
+    private val onNavigationEvent: (NavigationEvent, String?, InlineAutocompleteEditText.AutocompleteResult?) -> Unit
+) {
+
+    private var hasUserChangedURLSinceEditTextFocused = false
+
+    fun onCreateView(layout: View, viewLifecycleOwner: LifecycleOwner, fragmentManager: FragmentManager) {
+        val toolbarClickListener = ToolbarOnClickListener()
+        layout.topNavContainer.forEach {
+            it.nextFocusDownId = layout.navUrlInput.id
+            if (it.isFocusable) it.setOnClickListener(toolbarClickListener)
+        }
+
+        setupUrlInput(layout)
+        initToolbar(layout, viewLifecycleOwner, fragmentManager)
+    }
+
+    private fun setupUrlInput(layout: View) = with(layout.navUrlInput) {
+        setOnCommitListener {
+            val userInput = text.toString()
+            if (userInput == URLs.APP_URL_HOME) {
+                // If the input points to home, we short circuit and hide the keyboard, returning
+                // the user to the home screen
+                this.hideKeyboard()
+                return@setOnCommitListener
+            }
+
+            if (userInput.isNotEmpty()) {
+                val cachedAutocompleteResult = lastAutocompleteResult // setText clears the reference so we cache it here.
+                setText(cachedAutocompleteResult.text)
+                onNavigationEvent.invoke(NavigationEvent.LOAD_URL, userInput, cachedAutocompleteResult)
+            }
+        }
+        this.movementMethod = IgnoreFocusMovementMethod()
+        val autocompleteProvider = ShippedDomainsProvider().apply {
+            initialize(
+                    context = context
+            )
+        }
+        setOnFilterListener { searchText, view ->
+            val result = autocompleteProvider.getAutocompleteSuggestion(searchText)
+            if (result != null)
+                view?.onAutocomplete(InlineAutocompleteEditText.AutocompleteResult(result.text, result.source, result.totalItems))
+        }
+
+        setOnUserInputListener { hasUserChangedURLSinceEditTextFocused = true }
+        setOnFocusChangeListener { _, hasFocus -> if (!hasFocus) hasUserChangedURLSinceEditTextFocused = false }
+    }
+
+    private fun initToolbar(layout: View, viewLifecycleOwner: LifecycleOwner, fragmentManager: FragmentManager) {
+        fun updateOverlayButtonState(isEnabled: Boolean, overlayButton: ImageButton) {
+            overlayButton.isEnabled = isEnabled
+            overlayButton.isFocusable = isEnabled
+            overlayButton.alpha =
+                    if (isEnabled) NAVIGATION_BUTTON_ENABLED_ALPHA else NAVIGATION_BUTTON_DISABLED_ALPHA
+        }
+
+        val context = layout.context
+        val serviceLocator = context.serviceLocator
+
+        toolbarViewModel.state.observe(viewLifecycleOwner, Observer {
+            if (it == null) return@Observer
+            val focusedView = getCurrentFocus()
+            updateOverlayButtonState(it.backEnabled, layout.navButtonBack)
+            updateOverlayButtonState(it.forwardEnabled, layout.navButtonForward)
+            updateOverlayButtonState(it.pinEnabled, layout.pinButton)
+            updateOverlayButtonState(it.refreshEnabled, layout.navButtonReload)
+            updateOverlayButtonState(it.desktopModeEnabled, layout.desktopModeButton)
+
+            updateFocusableViews(focusedView)
+
+            layout.pinButton.isChecked = it.pinChecked
+            layout.desktopModeButton.isChecked = it.desktopModeChecked
+            layout.turboButton.isChecked = it.turboChecked
+
+            if (!hasUserChangedURLSinceEditTextFocused) {
+                // The url can get updated in the background, e.g. if a loading page is redirected. We
+                // don't want a url update to interrupt the user typing so we don't update the url from
+                // the background if the user has already updated the url themselves.
+                //
+                // We revert this state when the view is unfocused: it ensures the URL is usually accurate
+                // (for security reasons) and it's simple compared to other options which keep more state.
+                //
+                // One problem this solution has is that if the URL is updated in the background rapidly,
+                // sometimes key events will be dropped, but I don't think there's much we can do about this:
+                // we can't determine if the keyboard is up or not and focus isn't a good indicator because
+                // we can focus the EditText without opening the soft keyboard and the user won't even know
+                // these are inaccurate!
+                layout.navUrlInput.setText(it.urlBarText)
+            }
+        })
+
+        toolbarViewModel.events.observe(viewLifecycleOwner, Observer {
+            it?.consume {
+                when (it) {
+                    is ToolbarViewModel.Action.ShowTopToast -> ViewUtils.showCenteredTopToast(context, it.textId)
+                    is ToolbarViewModel.Action.ShowBottomToast -> ViewUtils.showCenteredBottomToast(context, it.textId)
+                    is ToolbarViewModel.Action.SetOverlayVisible -> serviceLocator.screenController
+                            .showNavigationOverlay(fragmentManager, it.visible)
+                    ToolbarViewModel.Action.ExitFirefox -> exitFirefox()
+                }.forceExhaustive
+                true
+            }
+        })
+    }
+
+    private inner class ToolbarOnClickListener : View.OnClickListener {
+        override fun onClick(view: View?) {
+            val event = NavigationEvent.fromViewClick(view?.id)
+                    ?: return
+
+            when (event) {
+                NavigationEvent.BACK -> toolbarViewModel.backButtonClicked()
+                NavigationEvent.FORWARD -> toolbarViewModel.forwardButtonClicked()
+                NavigationEvent.RELOAD -> toolbarViewModel.reloadButtonClicked()
+                NavigationEvent.PIN_ACTION -> toolbarViewModel.pinButtonClicked()
+                NavigationEvent.TURBO -> toolbarViewModel.turboButtonClicked()
+                NavigationEvent.DESKTOP_MODE -> toolbarViewModel.desktopModeButtonClicked()
+                NavigationEvent.EXIT_FIREFOX -> toolbarViewModel.exitFirefoxButtonClicked()
+                else -> Unit // Nothing to do.
+            }
+            onNavigationEvent.invoke(event, null, null)
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarUiController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarUiController.kt
@@ -30,8 +30,7 @@ private const val NAVIGATION_BUTTON_DISABLED_ALPHA = 0.3f
 class ToolbarUiController(
     private val toolbarViewModel: ToolbarViewModel,
     private val exitFirefox: () -> Unit,
-    private val getCurrentFocus: () -> View?,
-    private val updateFocusableViews: (View?) -> Unit,
+    private val updateFocusableViews: () -> Unit,
     private val onNavigationEvent: (NavigationEvent, String?, InlineAutocompleteEditText.AutocompleteResult?) -> Unit
 ) {
 
@@ -93,14 +92,13 @@ class ToolbarUiController(
 
         toolbarViewModel.state.observe(viewLifecycleOwner, Observer {
             if (it == null) return@Observer
-            val focusedView = getCurrentFocus()
             updateOverlayButtonState(it.backEnabled, layout.navButtonBack)
             updateOverlayButtonState(it.forwardEnabled, layout.navButtonForward)
             updateOverlayButtonState(it.pinEnabled, layout.pinButton)
             updateOverlayButtonState(it.refreshEnabled, layout.navButtonReload)
             updateOverlayButtonState(it.desktopModeEnabled, layout.desktopModeButton)
 
-            updateFocusableViews(focusedView)
+            updateFocusableViews()
 
             layout.pinButton.isChecked = it.pinChecked
             layout.desktopModeButton.isChecked = it.desktopModeChecked

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarViewModel.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarViewModel.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.tv.firefox.toolbar
+package org.mozilla.tv.firefox.navigationoverlay
 
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.ViewModel
@@ -13,7 +13,6 @@ import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.pinnedtile.PinnedTileRepo
 import org.mozilla.tv.firefox.session.SessionRepo
 import org.mozilla.tv.firefox.ext.LiveDataCombiners
-import org.mozilla.tv.firefox.navigationoverlay.NavigationEvent
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import org.mozilla.tv.firefox.utils.SetOnlyLiveData
 import org.mozilla.tv.firefox.utils.URLs

--- a/app/src/test/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarViewModelTest.kt
@@ -1,4 +1,4 @@
-package org.mozilla.tv.firefox.toolbar
+package org.mozilla.tv.firefox.navigationoverlay
 
 import android.arch.lifecycle.MutableLiveData
 import org.junit.Before


### PR DESCRIPTION
This will make NavOverlayFragment a little less unwieldy. I didn't move the code for the bottom part of the navigation overlay (after the split) because that'll get refactored to channels and my changes may not make sense.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - No functionality changes
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR
  - #1700 fails
  - OnboardingLaunchTest fails but also fails on master. Filed #1748
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
