### PR TITLE
No issue: Version bump and changelog for 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+
+### Fixed
+
+## [3.5-RO] 2019-03-12
+*Released to Fire TV 4K, staged roll-out*
+### Added
+
+### Changed
 - Updated dependencies to AndroidX
 
 ### Fixed
 - Bug where you could not use remote back button to exit YouTube if it was visited from Pocket (#1584)
 - Fixed 4K YT bug (#277)
-
-## [3.4.1] 2019-02-12
-*Released to Fire TV 4K.*
-### Added
-
-### Changed
-
-### Fixed
 - Bug where cursor would disappear if on overlay during page load finish (#1732)
 - Bug that could cause a crash on startup (#1778)
 - Fixed links on settings About page that did not load (#1731)
@@ -28,10 +28,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed bug that could cause YouTube to display vertically offset from where it should be (#1719)
 - Bug that could cause YouTube to be unresponsive if the overlay was opened during loading (#1830)
 
-## [3.4] - 2019-02-12
-*Released to all devices except Fire TV 4K.*
+## [3.4-B] - 2019-03-12
+*Version bump only, no change from v3.4-A. Released to all devices except Fire TV 4K*
 
-Second stage rollout of 3.3.1 to all devices - version-bump of v3.3.1
+## [3.4-A] - 2019-02-12
+*Released to all devices*
+Rollback to 3.1.3 (same as 3.2.5) due to 4k bug and other regressions. Version bump only.
 
 ## [3.3.1] - 2019-02-04
 *Released to Fire TV 4K.*
@@ -45,8 +47,8 @@ Second stage rollout of 3.3.1 to all devices - version-bump of v3.3.1
 - Fixed mismatch between internal and display state after clearing data (#1691)
 
 ## [3.3] - 2019-02-04
-*Released to all devices except Fire TV 4K.*  
-  
+*Released to all devices except Fire TV 4K.*
+
 Version-bump only - no change from v3.2.5
 
 ## [3.2.5] - 2019-01-16
@@ -194,9 +196,9 @@ The CHANGELOG entries for the releases listed below this were added retroactivel
 ## [1.0] - 2017-12-20
 *Initial release! A browser including home tile shortcuts.*
 
-[Unreleased]: https://github.com/mozilla-mobile/firefox-tv/compare/v3.4.1...HEAD
-[3.4.1]: https://github.com/mozilla-mobile/firefox-tv/compare/v3.4...v3.4.1
-[3.4]: https://github.com/mozilla-mobile/firefox-tv/compare/v3.3.1...v3.4
+[Unreleased]: https://github.com/mozilla-mobile/firefox-tv/compare/v3.5-RO...HEAD
+[3.5-RO]: https://github.com/mozilla-mobile/firefox-tv/compare/v3.4-A...v3.5-RO
+[3.4-A]: https://github.com/mozilla-mobile/firefox-tv/compare/v3.3.1...v3.4-A
 [3.3.1]: https://github.com/mozilla-mobile/firefox-tv/compare/v3.3...v3.3.1
 [3.3]: https://github.com/mozilla-mobile/firefox-tv/compare/v3.2.5...v3.3
 [3.2.5]: https://github.com/mozilla-mobile/firefox-tv/compare/v3.2.2...v3.2.5

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
         targetSdkVersion 28
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
         // override this with a generated versionCode at build time.
-        versionName "3.4.1-LAT1"
+        versionName "3.5-LAT1"
         testInstrumentationRunner "org.mozilla.tv.firefox.FirefoxTestRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
 


### PR DESCRIPTION
This includes some additional changes to reflect that we didn't actually ship 3.4.1 as intended, but just re-released 3.1.3 as 3.4-A. Also includes intended 3.5-RO release and re-release of 3.4-B.

For naming documentation, see wiki: https://github.com/mozilla-mobile/firefox-tv/wiki/Releng-Checklist

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
