### PR TITLE
Issue #2325: Expose way for QA to change pocket fetch delay

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
@@ -18,6 +18,7 @@ import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import org.mozilla.tv.firefox.utils.UrlUtils
 
 private const val EXTRA_ACTIVE_EXPERIMENTS = "qaActiveExperiments"
+private const val EXTRA_FETCH_DELAY_KEY = "fetchDelay"
 
 data class ValidatedIntentData(val url: String, val source: Session.Source)
 
@@ -66,11 +67,11 @@ object IntentValidator {
                     TelemetryIntegration.INSTANCE.youtubeCastEvent()
                     return ValidatedIntentData(url = "https://www.youtube.com/tv?$dialParams", source = Session.Source.ACTION_VIEW)
                 }
-                // The fetch delay can be changed for testing purposes through an intent with custom flags
-                // isQA and fetchDelay. Where isQA is true/false and fetchDelay is the intended next fetch time
-                // in seconds.
-                else if (extras.keySet().contains(IS_QA_BUILD_KEY)) {
-                    PocketVideoFetchScheduler.setDelayForQA(extras.getLong(FETCH_DELAY_KEY))
+
+                // The fetch delay can be changed for testing purposes through an intent with custom flag
+                // fetchDelay. Where fetchDelay is the intended next fetch time in seconds.
+                else if (extras.containsKey(EXTRA_FETCH_DELAY_KEY)) {
+                    PocketVideoFetchScheduler.setDelayForQA(extras.getLong(EXTRA_FETCH_DELAY_KEY))
                 }
             }
             Intent.ACTION_VIEW -> {

--- a/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
@@ -55,8 +55,8 @@ object IntentValidator {
     }
 
     fun validate(context: Context, intent: SafeIntent): ValidatedIntentData? {
-        setExperimentOverrides(intent, context)
-        changeFetchDelaySecondsForQA(intent, context)
+        setQAExperimentOverrides(intent, context)
+        setQAFetchDelayOverrides(intent, context)
 
         when (intent.action) {
             Intent.ACTION_MAIN -> {
@@ -88,7 +88,7 @@ object IntentValidator {
         return null
     }
 
-    private fun setExperimentOverrides(intent: SafeIntent, context: Context) {
+    private fun setQAExperimentOverrides(intent: SafeIntent, context: Context) {
         val experimentsArray = intent.extras?.getStringArray(EXTRA_ACTIVE_EXPERIMENTS) ?: return
         val fretboard = context.serviceLocator.fretboardProvider.fretboard
         fretboard.clearAllOverrides(context)
@@ -98,9 +98,9 @@ object IntentValidator {
         }
     }
 
-    private fun changeFetchDelaySecondsForQA(intent: SafeIntent, context: Context) {
+    private fun setQAFetchDelayOverrides(intent: SafeIntent, context: Context) {
         intent.extras?.getLong(EXTRA_FETCH_DELAY_KEY)?.let { delay ->
-            context.serviceLocator.pocketVideoFetchScheduler.setDelayForQA(delay)
+            context.serviceLocator.pocketVideoFetchScheduler.setQAFetchDelayOverride(delay)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.service.fretboard.ExperimentDescriptor
 import mozilla.components.support.utils.SafeIntent
 import org.mozilla.tv.firefox.ext.serviceLocator
+import org.mozilla.tv.firefox.pocket.PocketVideoFetchScheduler
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import org.mozilla.tv.firefox.utils.UrlUtils
 
@@ -56,7 +57,7 @@ object IntentValidator {
 
     fun validate(context: Context, intent: SafeIntent): ValidatedIntentData? {
         setQAExperimentOverrides(intent, context)
-        setQAFetchDelayOverrides(intent, context)
+        setQAFetchDelayOverrides(intent, context.serviceLocator.pocketVideoFetchScheduler)
 
         when (intent.action) {
             Intent.ACTION_MAIN -> {
@@ -98,9 +99,9 @@ object IntentValidator {
         }
     }
 
-    private fun setQAFetchDelayOverrides(intent: SafeIntent, context: Context) {
+    private fun setQAFetchDelayOverrides(intent: SafeIntent, pocketVideoFetchScheduler: PocketVideoFetchScheduler) {
         intent.extras?.getLong(EXTRA_FETCH_DELAY_KEY)?.let { delay ->
-            context.serviceLocator.pocketVideoFetchScheduler.setQAFetchDelayOverride(delay)
+            pocketVideoFetchScheduler.setQAFetchDelayOverride(delay)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
@@ -57,6 +57,7 @@ object IntentValidator {
 
     fun validate(context: Context, intent: SafeIntent): ValidatedIntentData? {
         setExperimentOverrides(intent, context)
+        changeFetchDelaySecondsForQA(intent)
 
         when (intent.action) {
             Intent.ACTION_MAIN -> {
@@ -66,12 +67,6 @@ object IntentValidator {
                 if (dialParams.isNotEmpty()) {
                     TelemetryIntegration.INSTANCE.youtubeCastEvent()
                     return ValidatedIntentData(url = "https://www.youtube.com/tv?$dialParams", source = Session.Source.ACTION_VIEW)
-                }
-
-                // The fetch delay can be changed for testing purposes through an intent with custom flag
-                // fetchDelay. Where fetchDelay is the intended next fetch time in seconds.
-                else if (extras.containsKey(EXTRA_FETCH_DELAY_KEY)) {
-                    PocketVideoFetchScheduler.setDelayForQA(extras.getLong(EXTRA_FETCH_DELAY_KEY))
                 }
             }
             Intent.ACTION_VIEW -> {
@@ -103,6 +98,12 @@ object IntentValidator {
 
         experimentsArray.forEach {
             fretboard.setOverride(context, ExperimentDescriptor(it), true)
+        }
+    }
+
+    private fun changeFetchDelaySecondsForQA(intent: SafeIntent) {
+        intent.extras?.getLong(EXTRA_FETCH_DELAY_KEY)?.let { delay ->
+            PocketVideoFetchScheduler.setDelayForQA(delay)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/IntentValidator.kt
@@ -13,12 +13,11 @@ import mozilla.components.browser.session.Session
 import mozilla.components.service.fretboard.ExperimentDescriptor
 import mozilla.components.support.utils.SafeIntent
 import org.mozilla.tv.firefox.ext.serviceLocator
-import org.mozilla.tv.firefox.pocket.PocketVideoFetchScheduler
 import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 import org.mozilla.tv.firefox.utils.UrlUtils
 
 private const val EXTRA_ACTIVE_EXPERIMENTS = "qaActiveExperiments"
-private const val EXTRA_FETCH_DELAY_KEY = "fetchDelay"
+private const val EXTRA_FETCH_DELAY_KEY = "qaFetchDelaySeconds"
 
 data class ValidatedIntentData(val url: String, val source: Session.Source)
 
@@ -57,12 +56,10 @@ object IntentValidator {
 
     fun validate(context: Context, intent: SafeIntent): ValidatedIntentData? {
         setExperimentOverrides(intent, context)
-        changeFetchDelaySecondsForQA(intent)
+        changeFetchDelaySecondsForQA(intent, context)
 
         when (intent.action) {
             Intent.ACTION_MAIN -> {
-                val extras = intent.extras ?: return null
-
                 val dialParams = intent.extras?.getString(DIAL_PARAMS_KEY) ?: return null
                 if (dialParams.isNotEmpty()) {
                     TelemetryIntegration.INSTANCE.youtubeCastEvent()
@@ -101,9 +98,9 @@ object IntentValidator {
         }
     }
 
-    private fun changeFetchDelaySecondsForQA(intent: SafeIntent) {
+    private fun changeFetchDelaySecondsForQA(intent: SafeIntent, context: Context) {
         intent.extras?.getLong(EXTRA_FETCH_DELAY_KEY)?.let { delay ->
-            PocketVideoFetchScheduler.setDelayForQA(delay)
+            context.serviceLocator.pocketVideoFetchScheduler.setDelayForQA(delay)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchScheduler.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchScheduler.kt
@@ -53,14 +53,15 @@ class PocketVideoFetchScheduler(
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
 
+        // This sets the custom fetch delay for testing purposes.
+        // The custom delay will only run once.
         val delay: Long
         val workPolicy: ExistingWorkPolicy
 
-        // This sets the custom fetch delay for testing purposes.
-        // The custom delay will only run once.
         if (IS_QA_BUILD) {
-            delay = DELAY_TIME_FOR_QA_MILLIS
+            delay = checkNotNull(DELAY_TIME_FOR_QA_MILLIS) { "Fetch delay value must be set" }
             workPolicy = ExistingWorkPolicy.REPLACE
+            // Only allow this value to be used once so we do not end up spamming the Pocket servers
             IS_QA_BUILD = false
         } else {
             delay = getDelayUntilUpcomingNightFetchMillis(now, randLong)
@@ -110,6 +111,11 @@ class PocketVideoFetchScheduler(
         return userFetchTime.timeInMillis - now.timeInMillis
     }
 
+    fun setDelayForQA(seconds: Long) {
+        IS_QA_BUILD = true
+        DELAY_TIME_FOR_QA_MILLIS = TimeUnit.SECONDS.toMillis(seconds)
+    }
+
     companion object {
         @VisibleForTesting(otherwise = PRIVATE) const val FETCH_START_HOUR = 3 // am
         @VisibleForTesting(otherwise = PRIVATE) const val FETCH_END_HOUR = 5L
@@ -120,12 +126,8 @@ class PocketVideoFetchScheduler(
         @VisibleForTesting(otherwise = PRIVATE) val BACKOFF_DELAY_MIN_MILLIS = TimeUnit.SECONDS.toMillis(30)
         @VisibleForTesting(otherwise = PRIVATE) val BACKOFF_DELAY_MAX_MILLIS = TimeUnit.SECONDS.toMillis(60)
 
-        private var DELAY_TIME_FOR_QA_MILLIS = TimeUnit.SECONDS.toMillis(5)
+        private var DELAY_TIME_FOR_QA_MILLIS: Long? = null
         private var IS_QA_BUILD = false
-        fun setDelayForQA(seconds: Long) {
-            IS_QA_BUILD = true
-            DELAY_TIME_FOR_QA_MILLIS = TimeUnit.SECONDS.toMillis(seconds)
-        }
     }
 }
 

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchScheduler.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchScheduler.kt
@@ -66,6 +66,7 @@ class PocketVideoFetchScheduler(
             delay = getDelayUntilUpcomingNightFetchMillis(now, randLong)
             workPolicy = ExistingWorkPolicy.KEEP
         }
+
         // When the user foregrounds the app, we schedule a one time update for a random time inside our fetch interval
         // (currently overnight). This will ensure that users always see fresh content every morning and that the content
         // is only refreshing at times when the user is most likely not using the app.

--- a/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchScheduler.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/pocket/PocketVideoFetchScheduler.kt
@@ -29,6 +29,7 @@ class PocketVideoFetchScheduler(
 ) : LifecycleObserver {
     private var qaFetchDelayOverrideMillis: Long? = null
     private var isQABuild = false
+    init { resetQAFetchDelayOverrides() } // Replace initial values above to avoid duplication.
 
     @OnLifecycleEvent(ON_START)
     fun onStart() {
@@ -112,8 +113,7 @@ class PocketVideoFetchScheduler(
     }
 
     /**
-     * Used for QA to set the fetch delay to a specified number of seconds. This is set through
-     * a custom intent.
+     * Sets the fetch delay to a specified number of seconds. This makes it easier to manually test.
      */
     fun setQAFetchDelayOverride(seconds: Long) {
         isQABuild = true
@@ -121,7 +121,7 @@ class PocketVideoFetchScheduler(
     }
 
     /**
-     * Used to reset QA fetch delay values after each use so we do not end up spamming the Pocket servers.
+     * Resets the fetch delay values to production values. We do this so we do not spam the Pocket servers.
      */
     private fun resetQAFetchDelayOverrides() {
         isQABuild = false


### PR DESCRIPTION
This allows QA to start the app through an intent with this command:
`adb shell am start -n org.mozilla.tv.firefox/org.mozilla.tv.firefox.MainActivity -a android.intent.action.MAIN --el qaFetchDelaySeconds 10`
where `qaFetchDelaySeconds` is in seconds.

The custom delay will only apply once. You need to run the command every time you want to use that custom delay.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
