### PR TITLE
No issue: group test artifact versions for easier upgrades.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,14 +134,13 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.0.1" // required for SDK 28
     testImplementation 'org.mockito:mockito-core:2.21.0'
 
-    testImplementation 'androidx.test:core:1.0.0' // required for robolectric 4.0+
+    testImplementation "androidx.test:core:$test_core"
 
-    androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
+    androidTestImplementation "com.android.support.test.uiautomator:uiautomator-v18:$uiautomator_version"
 
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espresso_version", {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-
     androidTestImplementation("com.android.support.test.espresso:espresso-contrib:$espresso_version") {
         exclude module: 'appcompat-v7'
         exclude module: 'support-v4'
@@ -150,12 +149,14 @@ dependencies {
         exclude module: 'design'
         exclude module: 'espresso-core'
     }
-
     androidTestImplementation "com.android.support.test.espresso:espresso-idling-resource:$espresso_version"
     androidTestImplementation "com.android.support.test.espresso:espresso-web:$espresso_version", {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestImplementation "com.android.support.test:rules:1.0.2"
+
+    androidTestImplementation "com.android.support.test:runner:$test_runner"
+    androidTestImplementation "com.android.support.test:rules:$test_rules"
+    androidTestUtil "androidx.test:orchestrator:$test_orchestrator"
 
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
@@ -163,9 +164,6 @@ dependencies {
     androidTestImplementation "tools.fastlane:screengrab:1.2.0", {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestUtil 'androidx.test:orchestrator:1.1.1'
 
     androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,19 @@
 buildscript {
     ext.support_libraries_version = '28.0.0'
     ext.architecture_components_version = '1.1.1'
-    ext.espresso_version = '3.0.2'
     ext.kotlin_version = '1.3.0'
     ext.moz_components_version = '0.37.0'
+
+    // Support library test dependencies
+    // - List of artifacts: https://developer.android.com/training/testing/set-up-project#android-test-dependencies
+    // - Pin to tested versions (in release notes): https://developer.android.com/jetpack/androidx/releases/archive/test
+    // TODO: these versions are not pinned to tested versions. Do this when upgrading to androidX #1398
+    ext.test_core = '1.0.0'
+    ext.test_runner = '1.0.2'
+    ext.test_rules = ext.test_runner
+    ext.test_orchestrator = '1.1.1'
+    ext.espresso_version = '3.0.2'
+    ext.uiautomator_version = '2.1.3'
 
     repositories {
         google()


### PR DESCRIPTION
We should be pinning the test versions together: by grouping them and
adding comments, this is more likely to happen.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Dependency versions don't need tests (though it would be interesting to set up static analysis to ensure they're pinned together)
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
