### PR TITLE
Closes #1761, Issue #1628: Remove and replace sessions when Activity …

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -61,7 +61,10 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
 
         val intentData = IntentValidator.validateOnCreate(this, intent.toSafeIntent(), savedInstanceState)
 
+        // This restores the SessionManager sessions so must be called before getOrCreateSession.
+        webRenderComponents.applicationLifecycleSessionCache.onCreateMaybeRestoreSessions()
         val session = getOrCreateSession(intentData)
+
         val screenController = serviceLocator.screenController
         screenController.setUpFragmentsForNewSession(supportFragmentManager, session)
 
@@ -88,6 +91,13 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         }
 
         serviceLocator.intentLiveData.value = Consumable.from(intentData)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        // This removes the Sessions from the SessionManager so should be called last.
+        webRenderComponents.applicationLifecycleSessionCache.onDestroyCacheSessions()
     }
 
     @SuppressLint("MissingSuperCall")

--- a/app/src/main/java/org/mozilla/tv/firefox/components/ApplicationLifecycleSessionCache.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/components/ApplicationLifecycleSessionCache.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.components
+
+import android.support.annotation.VisibleForTesting
+import android.support.annotation.VisibleForTesting.PRIVATE
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+
+/**
+ * An object that caches [Session]s in place of the [SessionManager] after the
+ * [mozilla.components.concept.engine.EngineView] owner's lifecycle has ended and restores the sessions when the
+ * EngineView is reattached. This is necessary because Android Components has a memory leak where [Session]s will keep a
+ * reference to their system WebView. They null the WebView reference when [Session]s are removed from the
+ * [SessionManager] so, as a workaround, we manually remove the [Session]s at the end of the lifecycle and re-add them
+ * when a new lifecycle begins.
+ *
+ * See more details in the issue mentioned below:
+ * TODO: implement the components solution in android-components#1915, remove this class and its calls
+ *
+ * We don't use lifecycle observers in this class because each method must be called at a precise time (see each
+ * lifecycle method's kdoc for details).
+ */
+class ApplicationLifecycleSessionCache(
+    private val sessionManager: SessionManager
+) {
+
+    @VisibleForTesting(otherwise = PRIVATE) val cachedSessions = mutableListOf<Session>()
+
+    /**
+     * Restores the sessions into the [SessionManager] in onCreate if the Activity has been destroyed and recreated but
+     * the Application remains: this must be called before the Activity attempts to access the current session.
+     */
+    fun onCreateMaybeRestoreSessions() {
+        if (cachedSessions.isEmpty()) return // unnecessary check but helps clarity.
+
+        cachedSessions.forEach {
+            sessionManager.add(it)
+        }
+
+        cachedSessions.clear()
+    }
+
+    /**
+     * Caches the sessions into the cache and removes all sessions from the [SessionManager] in onDestroy: see class kdoc
+     * for a greater explanation. afaict, onDestroy will not be called for process death (in which case, this memory
+     * leak doesn't matter) but is otherwise guaranteed to be called when the Activity is finished: this should be
+     * sufficient for our purposes. This should be called last in onDestroy, just in case another method tries to use
+     * the SessionManager
+     */
+    fun onDestroyCacheSessions() {
+        cachedSessions.addAll(sessionManager.all)
+        sessionManager.removeAll()
+    }
+}

--- a/app/src/main/java/org/mozilla/tv/firefox/components/ApplicationLifecycleSessionCache.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/components/ApplicationLifecycleSessionCache.kt
@@ -8,6 +8,7 @@ import android.support.annotation.VisibleForTesting
 import android.support.annotation.VisibleForTesting.PRIVATE
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import org.mozilla.tv.firefox.telemetry.SentryIntegration
 
 /**
  * An object that caches [Session]s in place of the [SessionManager] after the
@@ -34,6 +35,21 @@ class ApplicationLifecycleSessionCache(
      * the Application remains: this must be called before the Activity attempts to access the current session.
      */
     fun onCreateMaybeRestoreSessions() {
+        fun sendTelemetryIfMemoryLeakPersists() {
+            // If the SessionManager has Sessions when the app starts, they'll have references to a WebView: a memory
+            // leak. This will happen if the Activity is destroyed and recreated without onDestroy being called and
+            // the process/Application is not killed. With our understanding of Android, this should not happen but
+            // onDestroy is notoriously unreliable, the Android docs are not explicit about this, and we're running on
+            // non-standard Android. To be safe, we verify our assumptions with a telemetry ping. If this fails, we
+            // likely have to move the calls to onCreate/onStart/onStop; we chose not to write the code this way
+            // initially to keep thing simple.
+            if (sessionManager.size > 0) {
+                SentryIntegration.capture(IllegalStateException(
+                    "MEMORY LEAK: expected SessionManager to be empty in onCreate"))
+            }
+        }
+
+        sendTelemetryIfMemoryLeakPersists()
         if (cachedSessions.isEmpty()) return // unnecessary check but helps clarity.
 
         cachedSessions.forEach {

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderComponents.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderComponents.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.session.SessionUseCases
 import org.mozilla.tv.firefox.R
+import org.mozilla.tv.firefox.components.ApplicationLifecycleSessionCache
 import org.mozilla.tv.firefox.utils.Settings
 
 /**
@@ -44,4 +45,6 @@ class WebRenderComponents(applicationContext: Context, systemUserAgent: String) 
     val sessionManager by lazy { SessionManager(engine) }
 
     val sessionUseCases by lazy { SessionUseCases(sessionManager) }
+
+    val applicationLifecycleSessionCache by lazy { ApplicationLifecycleSessionCache(sessionManager) }
 }

--- a/app/src/test/java/org/mozilla/tv/firefox/components/ApplicationLifecycleSessionCacheTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/components/ApplicationLifecycleSessionCacheTest.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.components
+
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mozilla.tv.firefox.utils.anyNonNull
+
+class ApplicationLifecycleSessionCacheTest {
+
+    private lateinit var cache: ApplicationLifecycleSessionCache
+    private lateinit var sessionManager: SessionManager
+
+    @Before
+    fun setUp() {
+        sessionManager = mock(SessionManager::class.java)
+        cache = ApplicationLifecycleSessionCache(sessionManager)
+    }
+
+    @Test
+    fun `WHEN on destroy cache is called THEN all the sessions are removed from the session manager`() {
+        cache.onDestroyCacheSessions()
+        verify(sessionManager, times(1)).removeAll()
+    }
+
+    @Test
+    fun `WHEN on destroy cache is called THEN the cache contains the sessions in order`() {
+        val expected = listOf(mock(Session::class.java), mock(Session::class.java))
+        `when`(sessionManager.all).thenReturn(expected)
+
+        cache.onDestroyCacheSessions()
+
+        cache.cachedSessions.forEachIndexed { i, session ->
+            assertSame(expected[i], session)
+        }
+    }
+
+    @Test
+    fun `GIVEN there are no sessions in the cache WHEN onCreate is called THEN there are no sessions in the SessionManager`() {
+        cache.onCreateMaybeRestoreSessions()
+        verifySessionManagerAdd(expectedTimes = 0)
+    }
+
+    @Test
+    fun `GIVEN there are sessions in the cache WHEN on create is called THEN the sessions are restored`() {
+        val expected = listOf(mock(Session::class.java), mock(Session::class.java)).also { sessions ->
+            sessions.forEach { cache.cachedSessions.add(it) }
+        }
+
+        cache.onCreateMaybeRestoreSessions()
+
+        verifySessionManagerAdd(expectedTimes = expected.size)
+    }
+
+    private fun verifySessionManagerAdd(expectedTimes: Int) {
+        verify(sessionManager, times(expectedTimes)).add(
+            // Mockito doesn't known about default values. :(
+            anyNonNull(),
+            anyBoolean(),
+            any(),
+            any()
+        )
+    }
+}


### PR DESCRIPTION
…recreates.

This address a memory leak in components:
https://github.com/mozilla-mobile/android-components/issues/1915

I have tested that regular browsing, opening and closing the app, and
clear data work with:
- Don't keep activities on a TV emulator
- On 4K device
- Don't keep activities on tablet emulator + LeakCanary does not display
this leak

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
  - We haven't finished fixing all the memory leaks yet so no need for changelog entry
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
