### PR TITLE
No issue: auto-add bug label for bug reports.

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F41E Bug report"
 about: Create a report to help us improve
+label: "bug"
 
 ---
 
@@ -11,6 +12,5 @@ about: Create a report to help us improve
 ### Actual behavior
 
 ### Device information
-
 * Fire TV device: ?
 * Firefox version: ?


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
