### PR TITLE
Closes #2118: Remove alpha from hint bar animation.

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/hint/HintBinder.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/hint/HintBinder.kt
@@ -40,15 +40,14 @@ object HintBinder {
                     }
                     .subscribe { shouldDisplay ->
                         hintContainer.isVisible = true
-                        val (translationY, alpha) = when (shouldDisplay) {
-                            true -> Pair(0f, 1f)
-                            false -> Pair(hintContainer.height.toFloat(), 0f)
+                        val translationY = when (shouldDisplay) {
+                            true -> 0f
+                            false -> hintContainer.height.toFloat()
                         }
                         hintContainer.animate()
                                 .setDuration(250)
                                 .setInterpolator(FastOutSlowInInterpolator())
                                 .translationY(translationY)
-                                .alpha(alpha)
                                 .start()
                     }
         }


### PR DESCRIPTION
@brampitoyo Are you okay with us removing the alpha from the animation? It looks like it causes dropped frames when it appears over the web content.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Visual change
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
