### PR TITLE
Closes #1767: Upgrade a-c dependency to 0.41

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.architecture_components_version = '1.1.1'
     ext.espresso_version = '3.0.2'
     ext.kotlin_version = '1.3.0'
-    ext.moz_components_version = '0.37.0'
+    ext.moz_components_version = '0.41.0'
 
     repositories {
         google()


### PR DESCRIPTION
No component we use from a-c has any breaking API change since 0.37 
https://mozilla-mobile.github.io/android-components/changelog/#0410 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
