### PR TITLE
Issue #2445 - Upgrade AC to 1.0.0

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -110,7 +110,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         // TODO: refactor out the debug variant visibility check in #1953
         BuildConstants.debugLogStr?.apply {
             debugLog.visibility = View.VISIBLE
-            debugLog.text = this
+            debugLog.text = "$this ${webRenderComponents.engine.version}"
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.architecture_components_version = '2.0.0'
     ext.kotlin_version = '1.3.31'
     ext.coroutines_version = '1.0.1'
-    ext.moz_components_version = '0.56.1'
+    ext.moz_components_version = '1.0.0'
     ext.androidx_work_version = '2.0.1'
 
     ext.robolectric_version = '4.0.2' // required for SDK 28.


### PR DESCRIPTION
I also looked at upgrading the [GeckoView version](https://github.com/mozilla-mobile/android-components/blob/v1.0.0/buildSrc/src/main/java/Gecko.kt) but it seems like the current version doesn't build w/ GVDebug anyway so there didn't seem to be any point.
 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
