### PR TITLE
Closes #1865 - Workaround for grey screen on Youtube resume.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed 4K YT bug (#277)
 - Backing from the navigation overlay when on the first site in your backstack will now properly exit the app (#1916)
 - Fixed Youtube back bug (#1939)
+- Workaround for "grey screen" when returning to YouTube from Amazon homescreen (#1865)
 
 ## [3.5-RO] 2019-03-12
 *Released to Fire TV 4K, staged roll-out*
@@ -31,6 +32,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - A memory leak (#1628)
 - Fixed bug that could cause YouTube to display vertically offset from where it should be (#1719)
 - Bug that could cause YouTube to be unresponsive if the overlay was opened during loading (#1830)
+- Fixed Youtube back bug (#1939)
+- Workaround for "grey screen" when returning to YouTube from Amazon homescreen (#1865)
+- Backing from the navigation overlay when on the first site in your backstack will now properly exit the app (#1916)
 
 ## [3.4-B] - 2019-03-12
 *Version bump only, no change from v3.4-A. Released to all devices except Fire TV 4K*

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.tv.firefox.webrender
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
@@ -15,6 +16,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import kotlinx.android.synthetic.main.fragment_browser.view.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.permission.Permission
@@ -73,6 +78,19 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initSession()
+    }
+
+    @SuppressLint("RestrictedApi")
+    override fun onResume() {
+        super.onResume()
+        if (session.isYoutubeTV) {
+            // Send key events on the UI thread to clear webview grey screen, see #1865
+            GlobalScope.launch(Dispatchers.Main) {
+                delay(50)
+                activity?.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT))
+                activity?.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_LEFT))
+            }
+        }
     }
 
     private fun initSession() {

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -16,10 +16,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import kotlinx.android.synthetic.main.fragment_browser.view.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.permission.Permission
@@ -84,12 +80,7 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
     override fun onResume() {
         super.onResume()
         if (session.isYoutubeTV) {
-            // Send key events on the UI thread to clear webview grey screen, see #1865
-            GlobalScope.launch(Dispatchers.Main) {
-                delay(50)
-                activity?.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT))
-                activity?.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_LEFT))
-            }
+            YoutubeGreyScreenWorkaround.invoke(activity)
         }
     }
 

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/YoutubeGreyScreenWorkaround.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/YoutubeGreyScreenWorkaround.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.webrender
+
+import android.app.Activity
+import android.view.KeyEvent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Workaround fix for intermittent grey screen that shows instead of WebView when returning to
+ * YouTube from the home screen, see #1865. Follow-up investigation in #1940.
+ *
+ * This fix sends navigation key events on the UI thread to dispel the grey screen.
+ *
+ * Other failed attempted workarounds:
+ * - Calling engineView.resume to trigger the webview to "load" from grey screen
+ * - Scrolling webview
+ * - Sending non-view-changing key events
+ */
+object YoutubeGreyScreenWorkaround {
+    fun invoke(activity: Activity?) {
+        GlobalScope.launch(Dispatchers.Main) {
+            delay(50)
+            activity?.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT))
+            activity?.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_LEFT))
+        }
+    }
+}


### PR DESCRIPTION
This is a workaround for getting Youtube to not grey-screen that sends keypress events. Unfortunately, other no-op keypresses don't seem to work - maybe it's something that requires a repaint?
Could not repro this with 30 tries.

This requires a SuppressLint because of an Android bug: https://issuetracker.google.com/issues/37130193#comment21
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
- [X] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [X] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
