### PR TITLE
Closes #1946: Remove blocklist/entitylist generation build code.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -211,35 +211,6 @@ android.applicationVariants.all { variant ->
 }
 
 // -------------------------------------------------------------------------------------------------
-// Generate blocklists
-// -------------------------------------------------------------------------------------------------
-
-def blockListOutputDir = 'src/amazonWebview/res/raw'
-
-task buildBlocklists(type:Copy) {
-    from('../shavar-prod-lists') {
-        include '*.json'
-    }
-    into blockListOutputDir
-
-    // Android can't handle dashes in the filename, so we need to rename:
-    rename 'disconnect-blacklist.json', 'blocklist.json'
-    rename 'disconnect-entitylist.json', 'entitylist.json'
-    // google_mapping.json already has an expected name
-}
-
-clean.doLast {
-    file(blockListOutputDir).deleteDir()
-}
-
-tasks.whenTaskAdded { task ->
-    def name = task.name
-    if (name.contains("generate") && name.contains("Config") && name.contains("Webview")) {
-        task.dependsOn buildBlocklists
-    }
-}
-
-// -------------------------------------------------------------------------------------------------
 // Secrets: add API secrets from config files into the BuildConfig instance.
 // We use files because they're easier to manage than environment variables.
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The code using this generate artifacts was removed in
996999eff452913a4347948785cf655417db483a.

I verified this was still working after the patch by enabling turbo
mode on rottentomatoes and verifying the ads were missing.

Gradle! 🐘 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Build code change
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedSystemDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
