### PR TITLE
Use Review Mode in VoiceView on web sites.

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/architecture/ViewModelFactory.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/architecture/ViewModelFactory.kt
@@ -57,7 +57,6 @@ class ViewModelFactory(
             ) as T
 
             CursorViewModel::class.java -> CursorViewModel(
-                serviceLocator.frameworkRepo,
                 serviceLocator.screenController,
                 serviceLocator.sessionRepo
             ) as T

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/cursor/CursorViewModel.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/cursor/CursorViewModel.kt
@@ -37,7 +37,6 @@ const val DPAD_TAP_TIMEOUT = 300 // ViewConfiguration.TAP_TIMEOUT * 3
  * A [ViewModel] representing the spatial, d-pad cursor used to navigate web pages.
  */
 class CursorViewModel(
-    frameworkRepo: FrameworkRepo,
     screenController: ScreenController,
     sessionRepo: SessionRepo
 ) : ViewModel() {
@@ -49,21 +48,12 @@ class CursorViewModel(
             .fromPublisher(screenController.currentActiveScreen.toFlowable(BackpressureStrategy.LATEST))
 
     @Suppress("DEPRECATION")
-    private val isConfigurationWithOwnNavControls: LiveData<Boolean> = LiveDataCombiners.combineLatest(
-        frameworkRepo.isVoiceViewEnabled,
-        sessionRepo.legacyState
-    ) { isVoiceViewEnabled, sessionState ->
-        val isYouTubeTV = sessionState.currentUrl.isUriYouTubeTV
-        isYouTubeTV || isVoiceViewEnabled
-    }
-
-    // TODO: this complexly combines 3 streams by calling combineLatest twice: consider using a library instead #1783
     val isEnabled: LiveData<Boolean> = LiveDataCombiners.combineLatest(
-        isConfigurationWithOwnNavControls,
+        sessionRepo.legacyState,
         currentActiveScreen
-    ) { isConfigurationWithOwnNavControls, activeScreen ->
+    ) { sessionState, activeScreen ->
         val isWebRenderActive = activeScreen == WEB_RENDER
-        isWebRenderActive && !isConfigurationWithOwnNavControls
+        isWebRenderActive && !sessionState.currentUrl.isUriYouTubeTV
     }
 
     /**

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,6 +11,7 @@
             android:orientation="vertical"
             android:id="@+id/container_web_render"
             android:layout_width="match_parent"
+            android:importantForAccessibility="yes"
             android:layout_height="match_parent"/>
 
     <FrameLayout

--- a/app/src/test/java/org/mozilla/tv/firefox/webrender/cursor/CursorViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/webrender/cursor/CursorViewModelTest.kt
@@ -83,7 +83,7 @@ class CursorViewModelTest {
             `when`(it.legacyState).thenReturn(sessionState)
         }
 
-        viewModel = CursorViewModel(frameworkRepo, screenController, sessionRepo)
+        viewModel = CursorViewModel(screenController, sessionRepo)
     }
 
     // This method pattern is duplicated but it's significantly more readable this way.


### PR DESCRIPTION
If we would typically show a cursor for a web site (ie. not youtube), we
should add a special annotation to tell VoiceView to use Review Mode.

This matches how Silk works in web content.

I spent a whole day trying to figure out the ReactiveX stuff and the general architecture. I'm sure there is somewhere better for this change. Or at least tests. I didn't have any luck writing tests against the view with LiveData as input.

So I'm putting this here, hoping someone can review it and give me some direction - or better, take this over.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
