### PR TITLE
Closes #2133: fixes hint bar showing when A/B is disabled

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/hint/HintBinder.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/hint/HintBinder.kt
@@ -37,7 +37,6 @@ object HintBinder {
                                 .start()
                     }
                     .subscribe { shouldDisplay ->
-                        hintContainer.isVisible = true
                         val translationY = when (shouldDisplay) {
                             true -> 0f
                             false -> hintContainer.height.toFloat()


### PR DESCRIPTION
Root cause:
We previously enabled hint bar visibility on any isDisplayed change, then animated it to 0f opacity if !isDisplayed.  This opacity animation was removed in #2118, however always setting visibility to true was left in.  This led to an empty hint bar being always visible.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
Bug never reached users
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
