### PR TITLE
On merge to master, run on-device UI Test on Bitbar Cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ Screengrabfile
 .sentry_dsn_*
 .pocket_key_*
 .firebase_token*
+.bitbar_token_*

--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,4 @@ Screengrabfile
 .sentry_dsn_*
 .pocket_key_*
 .firebase_token*
-.bitbar_token_*
+.bitbar_token*

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -41,7 +41,7 @@ tasks:
           && git checkout {{event.head.sha}}
           && yes | sdkmanager --licenses
           && python tools/taskcluster/get-bitbar-token.py
-          && ./gradlew -PisPullRequest clean assembleSystem assembleAndroidTest lint checkstyle ktlint pmd detekt test testdroidUpload
+          && ./gradlew -PisPullRequest clean assembleSystem assembleAndroidTest lint checkstyle ktlint pmd detekt test testdroidUploadSystemDebugAndroidTest
           && ./tools/taskcluster/download-firebase-sdk.sh
           && ./tools/taskcluster/google-firebase-testlab-login.sh
           && ./tools/taskcluster/execute-firebase-test.sh system/debug app-system-debug model=taimen,version=26,orientation=landscape

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -13,6 +13,7 @@ tasks:
 # - Build the app (all flavors)
 # - Run unit tests
 # - Run code quality tools (findbugs, lint, checkstyle etc.)
+# - Upload build to Bitbar and run UI tests
 ###############################################################################
   - provisionerId: '{{ taskcluster.docker.provisionerId }}'
     workerType: '{{ taskcluster.docker.workerType }}'
@@ -39,7 +40,8 @@ tasks:
           && git config advice.detachedHead false
           && git checkout {{event.head.sha}}
           && yes | sdkmanager --licenses
-          && ./gradlew -PisPullRequest clean assembleSystem assembleAndroidTest lint checkstyle ktlint pmd detekt test
+          && python tools/taskcluster/get-bitbar-token.py
+          && ./gradlew -PisPullRequest clean assembleSystem assembleAndroidTest lint checkstyle ktlint pmd detekt test testdroidUpload
           && ./tools/taskcluster/download-firebase-sdk.sh
           && ./tools/taskcluster/google-firebase-testlab-login.sh
           && ./tools/taskcluster/execute-firebase-test.sh system/debug app-system-debug model=taimen,version=26,orientation=landscape

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -13,7 +13,6 @@ tasks:
 # - Build the app (all flavors)
 # - Run unit tests
 # - Run code quality tools (findbugs, lint, checkstyle etc.)
-# - Upload build to Bitbar and run UI tests
 ###############################################################################
   - provisionerId: '{{ taskcluster.docker.provisionerId }}'
     workerType: '{{ taskcluster.docker.workerType }}'
@@ -40,8 +39,7 @@ tasks:
           && git config advice.detachedHead false
           && git checkout {{event.head.sha}}
           && yes | sdkmanager --licenses
-          && python tools/taskcluster/get-bitbar-token.py
-          && ./gradlew -PisPullRequest clean assembleSystem assembleAndroidTest lint checkstyle ktlint pmd detekt test testdroidUploadSystemDebugAndroidTest
+          && ./gradlew -PisPullRequest clean assembleSystem assembleAndroidTest lint checkstyle ktlint pmd detekt test
           && ./tools/taskcluster/download-firebase-sdk.sh
           && ./tools/taskcluster/google-firebase-testlab-login.sh
           && ./tools/taskcluster/execute-firebase-test.sh system/debug app-system-debug model=taimen,version=26,orientation=landscape
@@ -72,7 +70,7 @@ tasks:
 # - Build the app (all flavors)
 # - Run unit tests
 # - Run code quality tools (findbugs, lint, checkstyle etc.)
-#
+# - Upload build to Bitbar and run UI tests
 # - HACK: Used {{ event.head.repo.url }} instead of origin because origin routes to
 #   the Focus Android repo
 ###############################################################################
@@ -99,7 +97,8 @@ tasks:
           && git config advice.detachedHead false
           && git checkout {{event.head.sha}}
           && yes | sdkmanager --licenses
-          && ./gradlew -PisPullRequest clean assembleSystem assembleAndroidTest lint checkstyle ktlint pmd detekt test
+          && python tools/taskcluster/get-bitbar-token.py
+          && ./gradlew -PisPullRequest clean assembleSystem assembleAndroidTest lint checkstyle ktlint pmd detekt test testdroidUploadSystemDebugAndroidTest
       artifacts:
         'public':
           type: 'directory'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import org.mozilla.gradle.tasks.ValidateAndroidAppReleaseConfiguration
+import java.text.SimpleDateFormat
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
@@ -12,6 +13,7 @@ apply plugin: 'jacoco'
 apply plugin: 'pmd'
 apply plugin: 'checkstyle'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'testdroid'
 
 apply from: "$project.rootDir/tools/gradle/versionCode.gradle"
 
@@ -465,4 +467,35 @@ if (project.hasProperty("coverage")) {
 
 afterEvaluate {
     check.dependsOn 'findbugs', 'pmd', 'checkstyle'
+}
+
+// -------------------------------------------------------------------------------------------------
+// Bitbar Cloud Testing: testDroidUpload
+// Upload both the application and test APK and conduct a UI test-run
+// Utilizes a preset group of Amazon Fire TV devices on a preset project and framework
+// -------------------------------------------------------------------------------------------------
+
+testdroid {
+
+    try {
+        def tokenFile = new File("${rootDir}/.bitbar_token.json")
+        def parsedFile = new groovy.json.JsonSlurper().parseText(tokenFile.text)
+
+        apiKey parsedFile.secret.bitbarToken.api_key
+        cloudUrl parsedFile.secret.bitbarToken.cloud_url
+
+        println "(Added from .bitbar_token file)"
+    } catch (FileNotFoundException ignored) {
+        println("X_X")
+    }
+
+    authorization "APIKEY"
+    deviceGroup "Amazon"
+    projectName "Firefox for Fire TV"
+    testRunName "Build: " + android.defaultConfig.versionName + " - " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())
+    frameworkId 24
+    fullRunConfig {
+        instrumentationRunner = android.defaultConfig.testInstrumentationRunner
+        withAnnotation = "org.mozilla.tv.firefox.ui"
+    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -480,6 +480,8 @@ testdroid {
         def tokenFile = new File("${rootDir}/.bitbar_token.json")
         def parsedFile = new groovy.json.JsonSlurper().parseText(tokenFile.text)
 
+        println parsedFile
+
         apiKey parsedFile.api_key
         cloudUrl parsedFile.cloud_url
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -476,13 +476,12 @@ afterEvaluate {
 // -------------------------------------------------------------------------------------------------
 
 testdroid {
-
     try {
         def tokenFile = new File("${rootDir}/.bitbar_token.json")
         def parsedFile = new groovy.json.JsonSlurper().parseText(tokenFile.text)
 
-        apiKey parsedFile.secret.bitbarToken.api_key
-        cloudUrl parsedFile.secret.bitbarToken.cloud_url
+        apiKey parsedFile.bitbarToken.api_key
+        cloudUrl parsedFile.bitbarToken.cloud_url
 
         println "(Added from .bitbar_token file)"
     } catch (FileNotFoundException ignored) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -493,6 +493,7 @@ testdroid {
     projectName "Firefox for Fire TV"
     testRunName "Build: " + android.defaultConfig.versionName + " - " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())
     frameworkId 24
+    scheduler "PARALLEL"
     fullRunConfig {
         instrumentationRunner = android.defaultConfig.testInstrumentationRunner
         withAnnotation = "org.mozilla.tv.firefox.ui"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -480,8 +480,8 @@ testdroid {
         def tokenFile = new File("${rootDir}/.bitbar_token.json")
         def parsedFile = new groovy.json.JsonSlurper().parseText(tokenFile.text)
 
-        apiKey parsedFile.bitbarToken.api_key
-        cloudUrl parsedFile.bitbarToken.cloud_url
+        apiKey parsedFile.api_key
+        cloudUrl parsedFile.cloud_url
 
         println "(Added from .bitbar_token file)"
     } catch (FileNotFoundException ignored) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -480,8 +480,6 @@ testdroid {
         def tokenFile = new File("${rootDir}/.bitbar_token.json")
         def parsedFile = new groovy.json.JsonSlurper().parseText(tokenFile.text)
 
-        println parsedFile
-
         apiKey parsedFile.api_key
         cloudUrl parsedFile.cloud_url
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ buildscript {
         classpath 'org.ajoberstar:grgit:1.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
+        classpath 'com.testdroid:gradle:2.63.1'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tools/taskcluster/get-bitbar-token.py
+++ b/tools/taskcluster/get-bitbar-token.py
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+This script talks to the taskcluster secrets service to obtain the
+Bitbar token and write it to the .bitbar_token file in the root
+directory.
+"""
+
+import os
+import taskcluster
+import json
+
+# Get JSON data from taskcluster secrets service
+secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+data = secrets.get('project/mobile/firefox-tv/tokens')
+
+with open(os.path.join(os.path.dirname(__file__), '../../.bitbar_token.json'), 'w') as file:
+    json.dump(data['secret']['bitbarToken'], file)
+
+print("Imported bitbar token from secrets service")


### PR DESCRIPTION
This PR integrates a Gradle plugin for supporting Bitbar Cloud UI testing on master merge. Configuration has to be defined in a Gradle task. Currently it uses a preset “Firefox for Fire TV” project defined on Bitbar using a predefined group of devices under a group name “Amazon”. We can customize the group of device selection through the front-end. Test run names are just a build + date (we can probably improve on that, just temporarily  using this approach).

Edit: I'll squash before merge.