### PR TITLE
Closes #1801: fixes WebViewCacheTest

### DIFF
--- a/app/src/test/java/org/mozilla/tv/firefox/webrender/WebViewCacheTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/webrender/WebViewCacheTest.kt
@@ -7,6 +7,7 @@ package org.mozilla.tv.firefox.webrender
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.test.core.app.ApplicationProvider
+import mozilla.components.browser.engine.system.SystemEngine
 import mozilla.components.browser.engine.system.SystemEngineView
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -24,6 +25,8 @@ class WebViewCacheTest {
 
     @Before
     fun setup() {
+        // A fake user agent is required in order to instantiate WebRenderComponents.engine in a test
+        SystemEngine.defaultUserAgent = "test-ua-string"
         webViewCache = WebViewCache(mock(SessionRepo::class.java))
     }
 


### PR DESCRIPTION
RCA:
WebViewCache previously instantiated its SystemEngineView by hand, but this was updated in 7f57f23 to delegate to WebRenderComponents.engine.  This object, however, requires a valid user agent before it can be instantiated, and none is provided in a test environment.  This can be fixed by supplying a fake user agent in the @Before block of the test.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
Change does not affect production code
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [X] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
