### PR TITLE
Issue #2111: follow-up nits to Pocket Channel PR

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/channels/DefaultChannelFactory.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/channels/DefaultChannelFactory.kt
@@ -18,7 +18,7 @@ class DefaultChannelFactory(
     fun createChannel(
         parent: ViewGroup,
         id: Int? = null,
-        channelConfig: ChannelConfig = ChannelConfig()
+        channelConfig: ChannelConfig
     ): DefaultChannel {
         val context = parent.context
         val channelAdapter = DefaultChannelAdapter(context, loadUrl, onTileFocused, channelConfig)

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketViewModel.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketViewModel.kt
@@ -48,6 +48,7 @@ class PocketViewModel(
         }
     }
 
+    // #2297: the PocketRepoCache is broken and will not stop videos from updating when the user is looking at them.
     val state: Observable<State> = pocketRepoCache.feedState
         .map { repoState ->
             when (repoState) {

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
@@ -71,8 +71,6 @@ open class TelemetryIntegration protected constructor(
         val YOUTUBE_CAST = "youtube_cast"
         val VIEW_INTENT = "view_intent"
         val IMPRESSION = "impression"
-        val VIEW = "view"
-        val FINISH = "finish"
         val PROGRAMMATICALLY_CLOSED = "programmatically_closed"
     }
 
@@ -103,7 +101,6 @@ open class TelemetryIntegration protected constructor(
         val TILE_BUNDLED = "bundled"
         val TILE_CUSTOM = "custom"
         val TILE_POCKET = "pocket"
-        val POCKET_VIDEO_MEGATILE = "pocket_video_tile"
         val YOUTUBE_TILE = "youtube_tile"
         val EXIT_FIREFOX = "exit"
         val SETTINGS_CLEAR_DATA_TILE = "clear_data_tile"

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -57,7 +57,7 @@ The event ping contains a list of events ([see event format on readthedocs.io](h
 
 | Event                                                | category   | method                  | object            | value      | extras.    |
 |------------------------------------------------------|------------|-------------------------|-------------------|------------|------------|
-| Pocket video feed: unique videos clicked per session | aggregate  | click                   | pocket_video      | `<int>`    |            |
+| Pocket channel: unique videos clicked per session    | aggregate  | click                   | pocket_video      | `<int>`    |            |
 | App opened from view intent                          | action     | view_intent             | app               |            |            |
 | Opening the overlay forced a video out of fullscreen | action     | programmatically_closed | full_screen_video |            |            |
 
@@ -69,7 +69,6 @@ The event ping contains a list of events ([see event format on readthedocs.io](h
 | Browser: back clicked                  | action   | click                 | menu         | back                     |               |
 | Browser: forward clicked               | action   | click                 | menu         | forward                  |               |
 | Browser: refresh clicked               | action   | click                 | menu         | refresh                  |               |
-| Pocket: tile clicked                   | action   | click                 | menu         | pocket_video_tile        |               |
 | Turbo mode switch clicked              | action   | change                | turbo_mode   | on/off (the new value)   |               |
 | Pin site switch clicked                | action   | change                | pin_page     | on/off (the new value)   | desktop_mode* |
 | Desktop mode switch clicked            | action   | change                | desktop_mode | on/off (the new value)   |               |
@@ -151,13 +150,13 @@ To elaborate on these events:
 - "Next/previous item" is intended to go to the next video/song in a playlist. We send the corresponding key event to the page which must support this functionality (it works on YouTube).
 - "Seek" aggregates the "fast-forward", "rewind", and "restart" commands ([#988](https://github.com/mozilla-mobile/firefox-tv/issues/988) is to split up this telemetry)
 
-### Pocket Feed
+### Pocket Channel
 | Event                                      | category | method         | object        | value          |
 |--------------------------------------------|----------|----------------|---------------|----------------|
-| PocketFeed: video click                    | action   | click          | video_id      | `<int>`        |
-| PocketFeed: video impression*              | action   | impression     | video_id      | `<int>`        |
+| Pocket video click                         | action   | click          | video_id      | `<int>`        |
+| Pocket video impression*                   | action   | impression     | video_id      | `<int>`        |
 
-(*) Video impressions are aggregated by the user initiating focus on the videos in the Pocket feed
+(*) Video impressions are aggregated by the user initiating focus on the videos in the Pocket feed and do not represent "impression" in the traditional sense: see #2251 for further discussion.
 
 ### Settings Channel
 


### PR DESCRIPTION
Follow-up nits to PR #2178.

@liuche FYI: I'm updating the telemetry docs for removed probes.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Addressing nits
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
