### PR TITLE
Closes #1748: Upgrade test orchestrator to latest.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,7 +165,7 @@ dependencies {
     }
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
+    androidTestUtil 'androidx.test:orchestrator:1.1.1'
 
     androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 }


### PR DESCRIPTION
Speculative fix: this may also fix #1755. These issues are intermittent
and not reproducible by everyone on every device. No-Jun removed the
test orchestrator and he was no longer able to reproduce his tests failing
for the same reason. I changed the test orchestrator and I am unable to
reproduce, however, I'm unable to reproduce when I use the old version
of test orchestrator either. Upgrading the version seems like a safe
move to try to fix the issues we're having.

The production code doesn't seem to be a problem: the loading state
(which the session idling resource depends on) updates correctly (false,
true, false) when running the application but does not update correctly
when running the test (false, true).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - build change
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
  - all but #1700 
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
