### PR TITLE
Fix telemetry

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -187,6 +187,7 @@ dependencies {
     androidTestUtil "androidx.test:orchestrator:$test_orchestrator"
 
     androidTestImplementation "org.mozilla.components:support-android-test:$moz_components_version"
+    testImplementation "org.mozilla.components:support-test:$moz_components_version"
 
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarViewModel.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/ToolbarViewModel.kt
@@ -71,18 +71,21 @@ class ToolbarViewModel(
 
     @UiThread
     fun backButtonClicked() {
+        sendOverlayClickTelemetry(NavigationEvent.BACK)
         sessionRepo.attemptBack(forceYouTubeExit = true)
         hideOverlay()
     }
 
     @UiThread
     fun forwardButtonClicked() {
+        sendOverlayClickTelemetry(NavigationEvent.FORWARD)
         sessionRepo.goForward()
         hideOverlay()
     }
 
     @UiThread
     fun reloadButtonClicked() {
+        sendOverlayClickTelemetry(NavigationEvent.RELOAD)
         sessionRepo.reload()
         sessionRepo.pushCurrentValue()
         hideOverlay()

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/channels/SettingsChannelAdapter.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/channels/SettingsChannelAdapter.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.settings_tile.view.*
 import org.mozilla.tv.firefox.R
+import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import org.mozilla.tv.firefox.utils.URLs
 
 class SettingsChannelAdapter(
@@ -58,6 +59,7 @@ class SettingsChannelAdapter(
                 SettingsButton.ABOUT -> loadUrl(URLs.URL_ABOUT)
                 SettingsButton.PRIVACY_POLICY -> loadUrl(URLs.PRIVACY_NOTICE_URL)
             }
+            TelemetryIntegration.INSTANCE.settingsTileClickEvent(itemData.type)
         }
         itemView.contentDescription = itemView.context.getString(itemData.titleRes)
         itemView.id = itemData.viewId // Add ids for testing

--- a/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
@@ -21,7 +21,6 @@ import org.mozilla.tv.firefox.ext.forceExhaustive
 import org.mozilla.tv.firefox.ext.serviceLocator
 import org.mozilla.tv.firefox.navigationoverlay.channels.SettingsScreen
 import org.mozilla.tv.firefox.navigationoverlay.channels.SettingsTile
-import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import java.lang.IllegalStateException
 
 const val KEY_SETTINGS_TYPE = "KEY_SETTINGS_TYPE"
@@ -75,7 +74,6 @@ class SettingsFragment : Fragment() {
                 when (event) {
                     Action.SESSION_CLEARED -> {
                         activity?.recreate()
-                        TelemetryIntegration.INSTANCE.clearDataEvent()
                     }
                 }.forceExhaustive
                 true

--- a/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import mozilla.components.support.base.observer.Consumable
 import org.mozilla.tv.firefox.session.SessionRepo
+import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import org.mozilla.tv.firefox.webrender.EngineViewCache
 
 class SettingsViewModel(
@@ -21,6 +22,7 @@ class SettingsViewModel(
     }
 
     fun clearBrowsingData(engineViewCache: EngineViewCache) {
+        TelemetryIntegration.INSTANCE.clearDataEvent()
         sessionRepo.clearBrowsingData(engineViewCache)
         _events.value = Consumable.from(SettingsFragment.Action.SESSION_CLEARED)
     }

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
@@ -26,6 +26,9 @@ import org.mozilla.telemetry.ping.TelemetryCorePingBuilder
 import org.mozilla.telemetry.ping.TelemetryMobileEventPingBuilder
 import org.mozilla.telemetry.ping.TelemetryPocketEventPingBuilder
 import org.mozilla.tv.firefox.ext.serviceLocator
+import org.mozilla.tv.firefox.navigationoverlay.channels.SettingsButton
+import org.mozilla.tv.firefox.navigationoverlay.channels.SettingsScreen
+import org.mozilla.tv.firefox.navigationoverlay.channels.SettingsTile
 import java.util.Collections
 
 private const val SHARED_PREFS_KEY = "telemetryLib" // Don't call it TelemetryWrapper to avoid accidental IDE rename.
@@ -104,6 +107,10 @@ open class TelemetryIntegration protected constructor(
         val POCKET_VIDEO_MEGATILE = "pocket_video_tile"
         val YOUTUBE_TILE = "youtube_tile"
         val EXIT_FIREFOX = "exit"
+        val SETTINGS_CLEAR_DATA_TILE = "clear_data_tile"
+        val SETTINGS_SEND_DATA_TILE = "send_data_tile"
+        val SETTINGS_ABOUT_TILE = "about_tile"
+        val SETTINGS_PRIVACY_TILE = "privacy_tile"
     }
 
     private object Extra {
@@ -265,6 +272,16 @@ open class TelemetryIntegration protected constructor(
         TelemetryEvent.create(Category.ACTION, Method.CHANGE, Object.SETTING, Value.CLEAR_DATA).queue()
     }
 
+    fun settingsTileClickEvent(tile: SettingsTile) {
+        val telemetryValue = when (tile) {
+            SettingsScreen.DATA_COLLECTION -> Value.SETTINGS_SEND_DATA_TILE
+            SettingsScreen.CLEAR_COOKIES -> Value.SETTINGS_CLEAR_DATA_TILE
+            SettingsButton.ABOUT -> Value.SETTINGS_ABOUT_TILE
+            SettingsButton.PRIVACY_POLICY -> Value.SETTINGS_PRIVACY_TILE
+            else -> null
+        }
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.SETTING, telemetryValue).queue()
+    }
     /**
      * Should only be used when a user action directly results in this change.
      *

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
@@ -320,14 +320,9 @@ open class TelemetryIntegration protected constructor(
                         boolToOnOff(isDesktopModeButtonChecked)).queue()
                 return
             }
-            NavigationEvent.SETTINGS_DATA_COLLECTION -> {
-                // TODO: Add telemetry #2044
-                return
-            }
-            NavigationEvent.SETTINGS_CLEAR_COOKIES -> {
-                // TODO: Add telemetry #2044
-                return
-            }
+
+            // Settings telemetry handled in a separate event
+            NavigationEvent.SETTINGS_DATA_COLLECTION, NavigationEvent.SETTINGS_CLEAR_COOKIES -> return
 
             // Load is handled in a separate event
             NavigationEvent.LOAD_URL, NavigationEvent.LOAD_TILE -> return

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -53,7 +53,6 @@ The event ping contains a list of events ([see event format on readthedocs.io](h
 
 | Event                                                | category   | method                  | object            | value      | extras.    |
 |------------------------------------------------------|------------|-------------------------|-------------------|------------|------------|
-| Settings: confirms clear data dialog                 | action     | change                  | setting           | clear_data |            |
 | Pocket video feed: unique videos clicked per session | aggregate  | click                   | pocket_video      | `<int>`    |            |
 | App opened from view intent                          | action     | view_intent             | app               |            |            |
 | Opening the overlay forced a video out of fullscreen | action     | programmatically_closed | full_screen_video |            |            |
@@ -142,9 +141,19 @@ To elaborate on these events:
 | Event                                      | category | method         | object        | value          |
 |--------------------------------------------|----------|----------------|---------------|----------------|
 | PocketFeed: video click                    | action   | click          | video_id      | `<int>`        |
-| POcketFeed: video impression*              | action   | impression     | video_id      | `<int>`        |
+| PocketFeed: video impression*              | action   | impression     | video_id      | `<int>`        |
 
 (*) Video impressions are aggregated by the user initiating focus on the videos in the Pocket feed
+
+### Settings Channel
+
+| Event                                       | category   | method      | object        | value          |
+|---------------------------------------------|------------|-------------|---------------|----------------|
+| Confirms clear data dialog                  | action     | change      | setting       | clear_data     |
+| Clear cookies and data tile clicked         | action     | click       | setting       | clear_data_tile|
+| Send usage data tile clicked                | action     | click       | setting       | send_data_tile |
+| About tile clicked                          | action     | click       | setting       | about_tile     |
+| Privacy Notice tile clicked                 | action     | click       | setting       | privacy_tile   |
 
 ## Limits
 


### PR DESCRIPTION
Adding back some missing telemetry, refactoring the settings telemetry, and collecting clicks on each settings tile.
Note: The `clear_data` telemetry is different from the `clear_data_tile` telemetry because it is the click on the confirmation button to actually clear the data, while the tile just brings up the confirmation dialog.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
