### PR TITLE
Issue #2314: add C branch to hint bar experiment

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
@@ -52,6 +52,7 @@ class ExperimentsProvider(private val fretboard: Fretboard, private val context:
             expDescriptor == null -> false
             expDescriptor.name.endsWith(ExperimentSuffix.A.value) -> true
             expDescriptor.name.endsWith(ExperimentSuffix.B.value) -> false
+            expDescriptor.name.endsWith(ExperimentSuffix.C.value) -> true
             else -> {
                 Sentry.capture(ExperimentIllegalStateException("Hint Bar Illegal Branch Name"))
                 false


### PR DESCRIPTION
C will later be used to put most users into the hint bar test.  This will allow us to maintain the same experience for the A and B populations, in order to allow for ongoing testing



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
