### PR TITLE
Closes #1967, add l10n.toml 🔄

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+basepath = "."
+
+locales = [
+    "de",
+    "es-ES",
+    "fr",
+    "it",
+    "ja",
+    "pt-BR",
+    "zh-CN",
+]
+
+# Expose the following branches to localization
+# Changes to this list should be announced to the l10n team ahead of time.
+branches = [
+    "master",
+]
+
+[env]
+
+[[paths]]
+  reference = "app/src/main/res/values/strings.xml"
+  l10n = "app/src/main/res/values-{android_locale}/strings.xml"


### PR DESCRIPTION
This is only a configuration change, to be used by the upcoming l10n ecosystem. Thus not tests or changelogs or QA tags on this one.

### Pull Request checklist
- [X] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
- [X] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
