### PR TITLE
Closes #1787: Add FirefoxViewModelProviders to reduce duplication

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -131,7 +131,8 @@ dependencies {
     testImplementation "android.arch.core:core-testing:$architecture_components_version"
 
     testImplementation 'junit:junit:4.12'
-    testImplementation "org.robolectric:robolectric:4.0.1" // required for SDK 28
+    testImplementation "org.robolectric:robolectric:$robolectric_version"
+    testImplementation "org.robolectric:shadows-supportv4:$robolectric_version"
     testImplementation 'org.mockito:mockito-core:2.21.0'
 
     testImplementation 'androidx.test:core:1.0.0' // required for robolectric 4.0+

--- a/app/src/main/java/org/mozilla/tv/firefox/architecture/FirefoxViewModelProviders.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/architecture/FirefoxViewModelProviders.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.architecture
+
+import android.arch.lifecycle.ViewModelProvider
+import android.arch.lifecycle.ViewModelProviders
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentActivity
+import org.mozilla.tv.firefox.ext.serviceLocator
+
+/**
+ * Returns an instance of the view model for the given application building block (fragment, activity)
+ * for the given lifecycle. This is a wrapper around the framework's [ViewModelProvider] using the application's
+ * [ViewModelFactory] to reduce code duplication.
+ */
+object FirefoxViewModelProviders {
+
+    fun of(activity: FragmentActivity): ViewModelProvider {
+        return ViewModelProviders.of(activity, activity.serviceLocator.viewModelFactory)
+    }
+
+    fun of(fragment: Fragment): ViewModelProvider {
+        // If we're attempting to retrieve a view model, we should be attached to a context already.
+        return ViewModelProviders.of(fragment, fragment.context!!.serviceLocator.viewModelFactory)
+    }
+}

--- a/app/src/main/java/org/mozilla/tv/firefox/architecture/ViewModelFactory.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/architecture/ViewModelFactory.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.tv.firefox
+package org.mozilla.tv.firefox.architecture
 
 import android.app.Application
 import android.arch.lifecycle.ViewModel

--- a/app/src/main/java/org/mozilla/tv/firefox/architecture/ViewModelFactory.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/architecture/ViewModelFactory.kt
@@ -17,10 +17,10 @@ import org.mozilla.tv.firefox.utils.ServiceLocator
 /**
  * Used by [ViewModelProviders] to instantiate [ViewModel]s with constructor arguments.
  *
+ * This should be used through [FirefoxViewModelProviders.of].
  * Example usage:
  * ```kotlin
- * val factory = ViewModelFactory(serviceLocator)
- * val myViewModel = ViewModelProviders.of(this, factory).get(ExampleViewModel::class.java)
+ * val myViewModel = FirefoxViewModelProviders.of(this).get(ExampleViewModel::class.java)
  * ```
  */
 class ViewModelFactory(

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.tv.firefox.navigationoverlay
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
@@ -31,6 +30,7 @@ import kotlinx.android.synthetic.main.pocket_video_mega_tile.*
 import kotlinx.coroutines.Job
 import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.R
+import org.mozilla.tv.firefox.architecture.FirefoxViewModelProviders
 import org.mozilla.tv.firefox.experiments.ExperimentConfig
 import org.mozilla.tv.firefox.ext.forceExhaustive
 import org.mozilla.tv.firefox.ext.isEffectivelyVisible
@@ -133,10 +133,9 @@ class NavigationOverlayFragment : Fragment() {
 
         serviceLocator = context!!.serviceLocator
 
-        val factory = serviceLocator.viewModelFactory
-        toolbarViewModel = ViewModelProviders.of(this, factory).get(ToolbarViewModel::class.java)
-        pinnedTileViewModel = ViewModelProviders.of(this, factory).get(PinnedTileViewModel::class.java)
-        pocketViewModel = ViewModelProviders.of(this, factory).get(PocketViewModel::class.java)
+        toolbarViewModel = FirefoxViewModelProviders.of(this).get(ToolbarViewModel::class.java)
+        pinnedTileViewModel = FirefoxViewModelProviders.of(this).get(PinnedTileViewModel::class.java)
+        pocketViewModel = FirefoxViewModelProviders.of(this).get(PocketViewModel::class.java)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.tv.firefox.pocket
 
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -25,6 +24,7 @@ import kotlinx.android.synthetic.main.fragment_pocket_video.view.*
 import mozilla.components.support.ktx.android.os.resetAfter
 import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.R
+import org.mozilla.tv.firefox.architecture.FirefoxViewModelProviders
 import org.mozilla.tv.firefox.ext.forceExhaustive
 import org.mozilla.tv.firefox.ext.serviceLocator
 import org.mozilla.tv.firefox.ext.updateLayoutParams
@@ -50,8 +50,7 @@ class PocketVideoFragment : Fragment() {
         PocketDrawable.setImageDrawableAsPocketWordmark(layout.pocketWordmarkView)
         layout.pocketHelpButton.setImageDrawable(context!!.getDrawable(R.drawable.pocket_onboarding_help_button))
 
-        val factory = context!!.serviceLocator.viewModelFactory
-        val viewModel = ViewModelProviders.of(this, factory).get(PocketViewModel::class.java)
+        val viewModel = FirefoxViewModelProviders.of(this).get(PocketViewModel::class.java)
 
         viewModel.state.observe(viewLifecycleOwner, Observer<PocketViewModel.State> { state ->
             when (state) {

--- a/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
@@ -6,7 +6,6 @@ package org.mozilla.tv.firefox.settings
 
 import android.app.AlertDialog
 import android.arch.lifecycle.Observer
-import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.LayoutInflater
@@ -16,6 +15,7 @@ import android.view.accessibility.AccessibilityManager
 import kotlinx.android.synthetic.main.fragment_settings.*
 import kotlinx.android.synthetic.main.fragment_settings.view.*
 import org.mozilla.tv.firefox.R
+import org.mozilla.tv.firefox.architecture.FirefoxViewModelProviders
 import org.mozilla.tv.firefox.ext.forceExhaustive
 import org.mozilla.tv.firefox.ext.getAccessibilityManager
 import org.mozilla.tv.firefox.ext.isVoiceViewEnabled
@@ -45,8 +45,7 @@ class SettingsFragment : Fragment() {
             serviceLocator?.screenController?.showBrowserScreenForUrl(fragmentManager!!, URLs.PRIVACY_NOTICE_URL)
         }
 
-        val factory = view.context.serviceLocator.viewModelFactory
-        ViewModelProviders.of(this@SettingsFragment, factory).get(SettingsViewModel::class.java).also { settingsVM ->
+        FirefoxViewModelProviders.of(this@SettingsFragment).get(SettingsViewModel::class.java).also { settingsVM ->
             setupSettingsViewModel(view, settingsVM)
         }
         return view

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -13,7 +13,7 @@ import mozilla.components.support.base.observer.Consumable
 import org.mozilla.tv.firefox.pinnedtile.PinnedTileRepo
 import org.mozilla.tv.firefox.ScreenController
 import org.mozilla.tv.firefox.ValidatedIntentData
-import org.mozilla.tv.firefox.ViewModelFactory
+import org.mozilla.tv.firefox.architecture.ViewModelFactory
 import org.mozilla.tv.firefox.ext.webRenderComponents
 import org.mozilla.tv.firefox.components.locale.LocaleManager
 import org.mozilla.tv.firefox.experiments.FretboardProvider

--- a/app/src/test/java/org/mozilla/tv/firefox/architecture/FirefoxViewModelProvidersTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/architecture/FirefoxViewModelProvidersTest.kt
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.architecture
+
+import android.arch.lifecycle.ViewModel
+import android.support.v4.app.Fragment
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.tv.firefox.MainActivity
+import org.mozilla.tv.firefox.pinnedtile.PinnedTileViewModel
+import org.mozilla.tv.firefox.settings.SettingsFragment
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.support.v4.SupportFragmentController
+
+@RunWith(RobolectricTestRunner::class)
+class FirefoxViewModelProvidersTest {
+
+    private lateinit var mainActivity: MainActivity
+    private lateinit var fragment: Fragment
+
+    @Before
+    fun setUp() {
+        // Ideally, we'd run the Activity through onCreate but Robolectric fails on WebView shadow creation.
+        mainActivity = Robolectric.buildActivity(MainActivity::class.java).get()
+        fragment = SupportFragmentController.of(SettingsFragment.create()).create().get()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `WHEN passed an unknown ViewModel THEN of(FragmentActivity) throws an exception`() {
+        FirefoxViewModelProviders.of(mainActivity).get(UnknownViewModel::class.java)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `WHEN passed an unknown ViewModel THEN of(Fragment) throws an exception`() {
+        FirefoxViewModelProviders.of(fragment).get(UnknownViewModel::class.java)
+    }
+
+    @Test
+    fun `WHEN passed a valid ViewModel THEN of(FragmentActivity) returns a non-null value`() {
+        assertNotNull(FirefoxViewModelProviders.of(mainActivity).get(PinnedTileViewModel::class.java))
+    }
+
+    @Test
+    fun `WHEN passed a valid ViewModel THEN of(Fragment) returns a non-null value`() {
+        assertNotNull(FirefoxViewModelProviders.of(fragment).get(PinnedTileViewModel::class.java))
+    }
+}
+
+private class UnknownViewModel : ViewModel()

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,11 @@
 buildscript {
     ext.support_libraries_version = '28.0.0'
     ext.architecture_components_version = '1.1.1'
-    ext.espresso_version = '3.0.2'
     ext.kotlin_version = '1.3.0'
     ext.moz_components_version = '0.37.0'
+
+    ext.espresso_version = '3.0.2'
+    ext.robolectric_version = '4.0.1' // required for SDK 28.
 
     repositories {
         google()


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Includes sanity tests
- [x] This PR includes a **CHANGELOG entry** or does not need one
  - Not user facing
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
