### PR TITLE
Issue #2273: Add readme to point users to Wiki

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,10 @@
+# mozilla-mobile/firefox-tv Documentation
+
+Documentation about this project, process, code, design decisions and more can
+be found on the public GitHub wiki website or via the corresponding git
+repository:
+
+- https://github.com/mozilla-mobile/firefox-tv/wiki
+- https://github.com/mozilla-mobile/firefox-tv.wiki.git
+
+Please also see this project's top-level [README.md](../README.md)


### PR DESCRIPTION
Closes #2273 to point users to the wiki where majority (maybe all?) docs exist to help with discoverability beyond the top-level README.
