### PR TITLE
Bug 1534764 - Restrict Taskcluster to PRs created by collaborators

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 version: 0
-allowPullRequests: public
+allowPullRequests: collaborators
 tasks:
 ###############################################################################
 # Task: Pull requests


### PR DESCRIPTION
https://docs.taskcluster.net/docs/reference/integrations/taskcluster-github/docs/taskcluster-yml-v0\#who-can-trigger-jobs-



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
