### PR TITLE
Closes #1720: Pause all video playbacks when transtioning to settings

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -14,6 +14,7 @@ import mozilla.components.browser.session.Session
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.ActiveScreen
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.Transition
 import org.mozilla.tv.firefox.ext.serviceLocator
+import org.mozilla.tv.firefox.ext.pauseAllVideoPlaybacks
 import org.mozilla.tv.firefox.navigationoverlay.NavigationOverlayFragment
 import org.mozilla.tv.firefox.pocket.PocketVideoFragment
 import org.mozilla.tv.firefox.settings.SettingsFragment
@@ -92,6 +93,11 @@ class ScreenController {
     }
 
     fun showSettingsScreen(fragmentManager: FragmentManager) {
+        /**
+         *  Pause all the videos when transitioning to [SettingsFragment] to mitigate possible memory
+         *  leak when clearing data. See [WebViewCache.clear] as well as #1720
+         */
+        fragmentManager.webRenderFragment().engineView?.pauseAllVideoPlaybacks()
         handleTransitionAndUpdateActiveScreen(fragmentManager, Transition.ADD_SETTINGS)
     }
 

--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -14,7 +14,6 @@ import mozilla.components.browser.session.Session
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.ActiveScreen
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.Transition
 import org.mozilla.tv.firefox.ext.serviceLocator
-import org.mozilla.tv.firefox.ext.pauseAllVideoPlaybacks
 import org.mozilla.tv.firefox.navigationoverlay.NavigationOverlayFragment
 import org.mozilla.tv.firefox.pocket.PocketVideoFragment
 import org.mozilla.tv.firefox.settings.SettingsFragment
@@ -93,11 +92,6 @@ class ScreenController {
     }
 
     fun showSettingsScreen(fragmentManager: FragmentManager) {
-        /**
-         *  Pause all the videos when transitioning to [SettingsFragment] to mitigate possible memory
-         *  leak when clearing data. See [WebViewCache.clear] as well as #1720
-         */
-        fragmentManager.webRenderFragment().engineView?.pauseAllVideoPlaybacks()
         handleTransitionAndUpdateActiveScreen(fragmentManager, Transition.ADD_SETTINGS)
     }
 

--- a/app/src/main/java/org/mozilla/tv/firefox/ext/EngineView.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ext/EngineView.kt
@@ -63,6 +63,10 @@ fun EngineView.evalJS(javascript: String, callback: ValueCallback<String>? = nul
     webView?.evaluateJavascript(javascript, callback)
 }
 
+fun EngineView.pauseAllVideoPlaybacks() {
+    evalJS("document.querySelectorAll('video').forEach(v => v.pause());")
+}
+
 /**
  * This functionality is not supported by browser-engine-system yet. See [EngineView.evalJS] comment for details.
  */

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/VideoVoiceCommandMediaSession.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/VideoVoiceCommandMediaSession.kt
@@ -43,6 +43,7 @@ import mozilla.components.concept.engine.EngineView
 import org.mozilla.tv.firefox.webrender.VideoVoiceCommandMediaSession.MediaSessionCallbacks
 import org.mozilla.tv.firefox.ext.addJavascriptInterface
 import org.mozilla.tv.firefox.ext.evalJS
+import org.mozilla.tv.firefox.ext.pauseAllVideoPlaybacks
 import org.mozilla.tv.firefox.ext.removeJavascriptInterface
 import org.mozilla.tv.firefox.telemetry.MediaSessionEventType
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
@@ -171,7 +172,7 @@ class VideoVoiceCommandMediaSession @UiThread constructor(
         //
         // The videos may send playback state update events to Java, which we're forced to ignore:
         // see JavascriptVideoPlaybackStateSyncer for the code.
-        engineView?.evalJS("document.querySelectorAll('video').forEach(v => v.pause());")
+        engineView?.pauseAllVideoPlaybacks()
 
         // Move MediaSession to inactive state.
         val playbackState = cachedPlaybackStateBuilder


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
