### PR TITLE
Closes 2095: fix Pocket timeout exceptions

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketEndpoint.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketEndpoint.kt
@@ -20,6 +20,7 @@ import org.mozilla.tv.firefox.utils.Endpoint
 import org.mozilla.tv.firefox.utils.OkHttpWrapper
 import org.mozilla.tv.firefox.utils.Response
 import java.io.IOException
+import java.util.concurrent.TimeoutException
 
 private const val LOGTAG = "PocketEndpoint"
 
@@ -94,6 +95,10 @@ private object PocketEndpointRaw {
             OkHttpWrapper.client.newCall(req).executeAndAwait()
         } catch (e: IOException) {
             Log.w(LOGTAG, "getGlobalVideoRecommendations: network error")
+            Log.w(LOGTAG, e)
+            return null
+        } catch (e: TimeoutException) {
+            Log.w(LOGTAG, "getGlobalVideoRecommendations: timed out")
             Log.w(LOGTAG, e)
             return null
         }


### PR DESCRIPTION
PocketEndpointRaw was not handling TimeoutException. Null values are already treated as a generic error downstream, so this is safe.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
