### PR TITLE
Issue #1850: let back work when YouTube focus breaks

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
@@ -11,19 +11,24 @@ import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.ext.evalJS
 import org.mozilla.tv.firefox.ext.handleYoutubeBack
 
+// This will only happen if YouTube is loading or navigation has broken
+private const val noElementFocused = "document.activeElement === null"
+// This will only happen if YouTube is loading or navigation has broken
+private const val bodyElementFocused = "document.activeElement.tagName === \"BODY\""
+private const val sidebarFocused = "document.activeElement.parentElement.parentElement.id === 'guide-list'"
+
 /**
  * youtube/tv does not handle their back stack correctly. Going back in history visits redirects
  * which do not alter the UI. Users must navigate back by pressing ESC. To deal with this,
- * we remap BACK presses to ESC. When the top of YouTube's back stack is reached, we back
- * all the way out of YouTube.
+ * we remap BACK presses to ESC. When the top of YouTube's back stack is reached, or we are in
+ * an unexpected state, we back all the way out of YouTube.
  *
- * If YouTube guide-list element is focused:
+ * If YouTube guide-list element is focused or we are in an unexpected state:
  * - Suppress the DOWN,BACK key event
  * - Change the UP,BACK key event to go back in history before YouTube
  * Else:
  * - Dispatch ESC key event
  */
-
 class YouTubeBackHandler(
     private val event: KeyEvent,
     private val engineView: EngineView?,
@@ -31,25 +36,27 @@ class YouTubeBackHandler(
 ) {
 
     fun handleBackClick() {
-        val jsCallback = ValueCallback<String> {
-            if (it == "true") {
+
+        val shouldWeExitPage = """
+               (function () {
+                    return $noElementFocused ||
+                        $bodyElementFocused ||
+                        $sidebarFocused;
+                })();
+        """.trimIndent()
+
+        val backOrMoveFocus = ValueCallback<String> { shouldExitPage ->
+            if (shouldExitPage == "true") {
                 if (event.action == KeyEvent.ACTION_DOWN) Unit
                 else goBackBeforeYouTube()
             } else {
+                // Esc will move focus within YouTube
                 val escKeyEvent = KeyEvent(event.action, KeyEvent.KEYCODE_ESCAPE)
                 activity.dispatchKeyEvent(escKeyEvent)
             }
         }
-        // This will return true if there is no focused element, the body tag is focused, or the
-        // currently focused element is a button in the left sidebar. Otherwise it will return false
-        engineView?.evalJS("""
-                (function () {
-                    return document.activeElement === null ||
-                        document.activeElement.tagName === "BODY" ||
-                        document.activeElement.parentElement.parentElement.id === 'guide-list';
-                })();
-                """,
-                jsCallback)
+
+        engineView?.evalJS(javascript = shouldWeExitPage, callback = backOrMoveFocus)
     }
 
     private fun goBackBeforeYouTube() {

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/YouTubeBackHandler.kt
@@ -24,10 +24,11 @@ import org.mozilla.tv.firefox.ext.handleYoutubeBack
  * - Dispatch ESC key event
  */
 
-class YouTubeBackHandler(event: KeyEvent, engineView: EngineView?, activity: MainActivity) {
-    private val event = event
-    private val engineView = engineView
-    private val activity = activity
+class YouTubeBackHandler(
+    private val event: KeyEvent,
+    private val engineView: EngineView?,
+    private val activity: MainActivity
+) {
 
     fun handleBackClick() {
         val jsCallback = ValueCallback<String> {
@@ -39,10 +40,13 @@ class YouTubeBackHandler(event: KeyEvent, engineView: EngineView?, activity: Mai
                 activity.dispatchKeyEvent(escKeyEvent)
             }
         }
-        // This will return true if the currently focused YouTube element is a button in the left sidebar, false otherwise
+        // This will return true if there is no focused element, the body tag is focused, or the
+        // currently focused element is a button in the left sidebar. Otherwise it will return false
         engineView?.evalJS("""
                 (function () {
-                    return document.activeElement.parentElement.parentElement.id === 'guide-list';
+                    return document.activeElement === null ||
+                        document.activeElement.tagName === "BODY" ||
+                        document.activeElement.parentElement.parentElement.id === 'guide-list';
                 })();
                 """,
                 jsCallback)


### PR DESCRIPTION
YouTube focus is very brittle, and has broken frequently. This mitigation lets the hardware back button navigate the user out of YouTube if focus is improperly moved to the body element



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
