### PR TITLE
Issue #2325: Add last unit tests for Pocket background fetch

### DIFF
--- a/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/CustomPocketFeedStateProvider.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/CustomPocketFeedStateProvider.kt
@@ -2,17 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("DEPRECATION") // PocketVideoParser.
-
 package org.mozilla.tv.firefox.helpers
 
 import android.app.Application
-import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.subjects.PublishSubject
-import org.mozilla.tv.firefox.pocket.PocketVideoParser
+import io.reactivex.subjects.BehaviorSubject
+import org.mozilla.tv.firefox.ext.serviceLocator
 import org.mozilla.tv.firefox.pocket.PocketVideoRepo
-import org.mozilla.tv.firefox.pocket.PocketVideoStore
 
 /**
  * Provides a fake [PocketVideoRepo] implementation for testing purposes.
@@ -21,14 +16,10 @@ import org.mozilla.tv.firefox.pocket.PocketVideoStore
  */
 class CustomPocketFeedStateProvider(private val appContext: Application) {
 
-    val fakedPocketRepoState = PublishSubject.create<PocketVideoRepo.FeedState>()
-    val fakedPocketRepo = object : PocketVideoRepo(
-        PocketVideoStore(appContext, appContext.assets, PocketVideoParser::convertVideosJSON),
+    val fakedPocketRepoState = BehaviorSubject.create<PocketVideoRepo.FeedState>()
+    val fakedPocketRepo = PocketVideoRepo(
+        appContext.serviceLocator.pocketVideoStore,
         isPocketEnabledByLocale = { true },
-        isPocketKeyValid = true
-    ) {
-        override val feedState: Observable<FeedState>
-            get() = fakedPocketRepoState
-                .observeOn(AndroidSchedulers.mainThread())
-    }
+        _feedState = fakedPocketRepoState
+    )
 }

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/CustomPocketFeedStateProvider.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/helpers/CustomPocketFeedStateProvider.kt
@@ -2,23 +2,31 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@file:Suppress("DEPRECATION") // PocketVideoParser
+
 package org.mozilla.tv.firefox.helpers
 
 import android.app.Application
 import io.reactivex.subjects.BehaviorSubject
-import org.mozilla.tv.firefox.ext.serviceLocator
+import org.mozilla.tv.firefox.pocket.PocketVideoJSONValidator
+import org.mozilla.tv.firefox.pocket.PocketVideoParser
 import org.mozilla.tv.firefox.pocket.PocketVideoRepo
+import org.mozilla.tv.firefox.pocket.PocketVideoStore
 
 /**
  * Provides a fake [PocketVideoRepo] implementation for testing purposes.
  *
  * Any values pushed to [fakedPocketRepoState] will be immediately emitted.
  */
-class CustomPocketFeedStateProvider(private val appContext: Application) {
+class CustomPocketFeedStateProvider(appContext: Application) {
 
     val fakedPocketRepoState = BehaviorSubject.create<PocketVideoRepo.FeedState>()
     val fakedPocketRepo = PocketVideoRepo(
-        appContext.serviceLocator.pocketVideoStore,
+        PocketVideoStore(
+            appContext,
+            appContext.assets,
+            PocketVideoJSONValidator(PocketVideoParser)
+        ),
         isPocketEnabledByLocale = { true },
         _feedState = fakedPocketRepoState
     )

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchWorker.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchWorker.kt
@@ -19,9 +19,6 @@ import org.mozilla.tv.firefox.ext.serviceLocator
  */
 class PocketVideoFetchWorker(appContext: Context, workerParams: WorkerParameters) : Worker(appContext, workerParams) {
 
-    // todo: does Sentry catch crashes in here?
-    // todo: what happens to thrown exceptions?
-
     private val pocketEndpointRaw = appContext.serviceLocator.pocketEndpointRaw
     private val store = appContext.serviceLocator.pocketVideoStore
 

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchWorker.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchWorker.kt
@@ -41,7 +41,6 @@ class PocketVideoFetchWorker(appContext: Context, workerParams: WorkerParameters
             return Result.failure()
         }
 
-        store.save(rawJSONStr)
         return Result.success()
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -97,7 +97,11 @@ open class ServiceLocator(val app: Application) {
     // These open vals are overridden in testing
     open val frameworkRepo = FrameworkRepo.newInstanceAndInit(app.getAccessibilityManager())
     open val pinnedTileRepo by lazy { PinnedTileRepo(app, bundleTileStore) }
-    open val pocketRepo = PocketVideoRepo(pocketVideoStore, isPocketEnabledByLocale, buildConfigDerivables.isPocketKeyValid)
+    open val pocketRepo by lazy { PocketVideoRepo.newInstance(
+        pocketVideoStore,
+        isPocketEnabledByLocale,
+        buildConfigDerivables.isPocketKeyValid
+    ) }
     open val sessionRepo by lazy { SessionRepo(sessionManager, sessionUseCases, turboMode).apply { observeSources() } }
     open val settingsRepo by lazy { SettingsRepo(app) }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -27,6 +27,7 @@ import org.mozilla.tv.firefox.channels.pinnedtile.PinnedTileImageUtilWrapper
 import org.mozilla.tv.firefox.channels.pinnedtile.PinnedTileRepo
 import org.mozilla.tv.firefox.pocket.PocketEndpointRaw
 import org.mozilla.tv.firefox.pocket.PocketVideoFetchScheduler
+import org.mozilla.tv.firefox.pocket.PocketVideoJSONValidator
 import org.mozilla.tv.firefox.pocket.PocketVideoParser
 import org.mozilla.tv.firefox.pocket.PocketVideoRepo
 import org.mozilla.tv.firefox.pocket.PocketVideoStore
@@ -73,6 +74,7 @@ open class ServiceLocator(val app: Application) {
     private val isPocketEnabledByLocale = { LocaleManager.getInstance().currentLanguageIsEnglish(app) } // Pocket is en-US only.
     private val bundleTileStore by lazy { BundleTilesStore(app) }
     private val pocketVideoParser by lazy { PocketVideoParser }
+    private val pocketVideoJSONValidator by lazy { PocketVideoJSONValidator(pocketVideoParser) }
 
     val intentLiveData by lazy { MutableLiveData<Consumable<ValidatedIntentData?>>() }
     val fretboardProvider: FretboardProvider by lazy { FretboardProvider(app) }
@@ -91,7 +93,7 @@ open class ServiceLocator(val app: Application) {
     val channelRepo by lazy { ChannelRepo(pinnedTileRepo) }
     @Suppress("DEPRECATION") // We need PocketEndpointRaw until we move to a-c's impl.
     val pocketEndpointRaw by lazy { PocketEndpointRaw(appVersion, buildConfigDerivables.globalPocketVideoEndpoint) }
-    val pocketVideoStore by lazy { PocketVideoStore(app, app.assets, pocketVideoParser::convertVideosJSON) }
+    val pocketVideoStore by lazy { PocketVideoStore(app, app.assets, pocketVideoJSONValidator) }
     val pocketVideoFetchScheduler by lazy { PocketVideoFetchScheduler(isPocketEnabledByLocale) }
 
     // These open vals are overridden in testing

--- a/app/src/test/java/org/mozilla/tv/firefox/helpers/PocketTestData.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/helpers/PocketTestData.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.helpers
+
+import org.mozilla.tv.firefox.pocket.PocketViewModel
+
+/**
+ * A collection of functions that generate test data for Pocket-related code.
+ */
+object PocketTestData {
+    fun getVideoItem(id: Int) =
+        PocketViewModel.FeedItem.Video(
+            id = id,
+            title = "Mozilla",
+            url = "https://www.mozilla.org/en-US/",
+            thumbnailURL = "https://blog.mozilla.org/firefox/files/2017/12/Screen-Shot-2017-12-18-at-2.39.25-PM.png",
+            popularitySortId = id,
+            authors = "0:{'name':'Mozilla'}"
+        )
+
+    fun getVideoFeed(size: Int) = List(size) { getVideoItem(it) }
+}

--- a/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchSchedulerTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchSchedulerTest.kt
@@ -12,16 +12,21 @@ import androidx.work.WorkManager
 import io.mockk.MockKAnnotations
 import io.mockk.called
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.tv.firefox.pocket.PocketVideoFetchScheduler.Companion.FETCH_END_HOUR
+import org.mozilla.tv.firefox.pocket.PocketVideoFetchScheduler.Companion.FETCH_START_HOUR
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
 
+@RunWith(RobolectricTestRunner::class)
 class PocketVideoFetchSchedulerTest {
 
     private lateinit var scheduler: PocketVideoFetchScheduler
@@ -38,7 +43,7 @@ class PocketVideoFetchSchedulerTest {
 
     @Test
     fun `GIVEN fetch interval constants THEN start hour is less than end hour`() {
-        assertTrue(PocketVideoFetchScheduler.FETCH_START_HOUR < PocketVideoFetchScheduler.FETCH_END_HOUR)
+        assertTrue(FETCH_START_HOUR < PocketVideoFetchScheduler.FETCH_END_HOUR)
     }
 
     @Test
@@ -46,14 +51,13 @@ class PocketVideoFetchSchedulerTest {
         assertTrue(PocketVideoFetchScheduler.BACKOFF_DELAY_MIN_MILLIS < PocketVideoFetchScheduler.BACKOFF_DELAY_MAX_MILLIS)
     }
 
-    @Ignore // TODO: the WorkManager dependency breaks calling onStart; after we commit the other tests, fix this test.
     @Test
     fun `WHEN onStart is called THEN schedulePocketBackgroundFetch is called`() {
         // This test is tightly coupled to the implementation but, given this daily background job will rarely be
         // tested, we want to verify the implementation hasn't accidentally changed in a way that broke the functionality.
-        val schedulerMock = mockk<PocketVideoFetchScheduler>(relaxUnitFun = true)
+        val schedulerMock = spyk(PocketVideoFetchScheduler { true })
         schedulerMock.onStart()
-        verify(exactly = 1) { schedulerMock.schedulePocketBackgroundFetch(any()) }
+        verify(exactly = 1) { schedulerMock.schedulePocketBackgroundFetch(any(), any(), any()) }
     }
 
     @Test
@@ -101,8 +105,47 @@ class PocketVideoFetchSchedulerTest {
         assertNotEquals(fromArg, untilArg) // Sanity check to verify test correctness on the tricky capturing above.
     }
 
-    // TODO: test initial delay in work request
-    // TODO: test getDelayUntilUpcomingNightFetchMillis logic (should we test it directly or as part of the request?)
+    @Test
+    fun `GIVEN there is no randomness WHEN scheduling a pocket background fetch THEN the initial delay is the millis until the expected fetch time`() {
+        val now = Calendar.getInstance().apply {
+            set(1, 1, 1, 2, 30, 30)
+            set(Calendar.MILLISECOND, 500)
+        }
+        val expectedFetchTimeForNoRandomness = Calendar.getInstance().apply {
+            set(1, 1, 2, FETCH_START_HOUR, 0, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+
+        // We'd return zero but randLong is used somewhere else and then we'd need robolectric.
+        // Implicit assumption that 0 is minimum for this.
+        val randLong = { from: Long, _: Long -> from }
+        val expected = expectedFetchTimeForNoRandomness.timeInMillis - now.timeInMillis
+
+        scheduler.schedulePocketBackgroundFetch(workManager, now, randLong)
+
+        val request = verifyWorkManagerEnqueueAndCaptureRequest()
+        assertEquals(expected, request.workSpec.initialDelay)
+    }
+
+    @Test
+    fun `GIVEN there is randomness WHEN scheduling a pocket background fetch THEN the initial delay is the millis until the expected fetch time plus random millis`() {
+        val now = Calendar.getInstance().apply {
+            set(1, 1, 1, 2, 30, 30)
+            set(Calendar.MILLISECOND, 500)
+        }
+        val nextFetchIntervalEndTime = Calendar.getInstance().apply {
+            set(1, 1, 2, FETCH_END_HOUR.toInt(), 0, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+
+        val randLong = { _: Long, until: Long -> until }
+        val expected = nextFetchIntervalEndTime.timeInMillis - now.timeInMillis
+
+        scheduler.schedulePocketBackgroundFetch(workManager, now, randLong)
+
+        val request = verifyWorkManagerEnqueueAndCaptureRequest()
+        assertEquals(expected, request.workSpec.initialDelay)
+    }
 
     private fun verifyWorkManagerEnqueueAndCaptureRequest(): OneTimeWorkRequest = slot<OneTimeWorkRequest>().also {
         verify { workManager.enqueueUniqueWork(any(), any(), capture(it)) }

--- a/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchWorkerTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchWorkerTest.kt
@@ -85,6 +85,8 @@ class PocketVideoFetchWorkerTest {
     }
 
     private fun everyEndpointRawGetVideoRecsReturnsANonNullValue() {
+        // For many tests, we only need a non-null return value to advance to the next portion of the function,
+        // which is the part we want to test.
         coEvery { endpointRaw.getGlobalVideoRecommendations() } returns "{}"
     }
 }

--- a/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoJSONValidatorTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoJSONValidatorTest.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.pocket
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.slot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.tv.firefox.helpers.PocketTestData
+
+class PocketVideoJSONValidatorTest {
+
+    @Suppress("DEPRECATION")
+    @MockK private lateinit var pocketVideoParser: PocketVideoParser
+
+    private lateinit var validator: PocketVideoJSONValidator
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        validator = PocketVideoJSONValidator(pocketVideoParser)
+    }
+
+    @Test
+    fun `WHEN validating for saving THEN the json argument is passed verbatim into the parser convert function`() {
+        val json = "{ }"
+        val slot = slot<String>()
+        every { pocketVideoParser.convertVideosJSON(capture(slot)) } returns null
+        validator.isJSONValidForSaving(json)
+
+        assertEquals(json, slot.captured)
+    }
+
+    @Test
+    fun `WHEN converting json to pocket videos THEN it delegates to the pocket parser`() {
+        val json = "{ }"
+        val slot = slot<String>()
+        every { pocketVideoParser.convertVideosJSON(capture(slot)) } returns null
+        validator.convertJSONToPocketVideos(json)
+
+        assertEquals(json, slot.captured)
+    }
+
+    @Test
+    fun `WHEN validating for saving and converted videos is null THEN return false`() {
+        every { pocketVideoParser.convertVideosJSON(any()) } returns null
+        assertFalse(validator.isJSONValidForSaving("{ }"))
+    }
+
+    @Test
+    fun `WHEN validating for saving and converted videos size is equal to required video count THEN return true`() {
+        every { pocketVideoParser.convertVideosJSON(any()) } returns
+            PocketTestData.getVideoFeed(PocketVideoJSONValidator.REQUIRED_POCKET_VIDEO_COUNT)
+        assertTrue(validator.isJSONValidForSaving("{ }"))
+    }
+
+    @Test
+    fun `WHEN validating for saving and converted videos size is less than required video count THEN return false`() {
+        every { pocketVideoParser.convertVideosJSON(any()) } returns
+            PocketTestData.getVideoFeed(PocketVideoJSONValidator.REQUIRED_POCKET_VIDEO_COUNT - 1)
+        assertFalse(validator.isJSONValidForSaving("{ }"))
+    }
+}

--- a/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoRepoTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoRepoTest.kt
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.pocket
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.reactivex.observers.TestObserver
+import io.reactivex.subjects.BehaviorSubject
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.tv.firefox.helpers.PocketTestData
+import org.mozilla.tv.firefox.pocket.PocketVideoRepo.FeedState
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PocketVideoRepoTest {
+
+    private lateinit var repo: PocketVideoRepo
+    @MockK private lateinit var videoStore: PocketVideoStore
+    private var isPocketEnabledByLocale = false
+
+    private lateinit var feedState: BehaviorSubject<FeedState>
+    private lateinit var feedStateTestObs: TestObserver<FeedState>
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        feedState = BehaviorSubject.create()
+        feedStateTestObs = feedState.test()
+        repo = PocketVideoRepo(videoStore, { isPocketEnabledByLocale }, feedState)
+    }
+
+    @Test
+    fun `GIVEN feedState is no api key WHEN updating Pocket from store THEN feedState is still no api key`() {
+        feedState.onNext(FeedState.NoAPIKey)
+
+        repo.updatePocketFromStore()
+
+        feedStateTestObs.assertValues(FeedState.NoAPIKey)
+    }
+
+    @Test
+    fun `GIVEN pocket is not enabled by locale WHEN updating Pocket from store THEN feedState becomes inactive`() {
+        repo.updatePocketFromStore()
+
+        feedStateTestObs.assertValues(FeedState.Inactive)
+    }
+
+    @Test
+    fun `GIVEN pocket is enabled by locale WHEN updating Pocket from store THEN feedState has videos loaded by store`() {
+        isPocketEnabledByLocale = true
+        val videos = PocketTestData.getVideoFeed(3)
+        every { videoStore.load() } returns videos
+        repo.updatePocketFromStore()
+
+        feedStateTestObs.assertValues(FeedState.LoadComplete(videos))
+    }
+
+    @Test
+    fun `GIVEN an existing feed state WHEN updating Pocket from store THEN feedState can change between the expected values`() {
+        val videos = PocketTestData.getVideoFeed(3)
+        every { videoStore.load() } returns videos
+        feedState.onNext(FeedState.Inactive)
+
+        isPocketEnabledByLocale = true
+        repo.updatePocketFromStore()
+
+        isPocketEnabledByLocale = false
+        repo.updatePocketFromStore()
+
+        isPocketEnabledByLocale = true
+        repo.updatePocketFromStore()
+
+        feedStateTestObs.assertValues(
+            FeedState.Inactive,
+            FeedState.LoadComplete(videos),
+            FeedState.Inactive,
+            FeedState.LoadComplete(videos)
+        )
+    }
+
+    @Test // sanity check
+    fun `WHEN getting a new instance THEN no exception is thrown`() {
+        PocketVideoRepo.newInstance(videoStore, { true }, true)
+    }
+
+    @Test
+    fun `GIVEN pocket key is valid WHEN getting a new instance THEN feed state starts inactive`() {
+        val repo = PocketVideoRepo.newInstance(videoStore, { true }, isPocketKeyValid = true)
+        assertEquals(FeedState.Inactive, repo.feedState.blockingFirst())
+    }
+
+    @Test
+    fun `GIVEN pocket key is not valid WHEN getting a new instance THEN feed state starts no api key`() {
+        val repo = PocketVideoRepo.newInstance(videoStore, { true }, isPocketKeyValid = false)
+        assertEquals(FeedState.NoAPIKey, repo.feedState.blockingFirst())
+    }
+}

--- a/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoStoreTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/pocket/PocketVideoStoreTest.kt
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.pocket
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.AssetManager
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.CapturingSlot
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.tv.firefox.helpers.PocketTestData
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+
+private val POCKET_FEED_TEST_DATA = PocketTestData.getVideoFeed(1)
+
+@RunWith(RobolectricTestRunner::class)
+class PocketVideoStoreTest {
+    private lateinit var pocketVideoStore: PocketVideoStore
+    private lateinit var sharedPrefs: SharedPreferences
+
+    @MockK private lateinit var context: Context
+    @MockK private lateinit var assetManager: AssetManager
+    @MockK private lateinit var jsonValidator: PocketVideoJSONValidator
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        sharedPrefs = ApplicationProvider.getApplicationContext<Context>().getSharedPreferences("PocketFetch", 0)
+        every { context.getSharedPreferences(any(), any()) } returns sharedPrefs
+
+        pocketVideoStore = PocketVideoStore(context, assetManager, jsonValidator)
+    }
+
+    @Test
+    fun `WHEN the raw json is valid THEN it is saved in shared preferences`() {
+        every { jsonValidator.isJSONValidForSaving(any()) } returns true
+        val expected = "{ }"
+
+        assertTrue(pocketVideoStore.save(expected))
+
+        val actual = sharedPrefs.getString("video_json", null)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN the raw json is invalid THEN it is not saved in shared preferences`() {
+        every { jsonValidator.isJSONValidForSaving(any()) } returns false
+
+        assertFalse(pocketVideoStore.save("{ }"))
+    }
+
+    @Test
+    fun `WHEN saving THEN the json to save is passed verbatim into the json validator`() {
+        arrayOf("{ }", "", " ", "{ ").forEachIndexed { i, json ->
+            // The return value doesn't matter.
+            val validatorJSONCaptured = slot<String>()
+            every { jsonValidator.isJSONValidForSaving(capture(validatorJSONCaptured)) } returns true
+
+            pocketVideoStore.save(json)
+
+            println("Input index $i: $json")
+            assertEquals(json, validatorJSONCaptured.captured)
+        }
+    }
+
+    @Test
+    fun `GIVEN shared preferences is empty WHEN loading THEN the bundled tiles json is passed verbatim into the json validator`() {
+        val expectedBundledJSON = "assets"
+        everyAssetManagerOpensInputStream(expectedBundledJSON.toInputStream())
+
+        // The return value doesn't matter.
+        val validatorJSONCaptured = everyJSONValidatorConversionReturnsList(emptyList())
+
+        pocketVideoStore.load()
+
+        assertEquals(expectedBundledJSON, validatorJSONCaptured.captured)
+    }
+
+    // shared pref videos is copied into validator
+    @Test
+    fun `GIVEN shared preferences is not empty WHEN loading THEN the json from shared prefs is passed verbatim into the json validator`() {
+        everyAssetManagerOpensInputStream("assets".toInputStream())
+        val expectedSharedPrefsValue = "{ }"
+        setJSONInSharedPrefs(expectedSharedPrefsValue)
+
+        // The return value doesn't matter.
+        val validatorJSONCaptured = everyJSONValidatorConversionReturnsList(emptyList())
+
+        pocketVideoStore.load()
+
+        assertEquals(expectedSharedPrefsValue, validatorJSONCaptured.captured)
+    }
+
+    @Test
+    fun `GIVEN shared preferences is not empty WHEN loading THEN the converted videos are returned`() {
+        everyAssetManagerOpensInputStream("assets".toInputStream())
+        setJSONInSharedPrefs("{ }")
+        everyJSONValidatorConversionReturnsList(POCKET_FEED_TEST_DATA)
+
+        val returnVal = pocketVideoStore.load()
+
+        assertEquals(POCKET_FEED_TEST_DATA, returnVal)
+    }
+
+    @Test
+    fun `GIVEN shared preferences is empty WHEN the converted videos is null THEN loading returns an empty list`() {
+        everyAssetManagerOpensInputStream("".toInputStream())
+        everyJSONValidatorConversionReturnsList(null)
+        val returnVal = pocketVideoStore.load()
+        assertEquals(emptyList<PocketViewModel.FeedItem>(), returnVal)
+    }
+
+    @Test
+    fun `GIVEN shared preferences is empty and conversion returns null WHEN loading THEN the input stream gets closed`() {
+        verifyLoadInputStreamIsClosed(given = {
+            everyJSONValidatorConversionReturnsList(null)
+        })
+    }
+
+    @Test
+    fun `GIVEN shared preferences is empty and conversion does not return null WHEN loading THEN the input stream gets closed`() {
+        verifyLoadInputStreamIsClosed(given = {
+            everyJSONValidatorConversionReturnsList(POCKET_FEED_TEST_DATA)
+        })
+    }
+
+    @Test(expected = IOException::class)
+    fun `GIVEN shared preferences is empty WHEN opening asset manager throws an exception THEN load throws the exception`() {
+        every { assetManager.open(any()) } throws IOException()
+        pocketVideoStore.load()
+    }
+
+    @Test(expected = IOException::class)
+    fun `GIVEN shared preferences is empty WHEN read text throws an exception THEN load throws the exception`() {
+        val inputStream = mockk<InputStream>().also {
+            every { it.read(any(), any(), any()) } throws IOException()
+        }
+
+        everyAssetManagerOpensInputStream(inputStream)
+        pocketVideoStore.load()
+    }
+
+    private fun verifyLoadInputStreamIsClosed(given: (InputStream) -> Unit) {
+        val inputStream = spyk("assets".toInputStream())
+        everyAssetManagerOpensInputStream(inputStream)
+        given(inputStream)
+
+        pocketVideoStore.load()
+
+        verify { inputStream.close() }
+    }
+
+    private fun setJSONInSharedPrefs(json: String) {
+        sharedPrefs.edit().putString(PocketVideoStore.KEY_VIDEO_JSON, json).apply()
+    }
+
+    private fun everyAssetManagerOpensInputStream(inputStream: InputStream) {
+        every { assetManager.open(any()) } returns inputStream
+    }
+
+    private fun everyJSONValidatorConversionReturnsList(pocketVideoList: List<PocketViewModel.FeedItem.Video>?): CapturingSlot<String> {
+        val validatorJSONCaptured = slot<String>()
+        every { jsonValidator.convertJSONToPocketVideos(capture(validatorJSONCaptured)) } returns pocketVideoList
+        return validatorJSONCaptured
+    }
+
+    private fun String.toInputStream() = ByteArrayInputStream(this.toByteArray())
+}


### PR DESCRIPTION
I paired with dnarcese on this from beginning to end so this doesn't require review but dnarcese isn't around to rubberstamp for me: @liuche can you rubberstamp?

The tests comprehensively test the functionality. However, we don't have many (any?) tests for the full integration (basically, does MainActivity call into the scheduler to add the job? Does MainActivity call into the VideoRepo to push state in onStart?) – these are hard to write so I'm not sure it's worth it.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
