### PR TITLE
No issue: include test command in PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -4,5 +4,5 @@
 <!-- Before submitting the PR, please address each item -->
 - [ ] This PR includes thorough **tests** or an explanation of why it does not
 - [ ] This PR includes a **CHANGELOG entry** or does not need one
-- [ ] The **UI tests** are passing after this PR
+- [ ] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
 - [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - doc update
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)