### PR TITLE
Closes #1585: Cleanup YouTube back behaviour

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/ext/EngineView.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ext/EngineView.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineView
 import org.mozilla.tv.firefox.webrender.FocusedDOMElementCache
 import org.mozilla.tv.firefox.utils.BuildConstants
+import org.mozilla.tv.firefox.utils.URLs
 import java.util.WeakHashMap
 
 // Extension methods on the EngineView class. This is used for additional features that are not part
@@ -97,6 +98,13 @@ fun EngineView.scrollByClamped(vx: Int, vy: Int) {
 
         scrollBy(scrollX, scrollY)
     }
+}
+
+fun EngineView.handleYoutubeBack() {
+    val backForwardUrlList = webView!!.copyBackForwardList().toList().map { it.originalUrl }
+    val youtubeIndex = backForwardUrlList.lastIndexOf(URLs.YOUTUBE_TILE_URL)
+    val goBackSteps = backForwardUrlList.size - youtubeIndex
+    webView!!.goBackOrForward(-goBackSteps)
 }
 
 val EngineView.focusedDOMElement: FocusedDOMElementCache

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
@@ -5,14 +5,11 @@
 package org.mozilla.tv.firefox.webrender
 
 import android.view.KeyEvent
-import android.view.ViewGroup
 import android.webkit.ValueCallback
-import android.webkit.WebView
 import mozilla.components.concept.engine.EngineView
 import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.ext.evalJS
-import org.mozilla.tv.firefox.ext.toList
-import org.mozilla.tv.firefox.utils.URLs
+import org.mozilla.tv.firefox.ext.handleYoutubeBack
 
 /**
  * youtube/tv does not handle their back stack correctly. Going back in history visits redirects which do not alter the UI.
@@ -51,10 +48,6 @@ class YouTubeBackHandler(event: KeyEvent, engineView: EngineView?, activity: Mai
     }
 
     private fun goBackBeforeYouTube() {
-        val webView = (engineView as ViewGroup).getChildAt(0) as WebView
-        val backForwardUrlList = webView.copyBackForwardList().toList().map { it.originalUrl }
-        val youtubeIndex = backForwardUrlList.lastIndexOf(URLs.YOUTUBE_TILE_URL)
-        val goBackSteps = backForwardUrlList.size - youtubeIndex
-        webView.goBackOrForward(-goBackSteps)
+        engineView?.handleYoutubeBack()
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
@@ -12,9 +12,10 @@ import org.mozilla.tv.firefox.ext.evalJS
 import org.mozilla.tv.firefox.ext.handleYoutubeBack
 
 /**
- * youtube/tv does not handle their back stack correctly. Going back in history visits redirects which do not alter the UI.
- * Users must navigate back by pressing ESC. To deal with this, we remap BACK presses to ESC.
- * When the top of YouTube's back stack is reached, we back all the way out of YouTube.
+ * youtube/tv does not handle their back stack correctly. Going back in history visits redirects
+ * which do not alter the UI. Users must navigate back by pressing ESC. To deal with this,
+ * we remap BACK presses to ESC. When the top of YouTube's back stack is reached, we back
+ * all the way out of YouTube.
  *
  * If YouTube guide-list element is focused:
  * - Suppress the DOWN,BACK key event

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.webrender
+
+import android.view.KeyEvent
+import android.view.ViewGroup
+import android.webkit.ValueCallback
+import android.webkit.WebView
+import mozilla.components.concept.engine.EngineView
+import org.mozilla.tv.firefox.MainActivity
+import org.mozilla.tv.firefox.ext.evalJS
+import org.mozilla.tv.firefox.ext.toList
+import org.mozilla.tv.firefox.utils.URLs
+
+/**
+ * youtube/tv does not handle their back stack correctly. Going back in history visits redirects which do not alter the UI.
+ * Users must navigate back by pressing ESC. To deal with this, we remap BACK presses to ESC.
+ * When the top of YouTube's back stack is reached, we back all the way out of YouTube.
+ *
+ * If YouTube guide-list element is focused:
+ * - Suppress the DOWN,BACK key event
+ * - Change the UP,BACK key event to go back in history before YouTube
+ * Else:
+ * - Dispatch ESC key event
+ */
+
+class YouTubeBackHandler(event: KeyEvent, engineView: EngineView?, activity: MainActivity) {
+    private val event = event
+    private val engineView = engineView
+    private val activity = activity
+
+    fun handleBackClick() {
+        val jsCallback = ValueCallback<String> {
+            if (it == "true") {
+                if (event.action == KeyEvent.ACTION_DOWN) Unit
+                else goBackBeforeYouTube()
+            } else {
+                val escKeyEvent = KeyEvent(event.action, KeyEvent.KEYCODE_ESCAPE)
+                activity.dispatchKeyEvent(escKeyEvent)
+            }
+        }
+        // This will return true if the currently focused YouTube element is a button in the left sidebar, false otherwise
+        engineView?.evalJS("""
+                (function () {
+                    return document.activeElement.parentElement.parentElement.id === 'guide-list';
+                })();
+                """,
+                jsCallback)
+    }
+
+    private fun goBackBeforeYouTube() {
+        val webView = (engineView as ViewGroup).getChildAt(0) as WebView
+        val backForwardUrlList = webView.copyBackForwardList().toList().map { it.originalUrl }
+        val youtubeIndex = backForwardUrlList.lastIndexOf(URLs.YOUTUBE_TILE_URL)
+        val goBackSteps = backForwardUrlList.size - youtubeIndex
+        webView.goBackOrForward(-goBackSteps)
+    }
+}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
Test will be written in #1584 because behaviour may change.
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
