### PR TITLE
Closes #1867: Set up GeckoRuntime during GeckoEngine setup allowing remoteDeubgging

### DIFF
--- a/app/src/gecko/java/org/mozilla/tv/firefox/ext/EngineView.kt
+++ b/app/src/gecko/java/org/mozilla/tv/firefox/ext/EngineView.kt
@@ -22,17 +22,6 @@ private val uiHandler = Handler(Looper.getMainLooper())
  * Firefox for Fire TV needs to configure every WebView appropriately.
  */
 fun EngineView.setupForApp() {
-    // Also increase text size to fill the viewport (this mirrors the behaviour of Firefox,
-    // Chrome does this in the current Chrome Dev, but not Chrome release).
-    // TODO #33: TEXT_AUTOSIZING does not exist in AmazonWebSettings
-    // geckoView.settings.setLayoutAlgorithm(AmazonWebSettings.LayoutAlgorithm.TEXT_AUTOSIZING);
-
-//    if (BuildConstants.isDevBuild) {
-//        GeckoView.setWebContentsDebuggingEnabled(true)
-//    }
-
-    // GeckoView can be null temporarily after clearData(); however, activity.recreate() would
-    // instantiate a new GeckoView instance
     geckoView?.setOnFocusChangeListener { _, hasFocus ->
         if (!hasFocus) {
             // For why we're modifying the focusedDOMElement, see FocusedDOMElementCacheInterface.

--- a/app/src/gecko/java/org/mozilla/tv/firefox/webrender/WebRenderComponents.kt
+++ b/app/src/gecko/java/org/mozilla/tv/firefox/webrender/WebRenderComponents.kt
@@ -10,7 +10,10 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.session.SessionUseCases
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.mozilla.tv.firefox.R
+import org.mozilla.tv.firefox.utils.BuildConstants
 import org.mozilla.tv.firefox.utils.Settings
 
 /**
@@ -38,10 +41,21 @@ class WebRenderComponents(applicationContext: Context, systemUserAgent: String) 
                 allowContentAccess = false,
 
                 mediaPlaybackRequiresUserGesture = false // Allows auto-play (which improves YouTube experience).
-        ))
+        ), getOrCreateRuntime(applicationContext))
     }
 
     val sessionManager by lazy { SessionManager(engine) }
 
     val sessionUseCases by lazy { SessionUseCases(sessionManager) }
+
+    @Synchronized
+    private fun getOrCreateRuntime(context: Context): GeckoRuntime {
+        val builder = GeckoRuntimeSettings.Builder()
+
+        if (BuildConstants.isDevBuild) {
+            builder.remoteDebuggingEnabled(true)
+        }
+
+        return GeckoRuntime.create(context, builder.build())
+    }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
