### PR TITLE
Fix Pocket and Settings focus after page load

### DIFF
--- a/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/Matchers.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/Matchers.kt
@@ -10,6 +10,7 @@ import org.hamcrest.Matcher
 import androidx.test.espresso.matcher.ViewMatchers.isChecked as espressoIsChecked
 import androidx.test.espresso.matcher.ViewMatchers.isEnabled as espressoIsEnabled
 import androidx.test.espresso.matcher.ViewMatchers.isSelected as espressoIsSelected
+import androidx.test.espresso.matcher.ViewMatchers.hasFocus as espressoHasFocus
 
 /**
  * The [espressoIsEnabled] function that can also handle disabled state through the boolean argument.
@@ -25,6 +26,8 @@ fun isChecked(isChecked: Boolean): Matcher<View> = maybeInvertMatcher(espressoIs
  * The [espressoIsSelected] function that can also handle not selected state through the boolean argument.
  */
 fun isSelected(isSelected: Boolean): Matcher<View> = maybeInvertMatcher(espressoIsSelected(), isSelected)
+
+fun hasFocus(hasFocus: Boolean): Matcher<View> = maybeInvertMatcher(espressoHasFocus(), hasFocus)
 
 private fun maybeInvertMatcher(matcher: Matcher<View>, useUnmodifiedMatcher: Boolean): Matcher<View> = when {
     useUnmodifiedMatcher -> matcher

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/ext/ViewInteraction.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/ext/ViewInteraction.kt
@@ -10,6 +10,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import org.mozilla.tv.firefox.helpers.isChecked
 import org.mozilla.tv.firefox.helpers.isEnabled
 import org.mozilla.tv.firefox.helpers.isSelected
+import org.mozilla.tv.firefox.helpers.hasFocus
 
 fun ViewInteraction.click(): ViewInteraction = this.perform(ViewActions.click())!!
 
@@ -23,4 +24,8 @@ fun ViewInteraction.assertIsChecked(isChecked: Boolean): ViewInteraction {
 
 fun ViewInteraction.assertIsSelected(isSelected: Boolean): ViewInteraction {
     return this.check(matches(isSelected(isSelected)))!!
+}
+
+fun ViewInteraction.assertHasFocus(hasFocus: Boolean): ViewInteraction {
+    return this.check(matches(hasFocus(hasFocus)))
 }

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/BasicNavigationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/BasicNavigationTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.tv.firefox.ui
 
+import android.net.Uri
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertNotEquals
 import org.junit.Ignore
@@ -132,6 +133,16 @@ class BasicNavigationTest {
         navigationOverlay {
             remoteBack()
             assertActivityFinishing(activityTestRule)
+        }
+    }
+    @Test
+    fun screenNavigationFocusTest() {
+        navigationOverlay {
+        }.enterUrlAndEnterToBrowser(Uri.parse("firefox:about")) {
+        }.openOverlay {
+        // Navigate to settings via keypresses, to maintain focus.
+        }.linearNavigateToSettingsAndOpen {
+            assertDataCollectionButtonFocused()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/NavigationOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/NavigationOverlayRobot.kt
@@ -42,7 +42,6 @@ class NavigationOverlayRobot {
     fun goForward() = forwardButton().click()
     fun reload() = reloadButton().click()
     fun toggleTurbo() = turboButton().click()
-    fun openSettings() = settingsButton().click()
 
     fun assertCanGoBack(canGoBack: Boolean) = backButton().assertIsEnabled(canGoBack)
     fun assertCanGoForward(canGoForward: Boolean) = forwardButton().assertIsEnabled(canGoForward)
@@ -118,6 +117,28 @@ class NavigationOverlayRobot {
 
         fun openSettings(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
             settingsButton().click()
+
+            SettingsRobot().interact()
+            return SettingsRobot.Transition()
+        }
+
+        /*
+         * Navigate to the settings button using keypresses and open, and maintain focus.
+         * Using click() to select buttons removes focus, so this is an alternative way to open
+         * Settings.
+         */
+        fun linearNavigateToSettingsAndOpen(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            // We hard-code this navigiation pattern because making a generic way to linearly navigate
+            // is very difficult within Espresso. Espresso supports asserting view state, but not
+            // querying it. Because of this, we can't write conditional logic based on the currently
+            // focused view.
+            device.apply {
+                // This will need to change if the button layout changes. However, such layout
+                // changes are infrequent, and updating this will be easy.
+                pressDPadUp()
+                repeat(5) { pressDPadRight() }
+                pressDPadCenter()
+            }
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/SettingsRobot.kt
@@ -7,7 +7,10 @@ package org.mozilla.tv.firefox.ui.robots
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import org.mozilla.tv.firefox.R
+import org.mozilla.tv.firefox.helpers.ext.assertHasFocus
 import org.mozilla.tv.firefox.helpers.ext.assertIsChecked
 import org.mozilla.tv.firefox.helpers.ext.click
 
@@ -15,6 +18,7 @@ import org.mozilla.tv.firefox.helpers.ext.click
  * Implementation of Robot Pattern for the settings page.
  */
 class SettingsRobot {
+    private val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     fun toggleDataCollectionButton() {
         dataCollectionButton().click()
     }
@@ -25,6 +29,10 @@ class SettingsRobot {
 
     fun assertDataCollectionButtonState(isChecked: Boolean) {
         dataCollectionButton().assertIsChecked(isChecked)
+    }
+
+    fun assertDataCollectionButtonFocused() {
+        dataCollectionButtonContainer().assertHasFocus(true)
     }
 
     class Transition {

--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -34,7 +34,6 @@ import org.mozilla.tv.firefox.utils.URLs
 import org.mozilla.tv.firefox.utils.ViewUtils
 import org.mozilla.tv.firefox.utils.publicsuffix.PublicSuffix
 import org.mozilla.tv.firefox.webrender.VideoVoiceCommandMediaSession
-import org.mozilla.tv.firefox.webrender.WebRenderFragment
 import org.mozilla.tv.firefox.widget.InlineAutocompleteEditText
 
 interface MediaSessionHolder {
@@ -219,21 +218,10 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         val fragmentManager = supportFragmentManager
 
-        val maybeBrowserFragment = (fragmentManager.findFragmentByTag(WebRenderFragment.FRAGMENT_TAG)
-                as WebRenderFragment?)?.let {
-            if (it.isVisible) it else null
-        }
         TelemetryIntegration.INSTANCE.saveRemoteControlInformation(applicationContext, event)
 
-        if (event.keyCode == KeyEvent.KEYCODE_MENU) {
-            if (event.action == KeyEvent.ACTION_DOWN) {
-                serviceLocator.screenController.handleMenu(supportFragmentManager)
-            }
-            return true
-        }
-
         return videoVoiceCommandMediaSession.dispatchKeyEvent(event) ||
-                (maybeBrowserFragment?.dispatchKeyEvent(event) ?: false) ||
+                serviceLocator.screenController.dispatchKeyEvent(event, fragmentManager) ||
                 super.dispatchKeyEvent(event)
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -125,7 +125,6 @@ class ScreenController {
     private fun fragmentManagerShowNavigationOverlay(fragmentManager: FragmentManager, toShow: Boolean) {
         val transaction = fragmentManager.beginTransaction()
         val overlayFragment = fragmentManager.navigationOverlayFragment()
-        val renderFragment = fragmentManager.webRenderFragment()
 
         if (toShow) {
             // If a user navigates to YouTube while a video is fullscreened, it will cause YouTube
@@ -146,7 +145,6 @@ class ScreenController {
         } else {
             transaction.hide(overlayFragment)
             MenuInteractionMonitor.menuClosed()
-            renderFragment.view?.requestFocus()
         }
 
         transaction.commit()

--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.MutableLiveData
 import android.content.Context
 import androidx.fragment.app.FragmentManager
 import android.text.TextUtils
+import android.view.KeyEvent
 import kotlinx.android.synthetic.main.fragment_navigation_overlay.*
 import mozilla.components.browser.session.Session
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.ActiveScreen
@@ -150,6 +151,19 @@ class ScreenController {
         transaction.commit()
     }
 
+    fun dispatchKeyEvent(keyEvent: KeyEvent, fragmentManager: FragmentManager): Boolean {
+        val keyMenuDown = keyEvent.keyCode == KeyEvent.KEYCODE_MENU && keyEvent.action == KeyEvent.ACTION_DOWN
+        if (keyMenuDown) {
+            return handleMenu(fragmentManager)
+        }
+
+        val webRenderIsActive = currentActiveScreen.value == ScreenControllerStateMachine.ActiveScreen.WEB_RENDER
+        if (webRenderIsActive) {
+            if (fragmentManager.webRenderFragment().dispatchKeyEvent(keyEvent)) return true
+        }
+        return false
+    }
+
     fun handleBack(fragmentManager: FragmentManager): Boolean {
         val webRenderFragment = fragmentManager.webRenderFragment()
         if (_currentActiveScreen.value == ActiveScreen.WEB_RENDER) {
@@ -159,9 +173,9 @@ class ScreenController {
         return handleTransitionAndUpdateActiveScreen(fragmentManager, transition)
     }
 
-    fun handleMenu(fragmentManager: FragmentManager) {
+    fun handleMenu(fragmentManager: FragmentManager): Boolean {
         val transition = ScreenControllerStateMachine.getNewStateMenuPress(_currentActiveScreen.value!!, isOnHomeUrl(fragmentManager))
-        handleTransitionAndUpdateActiveScreen(fragmentManager, transition)
+        return handleTransitionAndUpdateActiveScreen(fragmentManager, transition)
     }
 
     private fun isOnHomeUrl(fragmentManager: FragmentManager): Boolean {

--- a/app/src/main/java/org/mozilla/tv/firefox/architecture/FocusOnShowDelegate.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/architecture/FocusOnShowDelegate.kt
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.architecture
+
+import androidx.fragment.app.Fragment
+
+class FocusOnShowDelegate {
+    fun onHiddenChanged(fragment: Fragment, hidden: Boolean) {
+        if (!hidden) {
+            fragment.view?.requestFocus()
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/tv/firefox/components/locale/LocaleAwareFragment.java
+++ b/app/src/main/java/org/mozilla/tv/firefox/components/locale/LocaleAwareFragment.java
@@ -5,7 +5,6 @@
 package org.mozilla.tv.firefox.components.locale;
 
 import java.util.Locale;
-
 import androidx.fragment.app.Fragment;
 
 public abstract class LocaleAwareFragment extends Fragment {

--- a/app/src/main/java/org/mozilla/tv/firefox/components/locale/LocaleAwareFragment.java
+++ b/app/src/main/java/org/mozilla/tv/firefox/components/locale/LocaleAwareFragment.java
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 package org.mozilla.tv.firefox.components.locale;
 
-import androidx.fragment.app.Fragment;
-
 import java.util.Locale;
+
+import androidx.fragment.app.Fragment;
 
 public abstract class LocaleAwareFragment extends Fragment {
     private Locale cachedLocale = null;

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.Job
 import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.architecture.FirefoxViewModelProviders
+import org.mozilla.tv.firefox.architecture.FocusOnShowDelegate
 import org.mozilla.tv.firefox.experiments.ExperimentConfig
 import org.mozilla.tv.firefox.ext.forceExhaustive
 import org.mozilla.tv.firefox.ext.isEffectivelyVisible
@@ -211,6 +212,11 @@ class NavigationOverlayFragment : Fragment() {
     override fun onStop() {
         super.onStop()
         compositeDisposable.clear()
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        FocusOnShowDelegate().onHiddenChanged(this, hidden)
+        super.onHiddenChanged(hidden)
     }
 
     private fun exitFirefox() {

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.StrictMode
-import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -24,7 +23,6 @@ import kotlinx.android.synthetic.main.fragment_pocket_video.pocketHelpButton
 import kotlinx.android.synthetic.main.fragment_pocket_video.pocketWordmarkView
 import kotlinx.android.synthetic.main.fragment_pocket_video.videoFeed
 import mozilla.components.support.ktx.android.os.resetAfter
-import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.architecture.FirefoxViewModelProviders
 import org.mozilla.tv.firefox.architecture.FocusOnShowDelegate

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
@@ -27,6 +27,7 @@ import mozilla.components.support.ktx.android.os.resetAfter
 import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.architecture.FirefoxViewModelProviders
+import org.mozilla.tv.firefox.architecture.FocusOnShowDelegate
 import org.mozilla.tv.firefox.ext.forceExhaustive
 import org.mozilla.tv.firefox.ext.serviceLocator
 import org.mozilla.tv.firefox.ext.updateLayoutParams
@@ -81,6 +82,11 @@ class PocketVideoFragment : Fragment() {
     override fun onStop() {
         super.onStop()
         compositeDisposable.clear()
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        FocusOnShowDelegate().onHiddenChanged(this, hidden)
+        super.onHiddenChanged(hidden)
     }
 
     // When menu is pressed from the Pocket feed, go back to overlay

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFragment.kt
@@ -88,24 +88,12 @@ class PocketVideoFragment : Fragment() {
         FocusOnShowDelegate().onHiddenChanged(this, hidden)
         super.onHiddenChanged(hidden)
     }
-
-    // When menu is pressed from the Pocket feed, go back to overlay
-    fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        return when (event.keyCode) {
-            KeyEvent.KEYCODE_MENU -> {
-                (activity as MainActivity).dispatchKeyEvent(KeyEvent(event.action, KeyEvent.KEYCODE_BACK))
-                true
-            }
-            else -> false
-        }
-    }
 }
 
 private class PocketVideoAdapter(
     context: Context,
     private val fragmentManager: FragmentManager
 ) : RecyclerView.Adapter<PocketVideoViewHolder>() {
-
     private val pocketVideos = mutableListOf<PocketViewModel.FeedItem>()
 
     private val photonGrey70 = ContextCompat.getColor(context, R.color.photonGrey70)

--- a/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
@@ -7,14 +7,15 @@ package org.mozilla.tv.firefox.settings
 import android.app.AlertDialog
 import androidx.lifecycle.Observer
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_settings.*
 import kotlinx.android.synthetic.main.fragment_settings.view.*
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.architecture.FirefoxViewModelProviders
+import org.mozilla.tv.firefox.architecture.FocusOnShowDelegate
 import org.mozilla.tv.firefox.ext.forceExhaustive
 import org.mozilla.tv.firefox.ext.serviceLocator
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
@@ -41,6 +42,11 @@ class SettingsFragment : Fragment() {
             setupSettingsViewModel(view, settingsVM)
         }
         return view
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        FocusOnShowDelegate().onHiddenChanged(this, hidden)
+        super.onHiddenChanged(hidden)
     }
 
     private fun setupSettingsViewModel(parentView: View, settingsViewModel: SettingsViewModel) {

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -24,6 +24,7 @@ import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.MediaSessionHolder
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.ActiveScreen
+import org.mozilla.tv.firefox.architecture.FocusOnShowDelegate
 import org.mozilla.tv.firefox.ext.focusedDOMElement
 import org.mozilla.tv.firefox.ext.isYoutubeTV
 import org.mozilla.tv.firefox.ext.pauseAllVideoPlaybacks
@@ -172,6 +173,11 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
         cursor = null
 
         sessionFeature = null
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        FocusOnShowDelegate().onHiddenChanged(this, hidden)
+        super.onHiddenChanged(hidden)
     }
 
     fun onBackPressed(): Boolean {


### PR DESCRIPTION
Closes #1888 
Fixed the fragment focus test problem - apparently `click()` doesn't maintain focus, so a keypress solution was necessary.

~~Also, this doesn't maintain "previous button focus on return to overlay".~~ Actually, we removed cached focus when returning to overlay in the re-architecture.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
- [X] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [X] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
