### PR TITLE
No issue: add a-c loggers to logcat!!

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/FirefoxApplication.kt
@@ -8,6 +8,8 @@ import android.os.StrictMode
 import androidx.annotation.VisibleForTesting
 import android.webkit.WebSettings
 import mozilla.components.service.glean.Glean
+import mozilla.components.support.base.log.Log
+import mozilla.components.support.base.log.sink.AndroidLogSink
 import mozilla.components.support.ktx.android.content.runOnlyInMainProcess
 import org.mozilla.tv.firefox.components.locale.LocaleAwareApplication
 import org.mozilla.tv.firefox.telemetry.SentryIntegration
@@ -17,6 +19,8 @@ import org.mozilla.tv.firefox.utils.BuildConstants
 import org.mozilla.tv.firefox.utils.OkHttpWrapper
 import org.mozilla.tv.firefox.utils.ServiceLocator
 import org.mozilla.tv.firefox.webrender.WebRenderComponents
+
+private const val DEFAULT_LOGTAG = "FFTV"
 
 open class FirefoxApplication : LocaleAwareApplication() {
     lateinit var visibilityLifeCycleCallback: VisibilityLifeCycleCallback
@@ -40,6 +44,8 @@ open class FirefoxApplication : LocaleAwareApplication() {
 
     override fun onCreate() {
         super.onCreate()
+
+        enableAndroidComponentsLogging() // In theory, the Gecko process may use this logger so init for all processes.
 
         // If this is not the main process then do not continue with the initialization here. Everything that
         // follows only needs to be done in our app's main process and should not be done in other processes like
@@ -116,4 +122,8 @@ open class FirefoxApplication : LocaleAwareApplication() {
         serviceLocator.sessionManager.onLowMemory()
         // If you need to dump more memory, you may be able to clear the Picasso cache.
     }
+}
+
+private fun enableAndroidComponentsLogging() {
+    Log.addSink(AndroidLogSink(defaultTag = DEFAULT_LOGTAG))
 }


### PR DESCRIPTION

Apparently, the app must explicitly enable a-c's internal logging
through this code.

Connected to #???
<!-- Optional: the primary or additional issues or pull requests related to this, but merging this would not close it unless in the commit message -->

## Testing and Review Notes
<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos
<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->


## Checklist
<!-- Before submitting and merging the PR, please address each item -->

- [x] Confirm the  **acceptance criteria is/are fully satisfied** in the issue(s) this PR will close
- [x] Add **testing notes and/or screenshots** in PR description to help guide all potential reviewers
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
