### PR TITLE
Fix fullscreen view blocking web content on app re-foreground

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -149,6 +149,7 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
     override fun onStop() {
         super.onStop()
 
+        serviceLocator!!.sessionRepo.exitFullScreenIfPossible()
         sessionFeature?.stop()
     }
 


### PR DESCRIPTION
I'll cherry-pick this into the 3.4.1 release branch.

Quick release fix, I'm not sure how to actually test fullscreen video web content + app start/stop.
Doesn't need a changelog, it's a regression within 3.4.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [X] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
