### PR TITLE
Closes #1700 - Fix broken Data Toggle test and a11y

### DIFF
--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/ToggleDataCollectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/ToggleDataCollectionTest.kt
@@ -26,6 +26,41 @@ class ToggleDataCollectionTest {
         settingsRepo = activityTestRule.activity.application.serviceLocator.settingsRepo
     }
 
+    /**
+     * We have two code paths, one for a11y and one for non-a11y - therefore we test both the telemetry button
+     * and the container.
+     */
+    @Test
+    fun WHEN_data_collection_button_container_is_toggled_THEN_data_collection_matches_button_state() {
+        navigationOverlay {
+        }.openSettings {
+            assertDataCollectionButtonState(IS_TELEMETRY_ENABLED_DEFAULT)
+
+            toggleDataCollectionButtonContainer()
+            assertNotNull(settingsRepo.dataCollectionEnabled.value)
+            assertDataCollectionButtonState(settingsRepo.dataCollectionEnabled.value ?: false)
+
+            toggleDataCollectionButtonContainer()
+            assertNotNull(settingsRepo.dataCollectionEnabled.value)
+            assertDataCollectionButtonState(settingsRepo.dataCollectionEnabled.value ?: false)
+        }
+    }
+
+    @Test
+    fun WHEN_data_collection_button_container_is_toggled_THEN_button_state_persists_when_returning_to_settings() {
+        var cachedDataCollectionButtonIsChecked = IS_TELEMETRY_ENABLED_DEFAULT
+
+        navigationOverlay {
+        }.openSettings {
+            assertDataCollectionButtonState(cachedDataCollectionButtonIsChecked)
+            toggleDataCollectionButtonContainer()
+            cachedDataCollectionButtonIsChecked = !cachedDataCollectionButtonIsChecked
+        }.exitToOverlay {
+        }.openSettings {
+            assertDataCollectionButtonState(cachedDataCollectionButtonIsChecked)
+        }
+    }
+
     @Test
     fun WHEN_data_collection_button_is_toggled_THEN_data_collection_matches_button_state() {
         navigationOverlay {

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/SettingsRobot.kt
@@ -19,6 +19,10 @@ class SettingsRobot {
         dataCollectionButton().click()
     }
 
+    fun toggleDataCollectionButtonContainer() {
+        dataCollectionButtonContainer().click()
+    }
+
     fun assertDataCollectionButtonState(isChecked: Boolean) {
         dataCollectionButton().assertIsChecked(isChecked)
     }
@@ -52,6 +56,7 @@ fun settings(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
 }
 
 private fun dataCollectionButton() = onView(withId(R.id.telemetryButton))
+private fun dataCollectionButtonContainer() = onView(withId(R.id.telemetryButtonContainer))
 private fun aboutButton() = onView(withId(R.id.aboutButton))
 private fun privacyButton() = onView(withId(R.id.privacyNoticeButton))
 private fun clearDataButton() = onView(withId(R.id.deleteButton))

--- a/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
@@ -68,14 +68,17 @@ class SettingsFragment : Fragment() {
             }
         })
 
-        val dataPreferenceClickListener = { _: View ->
-            settingsViewModel.setDataCollectionEnabled(!telemetryButton.isChecked)
-        }
         // Due to accessibility hack for #293, where we want to focus a different (visible) element
         // for accessibility, either of these views could be unfocusable, so we need to set the
         // click listener on both.
-        parentView.telemetryButtonContainer.setOnClickListener(dataPreferenceClickListener)
-        parentView.telemetryButton.setOnClickListener(dataPreferenceClickListener)
+        parentView.telemetryButtonContainer.setOnClickListener {
+            // Manually toggle the telemetry button from the container click
+            telemetryButton.isChecked = !telemetryButton.isChecked
+            settingsViewModel.setDataCollectionEnabled((telemetryButton.isChecked))
+        }
+        parentView.telemetryButton.setOnClickListener {
+            settingsViewModel.setDataCollectionEnabled(telemetryButton.isChecked)
+        }
 
         parentView.deleteButton.setOnClickListener { _ ->
             AlertDialog.Builder(activity)


### PR DESCRIPTION
This code is annoyingly complex because we have two code paths for using VoiceView and not.

The fix in #1670 actually broke data toggling when VoiceView was enabled (because that is controlled directly through the checkbox, so it would never allow the checkbox to be changed) and the previous fix worked because it pushed a checkbox change through the SessionRepo. The fix here toggles the checkbox when the container being clicked.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [X] The **UI tests** are passing after this PR
- [X] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
