### PR TITLE
Issue #1247 : Moved to new version of Activity.onCreateView

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -203,12 +203,12 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         super.onDestroy()
     }
 
-    override fun onCreateView(name: String, context: Context, attrs: AttributeSet): View? {
+    override fun onCreateView(parent: View, name: String, context: Context, attrs: AttributeSet): View? {
         return if (name == EngineView::class.java.name) {
             context.serviceLocator.engineViewCache.getEngineView(context, attrs) {
                 setupForApp()
             }
-        } else super.onCreateView(name, context, attrs)
+        } else super.onCreateView(parent, name, context, attrs)
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
saw a note <a href = https://developer.android.com/reference/android/app/Activity.html#onCreateView(android.view.View,%20java.lang.String,%20android.content.Context,%20android.util.AttributeSet)>here</a> that parent might be null, but it looks like we don't use the parent anyway. Hence Compilation did not cause errors.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- ✔️ This PR includes thorough **tests** or an explanation of why it does not
- ✔️ This PR includes a **CHANGELOG entry** or does not need one
- ✔️ I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
