### PR TITLE
Issue #1921: Use `substitute-local-geckoview.gradle` from Bug 1533465…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,7 +147,7 @@ dependencies {
     // Required to override android.support lib in GeckoView dependency (uses palette-v7:26.1.0)
     geckoImplementation "androidx.palette:palette:$androidx_version"
     geckoImplementation "org.mozilla.components:browser-engine-gecko-nightly:$moz_components_version"
-    geckoImplementation Gecko.geckoview_nightly_arm
+    geckoImplementation "${Gecko.geckoview_nightly_arm}@aar"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 

--- a/build.gradle
+++ b/build.gradle
@@ -82,3 +82,9 @@ task ktlint(type: JavaExec, group: "verification") {
     main = "com.github.shyiko.ktlint.Main"
     args "**/*.kt"
 }
+
+// // To substitute a local GeckoView, uncomment and update the following line:
+// ext.topsrcdir = '/absolute/path/to/mozilla-central'
+// // And optionally, the following line:
+// ext.topobjdir = '/absolute/path/to/topobjdir'
+// apply from: "${ext.topsrcdir}/substitute-local-geckoview.gradle"


### PR DESCRIPTION
… for local GeckoView substitution.

See discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1533465.

This can land before Bug 1533465, since there's no existing support for this.  We may want to build more support for this in, i.e., parse `local.properties` to find substitution paths rather than requiring changes to `build.gradle`.  But that can be follow-up: it would be best to do that with a shared plugin, rather than with a script like this.

Closes #1921