### PR TITLE
String import 20190222-120551

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
   <string name="firefox_tv_brand_name">Firefox TV</string>
+  <string name="firefox_tv_brand_name_short">Firefox</string>
   <string name="pocket_brand_name">Pocket</string>
   <string name="action_cancel">キャンセル</string>
   <string name="action_ok">OK</string>
@@ -64,4 +65,5 @@
   <string name="notification_request_desktop_site">デスクトップ版を表示します</string>
   <string name="notification_request_non_desktop_site">デスクトップ版でない表示に戻しました</string>
   <string name="youtube_casting_onboarding_toast">YouTube 動画をスマートフォンやタブレットからキャスト配信します。開始するには、端末で YouTube を開き、%s をタップしてください。</string>
+  <string name="exit_firefox_a11y">%1$s を終了</string>
 </resources>


### PR DESCRIPTION

Automated import 20190222-120551

Log:
```
 [unchanged] app/src/main/res/values-fr/strings.xml
 [unchanged] app/src/main/res/values-de/strings.xml
 [unchanged] app/src/main/res/values-it/strings.xml
     [mkdir] app/src/main/res/values-zh-CN
   [created] app/src/main/res/values-zh-CN/strings.xml
     [mkdir] app/src/main/res/values-pt-BR
   [created] app/src/main/res/values-pt-BR/strings.xml
     [mkdir] app/src/main/res/values-es-ES
   [created] app/src/main/res/values-es-ES/strings.xml
   [updated] app/src/main/res/values-ja/strings.xml
Fixing ./values-es-ES -> ./values-es-rES
Fixing ./values-zh-CN -> ./values-zh-rCN
Fixing ./values-pt-BR -> ./values-pt-rBR
Checking for placeholders in translation files...
Warning: * [values-tr/strings.xml] number of placeholders not matching, key: your_rights_content5

```
