### PR TITLE
Closes #2040: disable block autoplay when using geckoview

### DIFF
--- a/app/src/gecko/java/org/mozilla/tv/firefox/webrender/WebRenderComponents.kt
+++ b/app/src/gecko/java/org/mozilla/tv/firefox/webrender/WebRenderComponents.kt
@@ -50,6 +50,7 @@ class WebRenderComponents(applicationContext: Context, systemUserAgent: String) 
                 runtimeSettingsBuilder.extras(extras)
             }
         }
+        runtimeSettingsBuilder.autoplayDefault(GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED)
 
         val runtime = GeckoRuntime.create(applicationContext,
                 runtimeSettingsBuilder.build())


### PR DESCRIPTION
Block autoplay is unintentionally not disabled when using GeckoView.
If you look, you'll see autoplay blocking is attempted to be disabled
when using the system webview settings further down, but GeckoView
doesn't honor those settings; there's a GeckoView setting which
needs to be set to disable autoplay blocking.

It's not clear to me how to write a test for the behaviour of web content with firefox-tv.

I don't think this requires a changelog entry, as this issue only affects GeckoView.

I don't think this requires QA, as this issue only affects GeckoView.

