### PR TITLE
No issue: add earliest affected FF version to issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -13,4 +13,5 @@ label: "bug"
 
 ### Device information
 * Fire TV device: ?
-* Firefox version: ?
+* Latest affected Firefox version: ?
+* Earliest affected Firefox version: ?


### PR DESCRIPTION
This was a request from @athomasmoz 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
