### PR TITLE
Closes #2379: fixes YouTube focus loss on menu press

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/focus/FocusRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/focus/FocusRepo.kt
@@ -15,7 +15,6 @@ import org.mozilla.tv.firefox.ScreenController
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.ActiveScreen
 import org.mozilla.tv.firefox.ext.validateKnownViewById
 import org.mozilla.tv.firefox.channels.pinnedtile.PinnedTileRepo
-import org.mozilla.tv.firefox.ext.ENGINE_VIEW_ID
 import org.mozilla.tv.firefox.pocket.PocketVideoRepo
 import org.mozilla.tv.firefox.session.SessionRepo
 import org.mozilla.tv.firefox.utils.URLs
@@ -143,7 +142,7 @@ class FocusRepo(
                     R.id.turboButton -> {
                         return getTurboButtonFocusState(focusNode, sessionState)
                     }
-                    View.NO_ID, ENGINE_VIEW_ID -> {
+                    View.NO_ID -> {
                         // Focus is lost so default it to navUrlInput and set focused = false
                         val newFocusNode = FocusNode(R.id.navUrlInput)
 


### PR DESCRIPTION
RCA:
0b7e1b9 made a change where any time the active screen is the overlay and the EngineView receives focus, focus is moved to the NavUrlBar. However it looks like this is getting hit while switching between overlay and render fragments (because our internal representation of current screen and the actually active screen are not exactly in sync). This moves focus around while on YouTube, breaking its navigation.

The change made here will partially reintroduce #2354. Focus will be non-fatally lost (hitting buttons will bring it back), and no crash will occur. This is a less frequent case than #2379 and focus is extremely finicky, so it's an acceptable change.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
Bug never reached users
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
