### PR TITLE
1916 fix back from webpage exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Fixed
+- Bug where you could not use remote back button to exit YouTube if it was visited from Pocket (#1584)
+- Fixed 4K YT bug (#277)
+- Backing from the navigation overlay when on the first site in your backstack will now properly exit the app (#1916)
 
 ## [3.5-RO] 2019-03-12
 *Released to Fire TV 4K, staged roll-out*

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/ext/ViewInteraction.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/ext/ViewInteraction.kt
@@ -7,6 +7,8 @@ package org.mozilla.tv.firefox.helpers.ext
 import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import org.hamcrest.CoreMatchers.not
 import org.mozilla.tv.firefox.helpers.isChecked
 import org.mozilla.tv.firefox.helpers.isEnabled
 import org.mozilla.tv.firefox.helpers.isSelected
@@ -28,4 +30,11 @@ fun ViewInteraction.assertIsSelected(isSelected: Boolean): ViewInteraction {
 
 fun ViewInteraction.assertHasFocus(hasFocus: Boolean): ViewInteraction {
     return this.check(matches(hasFocus(hasFocus)))
+}
+
+fun ViewInteraction.assertIsDisplayed(displayed: Boolean = true): ViewInteraction {
+    return when (displayed) {
+        true -> this.check(matches(isDisplayed()))
+        false -> this.check(matches(not(isDisplayed())))
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/BasicNavigationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/BasicNavigationTest.kt
@@ -128,6 +128,7 @@ class BasicNavigationTest {
             assertNotEquals(preReloadTitle, getPageTitle())
         }
     }
+
     @Test
     fun exitAppByBackButtonTest() {
         navigationOverlay {
@@ -135,6 +136,24 @@ class BasicNavigationTest {
             assertActivityFinishing(activityTestRule)
         }
     }
+
+    @Test
+    fun navigateThenExitAppByBackButtonTest() {
+        val server = MockWebServer().apply {
+            setDispatcher(AndroidAssetDispatcher())
+            start()
+        }
+
+        val pages = TestAssetHelper.getGenericAssets(server)
+
+        navigationOverlay {
+        }.enterUrlAndEnterToBrowser(pages.first().url) {
+        }.backButtonToOverlay {
+            remoteBack()
+            assertActivityFinishing(activityTestRule)
+        }
+    }
+
     @Test
     fun screenNavigationFocusTest() {
         navigationOverlay {

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/BrowserRobot.kt
@@ -54,6 +54,19 @@ class BrowserRobot {
             NavigationOverlayRobot().interact()
             return NavigationOverlayRobot.Transition()
         }
+
+        /**
+         * Will fail if pressing the back button does not open the overlay
+         */
+        fun backButtonToOverlay(interact: NavigationOverlayRobot.() -> Unit): NavigationOverlayRobot.Transition {
+            device.pressBack()
+
+            NavigationOverlayRobot().apply {
+                assertOverlayIsOpen()
+                interact()
+            }
+            return NavigationOverlayRobot.Transition()
+        }
     }
 }
 

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/NavigationOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/robots/NavigationOverlayRobot.kt
@@ -26,6 +26,7 @@ import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.helpers.MainActivityTestRule
 import org.mozilla.tv.firefox.helpers.RecyclerViewHelpers
 import org.mozilla.tv.firefox.helpers.ext.assertIsChecked
+import org.mozilla.tv.firefox.helpers.ext.assertIsDisplayed
 import org.mozilla.tv.firefox.helpers.ext.assertIsEnabled
 import org.mozilla.tv.firefox.helpers.ext.assertIsSelected
 import org.mozilla.tv.firefox.helpers.ext.click
@@ -42,6 +43,10 @@ class NavigationOverlayRobot {
     fun goForward() = forwardButton().click()
     fun reload() = reloadButton().click()
     fun toggleTurbo() = turboButton().click()
+
+    // The implementation of this method is arbitrary. We could run this check
+    // against any of its views
+    fun assertOverlayIsOpen() = urlBar().assertIsDisplayed()
 
     fun assertCanGoBack(canGoBack: Boolean) = backButton().assertIsEnabled(canGoBack)
     fun assertCanGoForward(canGoForward: Boolean) = forwardButton().assertIsEnabled(canGoForward)

--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenControllerStateMachine.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenControllerStateMachine.kt
@@ -35,13 +35,13 @@ object ScreenControllerStateMachine {
         }
     }
 
-    fun getNewStateBackPress(currentActiveScreen: ActiveScreen, isUrlHome: Boolean): Transition {
+    fun getNewStateBackPress(currentActiveScreen: ActiveScreen, canGoBack: Boolean): Transition {
         return when (currentActiveScreen) {
             ActiveScreen.NAVIGATION_OVERLAY -> {
-                return if (isUrlHome) {
-                    Transition.EXIT_APP
-                } else {
+                return if (canGoBack) {
                     Transition.REMOVE_OVERLAY
+                } else {
+                    Transition.EXIT_APP
                 }
             }
             ActiveScreen.WEB_RENDER -> { // The browser handles webview back presses first

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -72,7 +72,7 @@ open class ServiceLocator(val app: Application) {
     val turboMode: TurboMode by lazy { TurboMode(app) }
     val pocketRepoCache by lazy { PocketRepoCache(pocketRepo) }
     val viewModelFactory by lazy { ViewModelFactory(this, app) }
-    val screenController by lazy { ScreenController() }
+    val screenController by lazy { ScreenController(sessionRepo) }
     val engineViewCache by lazy { EngineViewCache(sessionRepo) }
     val sessionManager get() = app.webRenderComponents.sessionManager
     val sessionUseCases get() = app.webRenderComponents.sessionUseCases

--- a/app/src/test/java/org/mozilla/tv/firefox/ScreenControllerStateMachineTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/ScreenControllerStateMachineTest.kt
@@ -12,17 +12,17 @@ import org.mozilla.tv.firefox.ScreenControllerStateMachine.Transition.REMOVE_OVE
 class ScreenControllerStateMachineTest {
 
     @Test
-    fun `GIVEN overlay is active and url is home WHEN back is pressed THEN emit exit_app`() {
+    fun `GIVEN overlay is active and no previous sites are in the backstack WHEN back is pressed THEN emit exit_app`() {
         val currentActiveScreen = NAVIGATION_OVERLAY
-        val currentUrlIsHome = true
-        assertEquals(EXIT_APP, ScreenControllerStateMachine.getNewStateBackPress(currentActiveScreen, currentUrlIsHome))
+        val canGoBack = false
+        assertEquals(EXIT_APP, ScreenControllerStateMachine.getNewStateBackPress(currentActiveScreen, canGoBack))
     }
 
     @Test
-    fun `GIVEN overlay is active and url is not home WHEN back is pressed THEN emit remove_overlay`() {
+    fun `GIVEN overlay is active and previous sites are in the backstack WHEN back is pressed THEN emit remove_overlay`() {
         val currentActiveScreen = NAVIGATION_OVERLAY
-        val currentUrlIsHome = false
-        assertEquals(REMOVE_OVERLAY, ScreenControllerStateMachine.getNewStateBackPress(currentActiveScreen, currentUrlIsHome))
+        val canGoBack = true
+        assertEquals(REMOVE_OVERLAY, ScreenControllerStateMachine.getNewStateBackPress(currentActiveScreen, canGoBack))
     }
 
     @Test


### PR DESCRIPTION
Closes #1916 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [X] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
