### PR TITLE
Optimize and re-build docker image.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -28,7 +28,7 @@ tasks:
     payload:
       maxRunTime: 3600
       deadline: "{{ '2 hours' | $fromNow }}"
-      image: 'mozillamobile/firefox-tv:2.0'
+      image: 'mozillamobile/firefox-tv:2.2'
       command:
         - /bin/bash
         - '--login'
@@ -85,7 +85,7 @@ tasks:
     payload:
       maxRunTime: 3600
       deadline: "{{ '2 hours' | $fromNow }}"
-      image: 'mozillamobile/firefox-tv:2.0'
+      image: 'mozillamobile/firefox-tv:2.2'
       taskclusterProxy: true
       command:
         - /bin/bash
@@ -129,7 +129,7 @@ tasks:
     payload:
       maxRunTime: 3600
       deadline: "{{ '2 hours' | $fromNow }}"
-      image: 'mozillamobile/firefox-tv:2.0'
+      image: 'mozillamobile/firefox-tv:2.2'
       command:
         - /bin/bash
         - '--login'

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -17,6 +17,9 @@ ENV ANDROID_PLATFORM_VERSION "27"
 
 ENV PROJECT_REPOSITORY "https://github.com/mozilla-mobile/firefox-tv.git"
 
+# Disable interactive gradle output on taskcluster
+ENV TERM dumb
+
 # -- System -----------------------------------------------------------------------------
 
 RUN apt-get update -qq
@@ -64,22 +67,17 @@ RUN touch /build/android-sdk/.android/repositories.cfg
 
 RUN yes | sdkmanager --licenses
 
-RUN sdkmanager --verbose "platform-tools" \
-    "platforms;android-${ANDROID_PLATFORM_VERSION}" \
-    "build-tools;${ANDROID_BUILD_TOOLS}" \
-    "extras;android;m2repository" \
-    "extras;google;m2repository"
-
 # -- Project setup ----------------------------------------------------------------------
 
 WORKDIR /opt
 
 # Checkout source code
-RUN git clone ${PROJECT_REPOSITORY}
+RUN git clone --depth=1 ${PROJECT_REPOSITORY}
 
 # Build project and run gradle tasks once to pull all dependencies
 WORKDIR /opt/firefox-tv/
-RUN ./gradlew --no-daemon clean assemble lint checkstyle ktlint pmd detektCheck
+RUN ./gradlew --no-daemon clean assembleDebug lint checkstyle ktlint pmd detekt testSystemDebugUnitTest \
+    && ./gradlew --no-daemon clean
 
 # -- Post setup -------------------------------------------------------------------------
 
@@ -87,8 +85,4 @@ RUN ./gradlew --no-daemon clean assemble lint checkstyle ktlint pmd detektCheck
 RUN pip install -r tools/l10n/android2po/requirements.txt
 
 # Install taskcluster python library (used by decision tasks)
-RUN pip install taskcluster
-
-# -- Cleanup ----------------------------------------------------------------------------
-
-RUN apt-get clean
+RUN pip install 'taskcluster>=4,<5'


### PR DESCRIPTION
This PR updates the Docker image to 2.1. I've built and uploaded this image to Docker Hub today - so that it includes the latest cached dependencies.

In addition to that I ported some Dockerfile optimizations that we did in AC over to the FFFTV app:
- Use "--depth=1" to only checkout the latest state. No need to have the whole git history inside the image.
- Run "gradle clean" after the build. No need to keep outdated build artifacts inside the image.
- Do not download anything with "sdkmanager". The following gradle task will download what it needs anyways. There's a higher chance that we pick the wrong things or just too much.
- Do not run "apt-gen clean". Because of the way Docker images are layered this doesn't actually save any space.
