### PR TITLE
Issue #1652: Integrate Glean SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -148,6 +148,7 @@ dependencies {
     implementation "org.mozilla.components:service-fretboard:$moz_components_version"
     implementation "org.mozilla.components:support-ktx:$moz_components_version"
     implementation "org.mozilla.components:support-utils:$moz_components_version"
+    implementation "org.mozilla.components:service-glean:$moz_components_version"
 
     systemImplementation "org.mozilla.components:browser-engine-system:$moz_components_version"
     // Required to override android.support lib in GeckoView dependency (uses palette-v7:26.1.0)

--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -51,15 +51,7 @@ open class FirefoxApplication : LocaleAwareApplication() {
             // Enable crash reporting. Don't add anything above here because if it crashes, we won't know.
             SentryIntegration.init(this, serviceLocator.settingsRepo)
 
-            serviceLocator.settingsRepo.dataCollectionEnabled.observeForever { collectionEnabled ->
-                if (collectionEnabled != null) {
-                    // This needs to be called before Glean.initialize, or we risk 1) not
-                    // sending startup data, or 2) sending even when the user has toggled
-                    // off data collection
-                }
-                    Glean.setUploadEnabled(collectionEnabled)
-            }
-            Glean.initialize(applicationContext)
+            initGlean()
 
             TelemetryIntegration.INSTANCE.init(this)
 
@@ -74,6 +66,18 @@ open class FirefoxApplication : LocaleAwareApplication() {
                 registerActivityLifecycleCallbacks(it)
             }
         }
+    }
+
+    private fun initGlean() {
+        serviceLocator.settingsRepo.dataCollectionEnabled.observeForever { collectionEnabled ->
+            if (collectionEnabled != null) {
+                // This needs to be called before Glean.initialize, or we risk 1) not
+                // sending startup data, or 2) sending even when the user has toggled
+                // off data collection
+                Glean.setUploadEnabled(collectionEnabled)
+            }
+        }
+        Glean.initialize(applicationContext)
     }
 
     // ServiceLocator needs to be created in onCreate in order to accept Application

--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -7,6 +7,7 @@ package org.mozilla.tv.firefox
 import android.os.StrictMode
 import androidx.annotation.VisibleForTesting
 import android.webkit.WebSettings
+import mozilla.components.service.glean.Glean
 import mozilla.components.support.ktx.android.content.runOnlyInMainProcess
 import org.mozilla.tv.firefox.components.locale.LocaleAwareApplication
 import org.mozilla.tv.firefox.telemetry.SentryIntegration
@@ -49,6 +50,17 @@ open class FirefoxApplication : LocaleAwareApplication() {
 
             // Enable crash reporting. Don't add anything above here because if it crashes, we won't know.
             SentryIntegration.init(this, serviceLocator.settingsRepo)
+
+            // Set up Glean by connecting it to the preference flag for data collection and calling
+            // the initialize() function.
+            with(serviceLocator.settingsRepo) {
+                dataCollectionEnabled.observeForever { collectionEnabled ->
+                    if (collectionEnabled != null) {
+                        Glean.setUploadEnabled(collectionEnabled)
+                    }
+                }
+            }
+            Glean.initialize(applicationContext)
 
             TelemetryIntegration.INSTANCE.init(this)
 

--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -51,15 +51,13 @@ open class FirefoxApplication : LocaleAwareApplication() {
             // Enable crash reporting. Don't add anything above here because if it crashes, we won't know.
             SentryIntegration.init(this, serviceLocator.settingsRepo)
 
-            with(serviceLocator.settingsRepo) {
-                dataCollectionEnabled.observeForever { collectionEnabled ->
-                    if (collectionEnabled != null) {
-                        // This needs to be called before Glean.initialize, or we risk 1) not
-                        // sending startup data, or 2) sending even when the user has toggled
-                        // off data collection
-                        Glean.setUploadEnabled(collectionEnabled)
-                    }
+            serviceLocator.settingsRepo.dataCollectionEnabled.observeForever { collectionEnabled ->
+                if (collectionEnabled != null) {
+                    // This needs to be called before Glean.initialize, or we risk 1) not
+                    // sending startup data, or 2) sending even when the user has toggled
+                    // off data collection
                 }
+                    Glean.setUploadEnabled(collectionEnabled)
             }
             Glean.initialize(applicationContext)
 

--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -51,11 +51,12 @@ open class FirefoxApplication : LocaleAwareApplication() {
             // Enable crash reporting. Don't add anything above here because if it crashes, we won't know.
             SentryIntegration.init(this, serviceLocator.settingsRepo)
 
-            // Set up Glean by connecting it to the preference flag for data collection and calling
-            // the initialize() function.
             with(serviceLocator.settingsRepo) {
                 dataCollectionEnabled.observeForever { collectionEnabled ->
                     if (collectionEnabled != null) {
+                        // This needs to be called before Glean.initialize, or we risk 1) not
+                        // sending startup data, or 2) sending even when the user has toggled
+                        // off data collection
                         Glean.setUploadEnabled(collectionEnabled)
                     }
                 }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -5,12 +5,6 @@ For clients that have "send anonymous usage data" enabled Firefox for Fire TV se
 
 Firefox for Fire TV creates and tries to send a "baseline" ping when the app goes to the background. This baseline ping is defined by the [Glean](https://github.com/mozilla-mobile/android-components/tree/master/components/service/glean) component and [documented in the Android Components repository](https://github.com/mozilla-mobile/android-components/blob/master/components/service/glean/docs/baseline.md).
 
-## Events
-
-| Event     | Glean Key | Leanplum Key | extras |
-|-----------|-----------|--------------|--------|
-| OpenedApp |           | E_Opened_App |        |
-
 # Core ping
 
 Firefox for Fire TV creates and tries to send a "core" ping whenever the app goes to the background. This core ping uses the same format as Firefox for Android and is [documented on firefox-source-docs.mozilla.org](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/core-ping.html).

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,6 +1,16 @@
 # Telemetry
 For clients that have "send anonymous usage data" enabled Firefox for Fire TV sends a "core" ping, an "event" ping and "pocket" ping to Mozilla's telemetry service. Sending telemetry can be disabled in the app's settings. Builds of "Firefox for Fire TV" have telemetry enabled by default ("opt-out").
 
+## Baseline ping
+
+Firefox for Fire TV creates and tries to send a "baseline" ping when the app goes to the background. This baseline ping is defined by the [Glean](https://github.com/mozilla-mobile/android-components/tree/master/components/service/glean) component and [documented in the Android Components repository](https://github.com/mozilla-mobile/android-components/blob/master/components/service/glean/docs/baseline.md).
+
+## Events
+
+| Event     | Glean Key | Leanplum Key | extras |
+|-----------|-----------|--------------|--------|
+| OpenedApp |           | E_Opened_App |        |
+
 # Core ping
 
 Firefox for Fire TV creates and tries to send a "core" ping whenever the app goes to the background. This core ping uses the same format as Firefox for Android and is [documented on firefox-source-docs.mozilla.org](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/core-ping.html).


### PR DESCRIPTION
Closes #1652: This adds the basic Glean SDK integration.  **Only the baseline ping will be sent at this time** and this is why no `metrics.yaml` file is needed for this PR.  Any additional application specific metrics will need to be added in a later iteration and will require a `metrics.yaml` file to be added (and require a new data-review).

This is intended to be instrumented alongside the existing telemetry in order to do a side-by-side comparison and validation between the two. 

It should also be noted that additional pipeline work may be required before any data will be collected by the back end.

I believe this will also require data review from @liuche, @boek, or another data steward to be legitimate before merging.  For their reference, Glean has been reviewed and approved for the [reference-browser](https://github.com/mozilla-mobile/reference-browser/pull/677) and [fenix](https://github.com/mozilla-mobile/fenix/issues/1190).  Both of the links refer to custom specific metrics

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
