### PR TITLE
No issue: disable codecov status checks.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,11 +7,12 @@ coverage:
   status:
     project:
       default:
+       enabled: no
        threshold: 0.2
        if_not_found: success
     patch:
       default:
-        enabled: yes
+        enabled: no
         if_not_found: success
     changes:
       default:


### PR DESCRIPTION
Since codecov posts the coverage changes as comments in the PR, we no
longer need status checks (and thus their failures) to tell us the
coverage diffs. We could reconfigure such that the checks exist but
never fail but their docs are unintuitive so this seemed easier.

See this PR on FFES for what this looks like:
https://github.com/mozilla-mobile/firefox-echo-show/pull/232

![image](https://user-images.githubusercontent.com/759372/52606033-fde7b800-2e25-11e9-85ba-be75a0846a48.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
