### PR TITLE
No issue: fix channel focus problem created during channel styling

### DIFF
--- a/app/src/main/res/layout/home_tile.xml
+++ b/app/src/main/res/layout/home_tile.xml
@@ -13,6 +13,7 @@
               android:layout_width="@dimen/home_tile_width"
               android:layout_height="wrap_content"
               android:layout_marginStart="12dp"
+              android:focusable="true"
               android:layout_marginEnd="12dp">
 
     <LinearLayout


### PR DESCRIPTION
Channel styling (#2280) introduced an issue that was reproducible on device but not emulator where channel tiles were not focusable.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
