### PR TITLE
[DEPRIORITIZED] Closes #2091: Remove redundant YouTube tile clicked telemetry.

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
@@ -34,7 +34,6 @@ import java.util.Collections
 private const val SHARED_PREFS_KEY = "telemetryLib" // Don't call it TelemetryWrapper to avoid accidental IDE rename.
 private const val KEY_CLICKED_HOME_TILE_IDS_PER_SESSION = "clickedHomeTileIDsPerSession"
 private const val KEY_REMOTE_CONTROL_NAME = "remoteControlName"
-private const val YOUTUBE_TILE_ID = "youtube"
 
 @Suppress(
         // Yes, this a large class with a lot of functions. But it's very simple and still easy to read.
@@ -255,10 +254,6 @@ open class TelemetryIntegration protected constructor(
 
     @UiThread // via TelemetryHomeTileUniqueClickPerSessionCounter
     fun homeTileClickEvent(context: Context, tile: PinnedTile) {
-        if (tile.idToString() == YOUTUBE_TILE_ID) {
-            TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.HOME_TILE,
-                    Value.YOUTUBE_TILE).queue()
-        }
         // Add an extra that contains the tileId for bundled tiles only
         val tileType = getTileTypeAsStringValue(tile)
         if (tileType == Value.TILE_BUNDLED) {


### PR DESCRIPTION
**Merging this PR is blocked on an analysis by the data team to ensure the new probe was added correctly.**

@liuche Does removing a probe (like this) require a data review? I assume not so I did not include it.

The telemetry docs were already updated for this in #2014.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Code removal: no tests needed
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
