### PR TITLE
Closes #277: Fix 4K - Add SystemEngineSession.resetView().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Bug where you could not use remote back button to exit YouTube if it was visited from Pocket (#1584)
+- Fixed 4K YT bug (#277)
 
 ## [3.4.1] 2019-02-12
 *Released to Fire TV 4K.*

--- a/app/src/gecko/java/org/mozilla/tv/firefox/ext/EngineSession.kt
+++ b/app/src/gecko/java/org/mozilla/tv/firefox/ext/EngineSession.kt
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.ext
+
+import android.content.Context
+import mozilla.components.concept.engine.EngineSession
+
+// This is only required for [SystemEngineSession]
+fun EngineSession.resetView(@Suppress("UNUSED_PARAMETER") context: Context) { }

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -28,6 +28,7 @@ import org.mozilla.tv.firefox.ext.focusedDOMElement
 import org.mozilla.tv.firefox.ext.isYoutubeTV
 import org.mozilla.tv.firefox.ext.pauseAllVideoPlaybacks
 import org.mozilla.tv.firefox.ext.requireWebRenderComponents
+import org.mozilla.tv.firefox.ext.resetView
 import org.mozilla.tv.firefox.ext.serviceLocator
 import org.mozilla.tv.firefox.ext.webRenderComponents
 import org.mozilla.tv.firefox.telemetry.MenuInteractionMonitor
@@ -192,6 +193,7 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
             } else {
                 // There's no session (anymore). Let's create a new one.
                 requireWebRenderComponents.sessionManager.add(Session(url), selected = true)
+                requireWebRenderComponents.sessionManager.getOrCreateEngineSession().resetView(activity!!)
             }
         }
     }

--- a/app/src/system/java/org/mozilla/tv/firefox/ext/EngineSession.kt
+++ b/app/src/system/java/org/mozilla/tv/firefox/ext/EngineSession.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.ext
+
+import android.content.Context
+import mozilla.components.browser.engine.system.NestedWebView
+import mozilla.components.browser.engine.system.SystemEngineSession
+import mozilla.components.concept.engine.EngineSession
+
+/**
+ * [AmazonWebView] requires ActivityContext in order to show 4K resolution rendering option (#277)
+ *
+ * By default, a-c [SystemEngineSession.webView] uses ApplicationContext. This allows us to
+ * override the webView instance
+ */
+fun EngineSession.resetView(context: Context) {
+    (this as SystemEngineSession).webView = NestedWebView(context)
+}


### PR DESCRIPTION
AmazonWebView requires ActivityContext to show 4k resolution option. a-c SystemEngineSession defaults its webView instance to use ApplicationContext. We need to manually override this whenever we create a new session and properly deallocate when onDestroy()

**This PR depends on https://github.com/mozilla-mobile/firefox-tv/issues/1893 (https://github.com/mozilla-mobile/android-components/pull/2214) before merge**

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
