### PR TITLE
Closes #1759: call SessionManager.onLowMemory appropriately.

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -83,6 +83,7 @@ open class FirefoxApplication : LocaleAwareApplication() {
     override fun onLowMemory() {
         super.onLowMemory()
         OkHttpWrapper.onLowMemory()
+        serviceLocator.sessionManager.onLowMemory()
         // If you need to dump more memory, you may be able to clear the Picasso cache.
     }
 }

--- a/app/src/test/java/org/mozilla/tv/firefox/FirefoxApplicationTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/FirefoxApplicationTest.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox
+
+import mozilla.components.browser.session.SessionManager
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mozilla.tv.firefox.utils.ServiceLocator
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FirefoxApplicationTest {
+
+    private lateinit var application: FirefoxApplication
+    private lateinit var serviceLocator: ServiceLocator
+
+    @Before
+    fun setUp() {
+        serviceLocator = mock(ServiceLocator::class.java)
+        application = FirefoxApplication().apply {
+            serviceLocator = this@FirefoxApplicationTest.serviceLocator
+        }
+    }
+
+    @Test
+    fun `WHEN onLowMemory is called THEN the sessionManager's onLowMemory method is called`() {
+        val sessionManager = mock(SessionManager::class.java)
+        `when`(serviceLocator.sessionManager).thenReturn(sessionManager)
+
+        verify(sessionManager, never()).onLowMemory()
+        application.onLowMemory()
+        verify(sessionManager, times(1)).onLowMemory()
+    }
+}


### PR DESCRIPTION
It appears to clear the thumbnails, which we don't really use anyway.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
  - I assume so: this should have no impact
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
