### PR TITLE
No issue: replace releng with relman, fixing links

### DIFF
--- a/.github/ISSUE_TEMPLATE/---relman-checklist.md
+++ b/.github/ISSUE_TEMPLATE/---relman-checklist.md
@@ -1,7 +1,7 @@
 ---
-name: "✅ Releng checklist"
+name: "✅ Release management checklist"
 about: Keep track of the release activities
-title: 'Releng checklist - vX.X'
+title: 'Release management checklist - vX.X'
 
 ---
 
@@ -19,7 +19,7 @@ _Think something can be automated? Add it to [this doc](https://docs.google.com/
 - [ ] Create PR for bumping version (`X.X-LAT1`)
   - Merge to master
 - [ ] Cut LAT branch `releases/vX.X-LAT1`
-- [ ] Create GitHub pre-release build `vX.X-LAT1`([instructions](https://github.com/mozilla-mobile/firefox-tv/wiki/Releng-Checklist#final-builds))
+- [ ] Create GitHub pre-release build `vX.X-LAT1`([instructions](https://github.com/mozilla-mobile/firefox-tv/wiki/Release-Management-Checklist#final-builds))
 - [ ] Release LAT ([instructions](https://developer.amazon.com/docs/app-testing/live-app-testing-getting-started.html))
 
 #### Wednesday # 2 (soft code freeze)
@@ -27,14 +27,14 @@ _Think something can be automated? Add it to [this doc](https://docs.google.com/
 - [ ] Create PR for bumping version (`X.X-LAT2`)
   - Merge to master
 - [ ] Cut LAT branch `releases/vX.X-LAT2`
-- [ ] Create GitHub pre-release build `vX.X-LAT2` ([instructions](https://github.com/mozilla-mobile/firefox-tv/wiki/Releng-Checklist#final-builds))
+- [ ] Create GitHub pre-release build `vX.X-LAT2` ([instructions](https://github.com/mozilla-mobile/firefox-tv/wiki/Release-Management-Checklist#final-builds))
 - [ ] Release LAT ([instructions](https://developer.amazon.com/docs/app-testing/live-app-testing-getting-started.html))
 
 #### Thursday # 2
 
 - [ ] [QA] run screenshot test and upload ([instructions](https://github.com/mozilla-mobile/firefox-tv/wiki/Localization#screenshots))
 - [ ] Upgrade a-c on master
-- [ ] File new Releng checklist with next version and add to top of Backlog
+- [ ] File new Release Management checklist with next version and add to top of Backlog
 
 #### Friday # 2 (hard code freeze)
 
@@ -47,7 +47,7 @@ _Think something can be automated? Add it to [this doc](https://docs.google.com/
     features are missing and add the new release header (don't forget to add the diff links at the bottom)
   - Merge to master
 - [ ] Cut release branch `releases/vX.X`
-- [ ] Create GitHub release build `vX.X`([instructions](https://github.com/mozilla-mobile/firefox-tv/wiki/Releng-Checklist#final-builds))
+- [ ] Create GitHub release build `vX.X`([instructions](https://github.com/mozilla-mobile/firefox-tv/wiki/Release-Management-Checklist#final-builds))
 - [ ] Submit app with staged rollout at 1% ([instructions](https://developer.amazon.com/docs/app-submission/submitting-apps-to-amazon-appstore.html))
 
 #### Tuesday # 3


### PR DESCRIPTION
Release engineering is infrastructure for releases while release management, what we do, is doing the people work to push a release out the door.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
