### PR TITLE
Update pocket telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/channels/ChannelConfig.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/channels/ChannelConfig.kt
@@ -24,8 +24,11 @@ data class ChannelConfig(
     val enabledInLocales: KillswitchLocales
 ) {
     companion object {
-        fun getPocketConfig(): ChannelConfig = ChannelConfig(
-                onClickTelemetry = { tile -> TELEMETRY.pocketVideoClickEvent(tile.id) },
+        fun getPocketConfig(context: Context): ChannelConfig = ChannelConfig(
+                onClickTelemetry = { tile ->
+                    TELEMETRY.pocketVideoClickEvent(tile.id)
+                    TELEMETRY.homeTileClickEvent(context, tile)
+                },
                 // TODO focus telemetry should probably only be sent on focus gain, but this is
                 //  how our previous implementation worked. Keeping this to maintain data consistency
                 onFocusTelemetry = { tile, _ -> TELEMETRY.pocketVideoImpressionEvent(tile.id) },

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -435,7 +435,7 @@ private class ChannelReferenceContainer(
     val pocketChannel = channelFactory.createChannel(
         parent = channelContainerView,
         id = R.id.pocket_channel,
-        channelConfig = ChannelConfig.getPocketConfig()
+        channelConfig = ChannelConfig.getPocketConfig(channelContainerView.context)
     )
 
     val pinnedTileChannel = channelFactory.createChannel(

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -72,7 +72,7 @@ The event ping contains a list of events ([see event format on readthedocs.io](h
 | Turbo mode switch clicked              | action   | change                | turbo_mode   | on/off (the new value)   |               |
 | Pin site switch clicked                | action   | change                | pin_page     | on/off (the new value)   | desktop_mode* |
 | Desktop mode switch clicked            | action   | change                | desktop_mode | on/off (the new value)   |               |
-| Tile clicked                           | action   | click                 | home_tile    | bundled/custom/youtube** | tile_id***    |
+| Tile clicked                           | action   | click                 | home_tile    | bundled/custom/pocket/youtube** | tile_id***    |
 | Tile removed                           | action   | remove                | home_tile    | bundled/custom           |               |
 | Unique tiles clicked per session       | aggregate| click                 | home_tile    | `<int>`                  |               |
 | Menu opened by menu key †              | action   | user_show             | menu         |                          |               |


### PR DESCRIPTION
When we removed the Pocket Megatile, we also removed the telemetry for Pocket clicks. This is now only sent in the PocketPing, but that's not correlated to our telemetry clientID, so we need to add a "pocket" type to the home tile clicked ping.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
