### PR TITLE
Send better logs for ExperimentsProvider fallback

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentExceptions.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentExceptions.kt
@@ -11,3 +11,11 @@ package org.mozilla.tv.firefox.experiments
  * considered an illegal experiment state
  */
 open class ExperimentIllegalStateException(message: String) : IllegalStateException(message)
+
+/**
+ * [NotInExperimentException] is for logging users that are currently not part of an
+ * Experiment
+ *
+ * @param name: Name of the experiment
+ */
+open class NotInExperimentException(name: String) : Exception(name)

--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentExceptions.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentExceptions.kt
@@ -16,6 +16,11 @@ open class ExperimentIllegalStateException(message: String) : IllegalStateExcept
  * [NotInExperimentException] is for logging users that are currently not part of an
  * Experiment
  *
+ * Our current implementation for [FretboardProvider.loadExperiments] and
+ * [FretboardProvider.updateExperiments] are not synchronized. This is causing some of the
+ * new users to be not part of an experiment (even though they should be) in the initial
+ * launch (restarting the app would have you properly sync'd up) - #1978
+ *
  * @param name: Name of the experiment
  */
 open class NotInExperimentException(name: String) : Exception(name)

--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
@@ -39,6 +39,7 @@ class ExperimentsProvider(private val fretboard: Fretboard, private val context:
             }
         } else {
             // The user is currently not part of the experiment
+            Sentry.capture(NotInExperimentException("AAExperiment"))
             context.resources.getString(R.string.exit_firefox_a11y,
                 context.resources.getString(R.string.firefox_tv_brand_name_short))
         }

--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
@@ -51,13 +51,17 @@ class ExperimentsProvider(private val fretboard: Fretboard, private val context:
      * Return null otherwise
      */
     private fun checkBranchVariants(expConfig: ExperimentConfig): ExperimentDescriptor? {
-        var expDescriptor: ExperimentDescriptor? = null
+        var expDescriptor: ExperimentDescriptor?
 
         for (suffix in ExperimentSuffix.values()) {
             expDescriptor = ExperimentDescriptor(expConfig.value + ":" + suffix.name)
-            if (fretboard.isInExperiment(context, expDescriptor)) break
+            if (fretboard.isInExperiment(context, expDescriptor)) {
+                // Correct experiment variant is found
+                return expDescriptor
+            }
         }
 
-        return expDescriptor
+        // No matching experiment, so return null
+        return null
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
@@ -52,10 +52,8 @@ class ExperimentsProvider(private val fretboard: Fretboard, private val context:
      * Return null otherwise
      */
     private fun checkBranchVariants(expConfig: ExperimentConfig): ExperimentDescriptor? {
-        var expDescriptor: ExperimentDescriptor?
-
         for (suffix in ExperimentSuffix.values()) {
-            expDescriptor = ExperimentDescriptor(expConfig.value + ":" + suffix.name)
+            val expDescriptor = ExperimentDescriptor(expConfig.value + ":" + suffix.name)
             if (fretboard.isInExperiment(context, expDescriptor)) {
                 // Correct experiment variant is found
                 return expDescriptor


### PR DESCRIPTION
Closes #1969

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
