### PR TITLE
Closes #750, Issue #1628: Move Sentry init to application

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -44,7 +44,7 @@ open class FirefoxApplication : LocaleAwareApplication() {
         serviceLocator = createServiceLocator()
 
         // Enable crash reporting. Don't add anything above here because if it crashes, we won't know.
-        SentryIntegration.init(this, serviceLocator)
+        SentryIntegration.init(this, serviceLocator.settingsRepo)
 
         TelemetryIntegration.INSTANCE.init(this)
 

--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -9,6 +9,7 @@ import android.preference.PreferenceManager
 import android.support.annotation.VisibleForTesting
 import android.webkit.WebSettings
 import org.mozilla.tv.firefox.components.locale.LocaleAwareApplication
+import org.mozilla.tv.firefox.telemetry.SentryIntegration
 import org.mozilla.tv.firefox.webrender.VisibilityLifeCycleCallback
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import org.mozilla.tv.firefox.utils.BuildConstants
@@ -40,8 +41,10 @@ open class FirefoxApplication : LocaleAwareApplication() {
         super.onCreate()
 
         PreferenceManager.setDefaultValues(this, R.xml.settings, false)
-
         serviceLocator = createServiceLocator()
+
+        // Enable crash reporting. Don't add anything above here because if it crashes, we won't know.
+        SentryIntegration.init(this, serviceLocator)
 
         TelemetryIntegration.INSTANCE.init(this)
 

--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -25,7 +25,6 @@ import org.mozilla.tv.firefox.ext.toSafeIntent
 import org.mozilla.tv.firefox.ext.webRenderComponents
 import org.mozilla.tv.firefox.onboarding.OnboardingActivity
 import org.mozilla.tv.firefox.pocket.PocketOnboardingActivity
-import org.mozilla.tv.firefox.telemetry.SentryIntegration
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import org.mozilla.tv.firefox.telemetry.UrlTextInputLocation
 import org.mozilla.tv.firefox.utils.OnUrlEnteredListener
@@ -36,7 +35,6 @@ import org.mozilla.tv.firefox.utils.publicsuffix.PublicSuffix
 import org.mozilla.tv.firefox.webrender.VideoVoiceCommandMediaSession
 import org.mozilla.tv.firefox.webrender.WebRenderFragment
 import org.mozilla.tv.firefox.widget.InlineAutocompleteEditText
-import java.lang.IllegalStateException
 
 interface MediaSessionHolder {
     val videoVoiceCommandMediaSession: VideoVoiceCommandMediaSession
@@ -53,8 +51,6 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         // goes through onCreate.
         super.onCreate(savedInstanceState)
 
-        // Enable crash reporting. Don't add anything above here because if it crashes, we won't know.
-        SentryIntegration.init(this)
         PublicSuffix.init(this) // Used by Pocket Video feed & custom home tiles.
         initMediaSession()
         lifecycle.addObserver(serviceLocator.webViewCache)

--- a/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsRepo.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.tv.firefox.settings
 
 import android.app.Application

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/SentryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/SentryIntegration.kt
@@ -10,7 +10,7 @@ import android.support.annotation.VisibleForTesting.NONE
 import io.sentry.Sentry
 import io.sentry.android.AndroidSentryClientFactory
 import org.mozilla.tv.firefox.BuildConfig
-import org.mozilla.tv.firefox.utils.ServiceLocator
+import org.mozilla.tv.firefox.settings.SettingsRepo
 
 /**
  * An interface to the Sentry crash reporting SDK. All code that touches the Sentry APIs
@@ -38,12 +38,12 @@ object SentryIntegration {
     /**
      * Initializes Sentry. This method should only be called once.
      */
-    fun init(appContext: Context, serviceLocator: ServiceLocator) {
+    fun init(appContext: Context, settingsRepo: SettingsRepo) {
         isInit = true
 
         // This listener binds to the Context and observes forever so it's important
         // that we use an appContext to avoid memory leaks.
-        serviceLocator.settingsRepo.dataCollectionEnabled.observeForever { isEnabled ->
+        settingsRepo.dataCollectionEnabled.observeForever { isEnabled ->
             if (isEnabled != null) {
                 // The BuildConfig value is populated from a file at compile time.
                 // If the file did not exist, the value will be null.

--- a/app/src/test/java/org/mozilla/tv/firefox/telemetry/SentryIntegrationTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/telemetry/SentryIntegrationTest.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.telemetry
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SentryIntegrationTest {
+
+    @Test
+    fun `GIVEN the application is initialized THEN Sentry is init`() {
+        // application.onCreate(): RobolectricTestRunner automatically calls this before every test.
+        assertTrue(SentryIntegration.isInit)
+    }
+}


### PR DESCRIPTION
We verified with the Sentry team that this is an acceptable way to
initialize Sentry.

This change is beneficial because:
- It fixes a memory leak (not completely though: there are still things to follow-up on)
- It allows all Activites to get crash reporting
- We get crash reporting earlier in the init process

It's concerning because:
- we're modifying crash reporting code
- Sentry is slow to start up so this may further affect startup time

This change could be better if:
- We could initialize Sentry before the ServiceLocator is initialized
and before the PreferenceManager default values get set

I verified this change was working correctly by adding code to crash the
app (throw when M key is pressed) and ensuring the events were received
by the server. I also tested events are not received by the server when
data collection is disabled.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
  - No real issues fixed for users
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
  - #1700 is a known failure
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
