### PR TITLE
Add taskclusterProxy to master block in .tackcluster.yml

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -84,7 +84,6 @@ tasks:
       maxRunTime: 3600
       deadline: "{{ '2 hours' | $fromNow }}"
       image: 'mozillamobile/firefox-tv:2.3'
-      taskclusterProxy: true
       command:
         - /bin/bash
         - '--login'
@@ -103,6 +102,9 @@ tasks:
           type: 'directory'
           path: '/opt/firefox-tv/app/build/reports'
           expires: "{{ '1 week' | $fromNow }}"
+
+      features:
+          taskclusterProxy: true
 
     metadata:
       name: Firefox for Amazon's Fire TV - Build - Master


### PR DESCRIPTION
I believe this is needed to access secrets (required for the Bitbar token fetch) 

`taskcluster.exceptions.TaskclusterConnectionError: ('Failed to establish connection', ConnectionError(MaxRetryError("HTTPConnectionPool(host='taskcluster', port=80): Max retries exceeded with url: /secrets/v1/secret/project%2Fmobile%2Ffirefox-tv%2Ftokens (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f89e79a5610>: Failed to establish a new connection: [Errno -2] Name or service not known',))",),))
`