### PR TITLE
Make telemetry checkbox consistent in VoiceView on or off.

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
@@ -50,10 +50,6 @@ class SettingsFragment : Fragment() {
     }
 
     private fun setupSettingsViewModel(parentView: View, settingsViewModel: SettingsViewModel) {
-        settingsViewModel.isVoiceViewEnabled.observe(viewLifecycleOwner, Observer<Boolean> {
-            updateForAccessibility(it!!)
-        })
-
         settingsViewModel.dataCollectionEnabled.observe(viewLifecycleOwner, Observer<Boolean> { state ->
             parentView.telemetryButton.isChecked = state ?: return@Observer
         })
@@ -69,16 +65,10 @@ class SettingsFragment : Fragment() {
             }
         })
 
-        // Due to accessibility hack for #293, where we want to focus a different (visible) element
-        // for accessibility, either of these views could be unfocusable, so we need to set the
-        // click listener on both.
         parentView.telemetryButtonContainer.setOnClickListener {
             // Manually toggle the telemetry button from the container click
             telemetryButton.isChecked = !telemetryButton.isChecked
             settingsViewModel.setDataCollectionEnabled((telemetryButton.isChecked))
-        }
-        parentView.telemetryButton.setOnClickListener {
-            settingsViewModel.setDataCollectionEnabled(telemetryButton.isChecked)
         }
 
         parentView.deleteButton.setOnClickListener { _ ->
@@ -95,28 +85,6 @@ class SettingsFragment : Fragment() {
                     .setNegativeButton(
                             getString(R.string.action_cancel)) { dialog, _ -> dialog.cancel() }
                     .create().show()
-        }
-    }
-
-    /**
-     * Updates the views in this fragment based on Accessibility status.
-     * See the comment at the declaration of these views in XML for more details.
-     */
-    private fun updateForAccessibility(isVoiceViewEnabled: Boolean) {
-        // In order to read Accessibility text for the Telemetry checkbox WITH checked state,
-        // we need to focus the checkbox in VoiceView instead of the containing view.
-        //
-        // When we change VoiceView from enabled -> disabled and this setting is focused, focus is
-        // cleared from this setting and nothing is selected. This is fine: the user can press
-        // left-right to focus something else and it's an edge case that I don't think it is worth
-        // adding code to fix.
-        val shouldFocusButton = isVoiceViewEnabled
-        if (shouldFocusButton) {
-            // Clear focus so that focus passes to child telemetryButton view.
-            telemetryButtonContainer.isFocusable = false
-            telemetryButtonContainer.clearFocus()
-        } else {
-            telemetryButtonContainer.isFocusable = true
         }
     }
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -23,23 +23,6 @@
         android:layout_weight="1"
         android:layout_gravity="center">
 
-        <!-- a11y: we want to select the whole container when VoiceView is disabled. When VoiceView
-             is enabled, we want to announce, "TextView text, checkbox: (not) checked". However,
-             focusing the container will not announce the CheckBox state [1]. Therefore, we do the
-             following to focus the container without a11y and the CheckBox with a11y:
-             - Set the CheckBox important for a11y - in theroy, this makes it focusable with VoiceView
-             - Dynamically enable/disable focusable and change focus for the container when
-             VoiceView is enabled/disabled - the parent being focusable will prevent the children
-             from getting focused so, in practice, this makes the CheckBox focusable with VoiceView.
-             - Set the contentDescription of the CheckBox to the text of the TextView
-
-             Note: with VoiceView enabled, we sacrifice visual consistency (of which element is
-             highlighted) for functionality. I tried solutions that would avoid this using
-             AccessibiltyDelegate to override the parent announcements but they did not work with
-             VoiceView even though they worked with TalkBack. To save time, I implemented this instead.
-
-             [1]: Probably because in Android's view, the CheckBox can only change if it's directly
-             focused but we override that. -->
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -63,10 +46,9 @@
                 android:scaleType="fitCenter"
                 android:background="@drawable/telemetry_check_selector"
                 android:button="@null"
-                android:importantForAccessibility="yes"
-                android:contentDescription="@string/preference_mozilla_telemetry2"
+                android:focusable="false"
+                android:clickable="false"
                 android:layout_gravity="center"/>
-            <requestFocus/> <!-- Focuses CheckBox when a11y enabled, parent when not enabled. -->
         </LinearLayout>
 
         <LinearLayout


### PR DESCRIPTION
This removes a lot of the special accessibility code.

When the actual checkbox is non-interactive (not focusable or
clickable), its state is uttered when the cursor is on an ancestor node.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] ~This PR includes thorough **tests** or an explanation of why it does not~
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [ ] ~I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)~
