### PR TITLE
Issue #1247 :Moved to latest version of Activity.onCreateView

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -203,12 +203,12 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         super.onDestroy()
     }
 
-    override fun onCreateView(name: String, context: Context, attrs: AttributeSet): View? {
+    override fun onCreateView(parent: View?, name: String, context: Context, attrs: AttributeSet): View? {
         return if (name == EngineView::class.java.name) {
             context.serviceLocator.engineViewCache.getEngineView(context, attrs) {
                 setupForApp()
             }
-        } else super.onCreateView(name, context, attrs)
+        } else super.onCreateView(parent, name, context, attrs)
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
The old implementation caused obscure bugs. Now we have moved to the latest version of Activity.onCreateView giving better compatibility. The new parameter was specified nullable as google specifies that the argument may be null.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ✔️ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ✔️ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ✔️ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
