### PR TITLE
Add commandline control over fretboard experiments

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
@@ -61,22 +61,22 @@ class ExperimentsProvider(private val fretboard: Fretboard, private val context:
     }
 
     fun shouldShowTvGuideChannels(): Boolean {
-        return false // TODO Before enabling this code:
+// TODO before releasing to more than 0 population:
 //        - Add final channel content (list will be added to #2322)
 //        - Make sure all tiles have images (assets will be added to #2357)
 //        - Remove ChannelRepo#padToTen
 
-//        val expDescriptor = checkBranchVariants(ExperimentConfig.TV_GUIDE_CHANNELS)
-//        return when {
-//            // The user is currently not part of the experiment
-//            expDescriptor == null -> false
-//            expDescriptor.name.endsWith(ExperimentSuffix.A.value) -> false
-//            expDescriptor.name.endsWith(ExperimentSuffix.B.value) -> true
-//            else -> {
-//                Sentry.capture(ExperimentIllegalStateException("TV Guide Channels Illegal Branch Name"))
-//                false
-//            }
-//        }
+        val expDescriptor = checkBranchVariants(ExperimentConfig.TV_GUIDE_CHANNELS)
+        return when {
+            // The user is currently not part of the experiment
+            expDescriptor == null -> false
+            expDescriptor.name.endsWith(ExperimentSuffix.A.value) -> false
+            expDescriptor.name.endsWith(ExperimentSuffix.B.value) -> true
+            else -> {
+                Sentry.capture(ExperimentIllegalStateException("TV Guide Channels Illegal Branch Name"))
+                false
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
I based this off of Daniela's PR, but that could be pulled out (and could optionally depend on the `isQA` flag).

This is meant to be QA only, and run from command-line with intent extras and isn't an expected user path.

See usage [here](https://github.com/mozilla-mobile/firefox-tv/issues/2320#issuecomment-498904888). I'd probably add this explanation to the README as well (or our Fretboard documentation).

A few things probably should be updated from previous TODOs in the code.

One thing I learned is that for experiments to run at all, they need to be on Kinto - otherwise, the experiment just shortcircuits before you can handle overrides, etc.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
