### PR TITLE
Set the Firebase test device OS to 7.1 to match Stick 4K !!

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -44,7 +44,7 @@ tasks:
           && ./tools/taskcluster/upload-coverage-report.sh
           && ./tools/taskcluster/download-firebase-sdk.sh
           && ./tools/taskcluster/google-firebase-testlab-login.sh
-          && ./tools/taskcluster/execute-firebase-test.sh system/debug app-system-debug model=cheryl,version=25,orientation=landscape
+          && ./tools/taskcluster/execute-firebase-test.sh system/debug app-system-debug model=Nexus9,version=25,orientation=landscape
       artifacts:
         'public/reports':
           type: 'directory'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -44,7 +44,7 @@ tasks:
           && ./tools/taskcluster/upload-coverage-report.sh
           && ./tools/taskcluster/download-firebase-sdk.sh
           && ./tools/taskcluster/google-firebase-testlab-login.sh
-          && ./tools/taskcluster/execute-firebase-test.sh system/debug app-system-debug model=sailfish,version=25,orientation=landscape
+          && ./tools/taskcluster/execute-firebase-test.sh system/debug app-system-debug model=cheryl,version=25,orientation=landscape
       artifacts:
         'public/reports':
           type: 'directory'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -44,7 +44,7 @@ tasks:
           && ./tools/taskcluster/upload-coverage-report.sh
           && ./tools/taskcluster/download-firebase-sdk.sh
           && ./tools/taskcluster/google-firebase-testlab-login.sh
-          && ./tools/taskcluster/execute-firebase-test.sh system/debug app-system-debug model=taimen,version=26,orientation=landscape
+          && ./tools/taskcluster/execute-firebase-test.sh system/debug app-system-debug model=sailfish,version=25,orientation=landscape
       artifacts:
         'public/reports':
           type: 'directory'


### PR DESCRIPTION
Connected to #???

## Testing and Review Notes
Firebase tests are running on API 26, which is newer than newest OS available for Fire TV Stick, it should be set to API 25 which Fire TV 4K Stick uses

## Checklist
<!-- Before submitting and merging the PR, please address each item -->

- [ ] Confirm the  **acceptance criteria is/are fully satisfied** in the issue(s) this PR will close
- [ ] Add **testing notes and/or screenshots** in PR description to help guide all potential reviewers
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
