### PR TITLE
Closes #1830: fixes YouTube focus when overlay is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed links on settings About page that did not load (#1731)
 - A memory leak (#1628)
 - Fixed bug that could cause YouTube to display vertically offset from where it should be (#1719)
+- Bug that could cause YouTube to lose focus if the overlay was opened during loading (#1830)
 
 ## [3.3.1] - 2019-02-04
 *Released to Fire TV 4K.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed links on settings About page that did not load (#1731)
 - A memory leak (#1628)
 - Fixed bug that could cause YouTube to display vertically offset from where it should be (#1719)
-- Bug that could cause YouTube to lose focus if the overlay was opened during loading (#1830)
+- Bug that could cause YouTube to be unresponsive if the overlay was opened during loading (#1830)
 
 ## [3.3.1] - 2019-02-04
 *Released to Fire TV 4K.*

--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -174,6 +174,7 @@ class ScreenController {
                 _currentActiveScreen.value = ActiveScreen.NAVIGATION_OVERLAY
             }
             Transition.REMOVE_OVERLAY -> {
+                fragmentManager.webRenderFragment().onShowEngineView()
                 showNavigationOverlay(fragmentManager, false)
                 _currentActiveScreen.value = ActiveScreen.WEB_RENDER
             }
@@ -212,6 +213,7 @@ class ScreenController {
                     .hide(fragmentManager.pocketFragment())
                     .hide(fragmentManager.settingsFragment())
                     .commitNow()
+                fragmentManager.webRenderFragment().onShowEngineView()
                 _currentActiveScreen.value = ActiveScreen.WEB_RENDER
             }
             Transition.EXIT_APP -> { return false }

--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -30,7 +30,9 @@ class ScreenController {
     private val _currentActiveScreen = MutableLiveData<ActiveScreen>().apply {
         value = ActiveScreen.NAVIGATION_OVERLAY
     }
-    // This is updated just before the fragment transaction is committed
+    /**
+     * Observers will be notified just before the fragment transaction is committed
+     */
     val currentActiveScreen: LiveData<ActiveScreen> = _currentActiveScreen
 
     /**
@@ -171,6 +173,7 @@ class ScreenController {
         // Call show() before hide() so that focus moves correctly to the shown fragment once others are hidden
         when (transition) {
             Transition.ADD_OVERLAY -> {
+                // We always update the currentActiveScreen value before beginning the fragment transaction
                 _currentActiveScreen.value = ActiveScreen.NAVIGATION_OVERLAY
                 fragmentManagerShowNavigationOverlay(fragmentManager, true)
             }

--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -27,9 +27,10 @@ import org.mozilla.tv.firefox.widget.InlineAutocompleteEditText
 
 class ScreenController {
 
-    private var _currentActiveScreen = MutableLiveData<ActiveScreen>().apply {
+    private val _currentActiveScreen = MutableLiveData<ActiveScreen>().apply {
         value = ActiveScreen.NAVIGATION_OVERLAY
     }
+    // This is updated just before the fragment transaction is committed
     val currentActiveScreen: LiveData<ActiveScreen> = _currentActiveScreen
 
     /**
@@ -170,43 +171,44 @@ class ScreenController {
         // Call show() before hide() so that focus moves correctly to the shown fragment once others are hidden
         when (transition) {
             Transition.ADD_OVERLAY -> {
-                fragmentManagerShowNavigationOverlay(fragmentManager, true)
                 _currentActiveScreen.value = ActiveScreen.NAVIGATION_OVERLAY
+                fragmentManagerShowNavigationOverlay(fragmentManager, true)
             }
             Transition.REMOVE_OVERLAY -> {
-                fragmentManager.webRenderFragment().onShowEngineView()
-                showNavigationOverlay(fragmentManager, false)
                 _currentActiveScreen.value = ActiveScreen.WEB_RENDER
+                showNavigationOverlay(fragmentManager, false)
+                fragmentManager.webRenderFragment().onShowEngineView()
             }
             Transition.ADD_POCKET -> {
+                _currentActiveScreen.value = ActiveScreen.POCKET
                 fragmentManager.beginTransaction()
                     .show(fragmentManager.pocketFragment())
                     .hide(fragmentManager.navigationOverlayFragment())
                     .commit()
-                _currentActiveScreen.value = ActiveScreen.POCKET
             }
             Transition.REMOVE_POCKET -> {
+                _currentActiveScreen.value = ActiveScreen.NAVIGATION_OVERLAY
                 fragmentManager.beginTransaction()
                     .show(fragmentManager.navigationOverlayFragment())
                     .hide(fragmentManager.pocketFragment())
                     .commit()
-                _currentActiveScreen.value = ActiveScreen.NAVIGATION_OVERLAY
             }
             Transition.ADD_SETTINGS -> {
+                _currentActiveScreen.value = ActiveScreen.SETTINGS
                 fragmentManager.beginTransaction()
                     .show(fragmentManager.settingsFragment())
                     .hide(fragmentManager.navigationOverlayFragment())
                     .commit()
-                _currentActiveScreen.value = ActiveScreen.SETTINGS
             }
             Transition.REMOVE_SETTINGS -> {
+                _currentActiveScreen.value = ActiveScreen.NAVIGATION_OVERLAY
                 fragmentManager.beginTransaction()
                     .show(fragmentManager.navigationOverlayFragment())
                     .hide(fragmentManager.settingsFragment())
                     .commit()
-                _currentActiveScreen.value = ActiveScreen.NAVIGATION_OVERLAY
             }
             Transition.SHOW_BROWSER -> {
+                _currentActiveScreen.value = ActiveScreen.WEB_RENDER
                 fragmentManager.beginTransaction()
                     .show(fragmentManager.webRenderFragment())
                     .hide(fragmentManager.navigationOverlayFragment())
@@ -214,7 +216,6 @@ class ScreenController {
                     .hide(fragmentManager.settingsFragment())
                     .commitNow()
                 fragmentManager.webRenderFragment().onShowEngineView()
-                _currentActiveScreen.value = ActiveScreen.WEB_RENDER
             }
             Transition.EXIT_APP -> { return false }
             Transition.NO_OP -> { return true }

--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -177,7 +177,6 @@ class ScreenController {
             Transition.REMOVE_OVERLAY -> {
                 _currentActiveScreen.value = ActiveScreen.WEB_RENDER
                 showNavigationOverlay(fragmentManager, false)
-                fragmentManager.webRenderFragment().onShowEngineView()
             }
             Transition.ADD_POCKET -> {
                 _currentActiveScreen.value = ActiveScreen.POCKET
@@ -215,7 +214,6 @@ class ScreenController {
                     .hide(fragmentManager.pocketFragment())
                     .hide(fragmentManager.settingsFragment())
                     .commitNow()
-                fragmentManager.webRenderFragment().onShowEngineView()
             }
             Transition.EXIT_APP -> { return false }
             Transition.NO_OP -> { return true }

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/FocusedDOMElementCacheInterface.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/FocusedDOMElementCacheInterface.kt
@@ -17,6 +17,10 @@ import android.view.View
  * to restore the focused element, dpad navigation is entirely broken (#393): that is
  * why this class is necessary.
  *
+ * It is important that this value be cached just before the WebView regains focus.  Otherwise
+ * edge cases present themselves where a DOM element is cached, a new element is focused by a
+ * site, and then we return focus to the earlier (now incorrect) element (see #1830).
+ *
  * NB: if you create an Android View which steals focus from the WebView and it refreshes the
  * DOM state (e.g. page reload), *you must add custom handling to that view* in order to cache
  * the focused DOMElement: on your view that returns (and maybe takes) focus to the WebView,

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -135,8 +135,13 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
          *  memory leak while clearing data. See [WebViewCache.clear] as well as #1720
          */
         serviceLocator?.screenController?.currentActiveScreen?.observe(viewLifecycleOwner, Observer {
-            if (it != ScreenControllerStateMachine.ActiveScreen.WEB_RENDER) {
-                engineView.pauseAllVideoPlaybacks()
+            when (it) {
+                // Cache focused DOM element just before WebView gains focus. See comment in
+                // FocusedDOMElementCacheInterface for details
+                ScreenControllerStateMachine.ActiveScreen.WEB_RENDER -> engineView.focusedDOMElement.cache()
+                // Pause all the videos when transitioning out of [WebRenderFragment] to mitigate possible
+                // memory leak while clearing data. See [WebViewCache.clear] as well as #1720
+                else -> engineView.pauseAllVideoPlaybacks()
             }
         })
     }
@@ -211,12 +216,5 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
             return true
         }
         return false
-    }
-
-    /**
-     * Called before the [EngineView] is shown
-     */
-    fun onShowEngineView() {
-        engineView?.focusedDOMElement?.cache()
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -23,7 +23,7 @@ import mozilla.components.feature.session.SessionFeature
 import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.MediaSessionHolder
 import org.mozilla.tv.firefox.R
-import org.mozilla.tv.firefox.ScreenControllerStateMachine
+import org.mozilla.tv.firefox.ScreenControllerStateMachine.ActiveScreen
 import org.mozilla.tv.firefox.ext.focusedDOMElement
 import org.mozilla.tv.firefox.ext.isYoutubeTV
 import org.mozilla.tv.firefox.ext.pauseAllVideoPlaybacks
@@ -130,18 +130,15 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
             requireWebRenderComponents.sessionUseCases,
             engineView)
 
-        /**
-         *  Pause all the videos when transitioning out of [WebRenderFragment] to mitigate possible
-         *  memory leak while clearing data. See [WebViewCache.clear] as well as #1720
-         */
         serviceLocator?.screenController?.currentActiveScreen?.observe(viewLifecycleOwner, Observer {
-            when (it) {
+            if (it == ActiveScreen.WEB_RENDER) {
                 // Cache focused DOM element just before WebView gains focus. See comment in
                 // FocusedDOMElementCacheInterface for details
-                ScreenControllerStateMachine.ActiveScreen.WEB_RENDER -> engineView.focusedDOMElement.cache()
+                engineView.focusedDOMElement.cache()
+            } else {
                 // Pause all the videos when transitioning out of [WebRenderFragment] to mitigate possible
                 // memory leak while clearing data. See [WebViewCache.clear] as well as #1720
-                else -> engineView.pauseAllVideoPlaybacks()
+                engineView.pauseAllVideoPlaybacks()
             }
         })
     }

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -24,6 +24,7 @@ import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.MediaSessionHolder
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.ScreenControllerStateMachine
+import org.mozilla.tv.firefox.ext.focusedDOMElement
 import org.mozilla.tv.firefox.ext.isYoutubeTV
 import org.mozilla.tv.firefox.ext.pauseAllVideoPlaybacks
 import org.mozilla.tv.firefox.ext.requireWebRenderComponents
@@ -210,5 +211,12 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
             return true
         }
         return false
+    }
+
+    /**
+     * Called before the [EngineView] is shown
+     */
+    fun onShowEngineView() {
+        engineView?.focusedDOMElement?.cache()
     }
 }

--- a/app/src/system/java/org/mozilla/tv/firefox/ext/EngineView.kt
+++ b/app/src/system/java/org/mozilla/tv/firefox/ext/EngineView.kt
@@ -40,6 +40,10 @@ fun EngineView.setupForApp() {
     // instantiate a new WebView instance
     webView?.setOnFocusChangeListener { _, hasFocus ->
         if (hasFocus) {
+            // See FocusedDOMElementCacheInterface for details on why this happens
+            //
+            // Note that caching of this value is done elsewhere
+            //
             // Trying to restore immediately doesn't work - perhaps the WebView hasn't actually
             // received focus yet? Posting to the end of the UI queue seems to solve the problem.
             uiHandler.post { focusedDOMElement.restore() }

--- a/app/src/system/java/org/mozilla/tv/firefox/ext/EngineView.kt
+++ b/app/src/system/java/org/mozilla/tv/firefox/ext/EngineView.kt
@@ -39,14 +39,7 @@ fun EngineView.setupForApp() {
     // WebView can be null temporarily after clearData(); however, activity.recreate() would
     // instantiate a new WebView instance
     webView?.setOnFocusChangeListener { _, hasFocus ->
-        if (!hasFocus) {
-            // For why we're modifying the focusedDOMElement, see FocusedDOMElementCacheInterface.
-            //
-            // Any views (like BrowserNavigationOverlay) that may clear the cache, e.g. by
-            // reloading the page, are required to handle their own caching. Here we'll handle
-            // cases where the page cache isn't cleared.
-            focusedDOMElement.cache()
-        } else {
+        if (hasFocus) {
             // Trying to restore immediately doesn't work - perhaps the WebView hasn't actually
             // received focus yet? Posting to the end of the UI queue seems to solve the problem.
             uiHandler.post { focusedDOMElement.restore() }


### PR DESCRIPTION
RCA:
There is a WebView bug that, when the WV loses and regains focus, causes the incorrect DOM element to receive focus (https://bugs.chromium.org/p/chromium/issues/detail?id=826577). Our workaround for this caches the currently focused view on overlay open, then focuses it on overlay close. When we open the overlay during a loading screen, we cache the body element. The overlay is then closed, and the body element focused, rather than the view on which YouTube has programmatically requested focus.

Fix:
Instead of caching focus on overlay open, this now caches it just before overlay close.  This allows us to use the most recently focused DOM element.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
Testing this will involve writing a complex Espresso test.  This is out of scope for this story, but https://github.com/mozilla-mobile/firefox-tv/issues/1832 was opened
- [X] This PR includes a **CHANGELOG entry** or does not need one
- [X] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [X] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
