### PR TITLE
Closes #1800 - Update Taskcluster secrets to use projects/mobile

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -109,7 +109,7 @@ tasks:
         events:
           - release
     scopes:
-      - "secrets:get:project/firefox-tv/tokens"
+      - "secrets:get:project/mobile/firefox-tv/tokens"
     payload:
       maxRunTime: 3600
       deadline: "{{ '2 hours' | $fromNow }}"

--- a/tools/taskcluster/get-pocket-token.py
+++ b/tools/taskcluster/get-pocket-token.py
@@ -13,7 +13,7 @@ import taskcluster
 
 # Get JSON data from taskcluster secrets service
 secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
-data = secrets.get('project/firefox-tv/tokens')
+data = secrets.get('project/mobile/firefox-tv/tokens')
 
 token_file_path = os.path.join(os.path.dirname(__file__), '../../.pocket_key_release')
 with open(token_file_path, 'w') as token_file:

--- a/tools/taskcluster/get-sentry-token.py
+++ b/tools/taskcluster/get-sentry-token.py
@@ -13,7 +13,7 @@ import taskcluster
 
 # Get JSON data from taskcluster secrets service
 secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
-data = secrets.get('project/firefox-tv/tokens')
+data = secrets.get('project/mobile/firefox-tv/tokens')
 
 token_file_path = os.path.join(os.path.dirname(__file__), '../../.sentry_dsn_release')
 with open(token_file_path, 'w') as token_file:


### PR DESCRIPTION
Non-user-facing, and can only be tested as a PR/release.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
