### PR TITLE
Issue #2445: Add FxA account sign in

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,6 +147,7 @@ dependencies {
     implementation "org.mozilla.components:feature-session:$moz_components_version"
     implementation "org.mozilla.components:ui-icons:$moz_components_version"
     implementation "org.mozilla.components:service-fretboard:$moz_components_version"
+    implementation "org.mozilla.components:service-firefox-accounts:$moz_components_version"
     implementation "org.mozilla.components:support-ktx:$moz_components_version"
     implementation "org.mozilla.components:support-utils:$moz_components_version"
     implementation "org.mozilla.components:service-glean:$moz_components_version"

--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentConfig.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentConfig.kt
@@ -10,9 +10,13 @@ import mozilla.components.service.fretboard.ExperimentDescriptor
  * [ExperimentConfig] defines a set of supported [ExperimentDescriptor] from [Fretboard]
  */
 enum class ExperimentConfig(val value: String) {
+    // N.B.: an experiment WILL ALWAYS BE DISABLED if it is not added to the fretboard backend.
+    //
+    // The format is: "ExperimentName-IssueNumberForExperiment"
     AA_TEST("AAtest-1675"),
     HINT_BAR_TEST("HintBar-2011"),
-    TV_GUIDE_CHANNELS("TvGuideChannels-2195")
+    TV_GUIDE_CHANNELS("TvGuideChannels-2195"),
+    SEND_TAB("SendTab-2511")
 }
 
 /**

--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
@@ -74,6 +74,19 @@ class ExperimentsProvider(private val fretboard: Fretboard, private val context:
         }
     }
 
+    fun shouldShowSendTab(): Boolean {
+        val expDescriptor = checkBranchVariants(ExperimentConfig.SEND_TAB)
+        return when {
+            expDescriptor == null -> false // Experiment unknown, or overridden to be false.
+            expDescriptor.name.endsWith(ExperimentSuffix.A.value) -> false
+            expDescriptor.name.endsWith(ExperimentSuffix.B.value) -> true
+            else -> {
+                Sentry.capture(ExperimentIllegalStateException("FxA Login Illegal Branch Name"))
+                false
+            }
+        }
+    }
+
     /**
      * Check if [ExperimentConfig] + [ExperimentSuffix] is in the experiment and return its
      * corresponding [ExperimentDescriptor].

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaLoginUseCase.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaLoginUseCase.kt
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.fxa
+
+import android.net.Uri
+import androidx.fragment.app.FragmentManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import org.mozilla.tv.firefox.ScreenController
+import org.mozilla.tv.firefox.session.SessionRepo
+import org.mozilla.tv.firefox.telemetry.SentryIntegration
+
+private const val LOGTAG = "FxaLoginUseCase"
+
+/**
+ * Manages login with a Firefox Account (FxA).
+ *
+ * To begin the login flow, we call [beginLogin]: this loads the login page into the engine view. This login page
+ * does the heavy lifting: most error states (e.g. invalid credentials) are handled in the engine view and are not
+ * reported to us. On success, our observer in this class transmits the results from the engine view back to the FxA
+ * library. After that, control of FxA state is returned to the [fxaRepo].
+ *
+ * This class was created as a "super repo": it allows repos to interact with each other without having
+ * references to each other, eliminating possible circular dependencies.
+ */
+class FxaLoginUseCase(
+    private val fxaRepo: FxaRepo,
+    private val sessionRepo: SessionRepo,
+    private val screenController: ScreenController,
+    private val sentryIntegration: SentryIntegration = SentryIntegration
+) {
+
+    /**
+     * Opens the browser screen and loads the FxA login URL to begin the login flow.
+     */
+    fun beginLogin(fragmentManager: FragmentManager) {
+        // TODO: should we throw an error if we're already authenticated when this is called?
+        GlobalScope.launch(Dispatchers.Main) { // main thread: we modify UI state.
+            // a-c#3713: this await will never resume if the user is already logged in.
+            val loginUri = fxaRepo.beginLoginInternalAsync().await()
+
+            // This may be null when the FxA library fails to do things internally, mostly likely due to network issues.
+            if (loginUri == null) {
+                sentryIntegration.captureAndLogError(
+                    LOGTAG, IllegalStateException("beginAuthenticationAsync returned null loginUri"))
+                return@launch
+            }
+
+            // TODO: if user is already signing in, we should consider not reloading the page.
+            screenController.showBrowserScreenForUrl(fragmentManager, loginUri)
+        }
+    }
+
+    init {
+        attachFxaLoginSuccessObserver() // @Suppress cannot be used on an initializer so we call a helper method.
+    }
+
+    @Suppress("CheckResult") // no need to dispose: sessionRepo is active for the duration of the app.
+    private fun attachFxaLoginSuccessObserver() {
+        fun isLoginSuccessUri(uri: String): Boolean = uri.startsWith(FxaRepo.REDIRECT_URI)
+
+        fun extractLoginSuccessKeys(uriStr: String): LoginSuccessKeys? {
+            val uri = Uri.parse(uriStr)
+            val code = uri.getQueryParameter("code")
+            val state = uri.getQueryParameter("state")
+            return if (code != null && state != null) LoginSuccessKeys(code = code, state = state) else null
+        }
+
+        sessionRepo.state
+            .map { it.currentUrl }
+            .distinctUntilChanged()
+            .subscribe {
+                if (!isLoginSuccessUri(it)) {
+                    return@subscribe
+                }
+
+                val loginSuccessKeys = extractLoginSuccessKeys(it)
+                if (loginSuccessKeys == null) {
+                    // Since we received a login success URL, this is never expected. However, since this action is
+                    // controlled by a server, we don't want to crash the app so we log to Sentry instead.
+                    sentryIntegration.captureAndLogError(
+                        LOGTAG, IllegalStateException("Received success URI but success keys cannot be found"))
+                    return@subscribe
+                }
+
+                // TODO: do we want to pop these fxa pages from the user's browsing history?
+                fxaRepo.accountManager.finishAuthenticationAsync(loginSuccessKeys)
+            }
+    }
+
+    private data class LoginSuccessKeys(val code: String, val state: String)
+
+    private fun FxaAccountManager.finishAuthenticationAsync(keys: LoginSuccessKeys) {
+        @Suppress("DeferredResultUnused") // We don't care to wait until completion.
+        finishAuthenticationAsync(code = keys.code, state = keys.state)
+    }
+}

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaLoginUseCase.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaLoginUseCase.kt
@@ -10,11 +10,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.tv.firefox.ScreenController
 import org.mozilla.tv.firefox.session.SessionRepo
 import org.mozilla.tv.firefox.telemetry.SentryIntegration
 
-private const val LOGTAG = "FxaLoginUseCase"
+private val logger = Logger("FxaLoginUseCase")
 
 /**
  * Manages login with a Firefox Account (FxA).
@@ -46,7 +47,7 @@ class FxaLoginUseCase(
             // This may be null when the FxA library fails to do things internally, mostly likely due to network issues.
             if (loginUri == null) {
                 sentryIntegration.captureAndLogError(
-                    LOGTAG, IllegalStateException("beginAuthenticationAsync returned null loginUri"))
+                    logger, IllegalStateException("beginAuthenticationAsync returned null loginUri"))
                 return@launch
             }
 
@@ -83,7 +84,7 @@ class FxaLoginUseCase(
                     // Since we received a login success URL, this is never expected. However, since this action is
                     // controlled by a server, we don't want to crash the app so we log to Sentry instead.
                     sentryIntegration.captureAndLogError(
-                        LOGTAG, IllegalStateException("Received success URI but success keys cannot be found"))
+                        logger, IllegalStateException("Received success URI but success keys cannot be found"))
                     return@subscribe
                 }
 

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaLoginUseCase.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaLoginUseCase.kt
@@ -25,8 +25,14 @@ private val logger = Logger("FxaLoginUseCase")
  * reported to us. On success, our observer in this class transmits the results from the engine view back to the FxA
  * library. After that, control of FxA state is returned to the [fxaRepo].
  *
- * This class was created as a "super repo": it allows repos to interact with each other without having
- * references to each other, eliminating possible circular dependencies.
+ * This class is designed to allows repos to interact with each other without references to each other,
+ * allowing each repo to operate independently of other repos, simplifying state.
+ *
+ * FxaRepo    SessionRepo
+ *    |            |
+ *     ------------
+ *           |
+ *    FxaLoginUseCase
  */
 class FxaLoginUseCase(
     private val fxaRepo: FxaRepo,

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaLoginUseCase.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaLoginUseCase.kt
@@ -63,7 +63,8 @@ class FxaLoginUseCase(
     }
 
     init {
-        attachFxaLoginSuccessObserver() // @Suppress cannot be used on an initializer so we call a helper method.
+        // @Suppress cannot be used on an initializer so we call a helper method.
+        attachFxaLoginSuccessObserver()
     }
 
     @Suppress("CheckResult") // no need to dispose: sessionRepo is active for the duration of the app.

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.fxa
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ProcessLifecycleOwner
+import io.reactivex.subjects.BehaviorSubject
+import kotlinx.coroutines.Deferred
+import mozilla.appservices.fxaclient.Config
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.DeviceCapability
+import mozilla.components.concept.sync.DeviceEvent
+import mozilla.components.concept.sync.DeviceEventsObserver
+import mozilla.components.concept.sync.DeviceType
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.concept.sync.Profile
+import mozilla.components.service.fxa.manager.DeviceTuple
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.AUTHENTICATED
+import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.AUTHENTICATED_NO_PROFILE
+import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.NEEDS_REAUTHENTICATION
+import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.NOT_AUTHENTICATED
+
+private const val LOGTAG = "FxaRepo"
+
+/**
+ * Manages Firefox Account (FxA) state. In particular, [accountStateDontUseMeYet] exposes the current sign in
+ * state of the user. If you want to initiate sign in, see [FxaLoginUseCase.beginLogin].
+ *
+ * Devs should use this class rather than interacting with the FxA library directly.
+ */
+class FxaRepo(
+    context: Context,
+    val accountManager: FxaAccountManager = newInstanceDefaultAccountManager(context)
+) {
+
+    enum class AccountState {
+        // TODO: Are these states accurate?
+        // TODO: Later, may need "failed to login": https://github.com/mozilla-mobile/android-components/issues/3712
+        AUTHENTICATED,
+        AUTHENTICATED_NO_PROFILE, // todo: necessary? profile seems to be fetched async so yes?
+        NEEDS_REAUTHENTICATION,
+        NOT_AUTHENTICATED
+        // TODO: do we need initial state before state is fetched from disk?
+    }
+
+    // TODO: set state accurately, choose correct subject, set initial state, etc.
+    val accountStateDontUseMeYet = BehaviorSubject.create<AccountState>()
+
+    init {
+        accountManager.register(FirefoxAccountObserver())
+        accountManager.registerForDeviceEvents(FirefoxDeviceEventsObserver(), ProcessLifecycleOwner.get(),
+            autoPause = false /* Avoid pausing even when the app is backgrounded. */)
+
+        @Suppress("DeferredResultUnused") // No value is returned & we don't need to wait for this to complete.
+        accountManager.initAsync() // If user is already logged in, the appropriate observers will be triggered.
+    }
+
+    /**
+     * Notifies the FxA library that login is starting: callers should generally call [FxaLoginUseCase.beginLogin]
+     * instead of this method.
+     */
+    fun beginLoginInternalAsync(): Deferred<String?> {
+        return accountManager.beginAuthenticationAsync()
+    }
+
+    private inner class FirefoxAccountObserver : AccountObserver {
+        override fun onAuthenticated(account: OAuthAccount) {
+            Log.d(LOGTAG, "onAuthenticated")
+            // todo: is this correct?
+            val nextState = if (accountManager.accountProfile() != null) AUTHENTICATED else AUTHENTICATED_NO_PROFILE
+            accountStateDontUseMeYet.onNext(nextState)
+        }
+
+        override fun onAuthenticationProblems() {
+            Log.d(LOGTAG, "onAuthenticationProblems")
+            accountStateDontUseMeYet.onNext(NEEDS_REAUTHENTICATION)
+        }
+
+        override fun onError(error: Exception) {
+            // This is for internal errors in the sync library and is an unexpected state.
+            Log.d(LOGTAG, "onError")
+        }
+
+        override fun onLoggedOut() {
+            Log.d(LOGTAG, "onLoggedOut")
+            accountStateDontUseMeYet.onNext(NOT_AUTHENTICATED)
+        }
+
+        override fun onProfileUpdated(profile: Profile) {
+            Log.d(LOGTAG, "onProfileUpdated")
+            // todo: update state.
+        }
+    }
+
+    private inner class FirefoxDeviceEventsObserver : DeviceEventsObserver {
+        override fun onEvents(events: List<DeviceEvent>) {
+            Log.d(LOGTAG, "received device events: $events")
+        }
+    }
+
+    companion object {
+        // TODO #2506: use production FFTV client ID (this ID is from an FxA sample app).
+        private const val CLIENT_ID = "a2270f727f45f648"
+        const val REDIRECT_URI = "https://accounts.firefox.com/oauth/success/$CLIENT_ID"
+
+        private fun newInstanceDefaultAccountManager(context: Context): FxaAccountManager {
+            return FxaAccountManager(
+                context,
+                Config.release(CLIENT_ID, REDIRECT_URI),
+                applicationScopes = arrayOf("profile", "https://identity.mozilla.com/apps/oldsync"), // todo: proper vals?
+                deviceTuple = DeviceTuple(
+                    name = "Firefox for Fire TV",
+                    type = DeviceType.MOBILE, // todo: proper values?
+                    capabilities = listOf(DeviceCapability.SEND_TAB) // todo: proper values?
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -16,7 +16,7 @@ import mozilla.components.concept.sync.DeviceEventsObserver
 import mozilla.components.concept.sync.DeviceType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
-import mozilla.components.service.fxa.manager.DeviceTuple
+import mozilla.components.service.fxa.DeviceConfig
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.AUTHENTICATED
@@ -26,7 +26,7 @@ import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.NOT_AUTHENTICATED
 
 private val logger = Logger("FxaRepo")
 
-private val APPLICATION_SCOPES = arrayOf(
+private val APPLICATION_SCOPES = setOf(
     // We don't use sync, however, if we later add the sync scope, already authenticated users
     // will have to log in again. To avoid this in the future, we preemptively declare a sync scope.
     "https://identity.mozilla.com/apps/oldsync"
@@ -90,11 +90,6 @@ class FxaRepo(
             accountStateDontUseMeYet.onNext(NEEDS_REAUTHENTICATION)
         }
 
-        override fun onError(error: Exception) {
-            // This is for internal errors in the sync library and is an unexpected state.
-            logger.debug("onError")
-        }
-
         override fun onLoggedOut() {
             logger.debug("onLoggedOut")
             accountStateDontUseMeYet.onNext(NOT_AUTHENTICATED)
@@ -122,11 +117,12 @@ class FxaRepo(
                 context,
                 Config.release(CLIENT_ID, REDIRECT_URI),
                 applicationScopes = APPLICATION_SCOPES,
-                deviceTuple = DeviceTuple(
+                deviceConfig = DeviceConfig(
                     name = "Firefox for Fire TV", // TODO: #2516 choose final value.
                     type = DeviceType.MOBILE, // TODO: appservices is considering adding DeviceType.TV.
-                    capabilities = listOf(DeviceCapability.SEND_TAB) // required to receive tabs.
-                )
+                    capabilities = setOf(DeviceCapability.SEND_TAB) // required to receive tabs.
+                ),
+                syncConfig = null
             )
         }
     }

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -26,6 +26,12 @@ import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.NOT_AUTHENTICATED
 
 private const val LOGTAG = "FxaRepo"
 
+private val APPLICATION_SCOPES = arrayOf(
+    // We don't use sync, however, if we later add the sync scope, already authenticated users
+    // will have to log in again. To avoid this in the future, we preemptively declare a sync scope.
+    "https://identity.mozilla.com/apps/oldsync"
+)
+
 /**
  * Manages Firefox Account (FxA) state. In particular, [accountStateDontUseMeYet] exposes the current sign in
  * state of the user. If you want to initiate sign in, see [FxaLoginUseCase.beginLogin].
@@ -111,11 +117,11 @@ class FxaRepo(
             return FxaAccountManager(
                 context,
                 Config.release(CLIENT_ID, REDIRECT_URI),
-                applicationScopes = arrayOf("profile", "https://identity.mozilla.com/apps/oldsync"), // todo: proper vals?
+                applicationScopes = APPLICATION_SCOPES,
                 deviceTuple = DeviceTuple(
-                    name = "Firefox for Fire TV",
-                    type = DeviceType.MOBILE, // todo: proper values?
-                    capabilities = listOf(DeviceCapability.SEND_TAB) // todo: proper values?
+                    name = "Firefox for Fire TV", // TODO: #2516 choose final value.
+                    type = DeviceType.MOBILE, // TODO: appservices is considering adding DeviceType.TV.
+                    capabilities = listOf(DeviceCapability.SEND_TAB) // required to receive tabs.
                 )
             )
         }

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -77,7 +77,11 @@ class FxaRepo(
         override fun onAuthenticated(account: OAuthAccount) {
             Log.d(LOGTAG, "onAuthenticated")
             // todo: is this correct?
-            val nextState = if (accountManager.accountProfile() != null) AUTHENTICATED else AUTHENTICATED_NO_PROFILE
+            val nextState = if (accountManager.accountProfile() != null) {
+                AUTHENTICATED
+            } else {
+                AUTHENTICATED_NO_PROFILE
+            }
             accountStateDontUseMeYet.onNext(nextState)
         }
 

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -5,7 +5,6 @@
 package org.mozilla.tv.firefox.fxa
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.reactivex.subjects.BehaviorSubject
 import kotlinx.coroutines.Deferred
@@ -19,12 +18,13 @@ import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
 import mozilla.components.service.fxa.manager.DeviceTuple
 import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.AUTHENTICATED
 import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.AUTHENTICATED_NO_PROFILE
 import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.NEEDS_REAUTHENTICATION
 import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.NOT_AUTHENTICATED
 
-private const val LOGTAG = "FxaRepo"
+private val logger = Logger("FxaRepo")
 
 private val APPLICATION_SCOPES = arrayOf(
     // We don't use sync, however, if we later add the sync scope, already authenticated users
@@ -75,7 +75,7 @@ class FxaRepo(
 
     private inner class FirefoxAccountObserver : AccountObserver {
         override fun onAuthenticated(account: OAuthAccount) {
-            Log.d(LOGTAG, "onAuthenticated")
+            logger.debug("onAuthenticated")
             // todo: is this correct?
             val nextState = if (accountManager.accountProfile() != null) {
                 AUTHENTICATED
@@ -86,29 +86,29 @@ class FxaRepo(
         }
 
         override fun onAuthenticationProblems() {
-            Log.d(LOGTAG, "onAuthenticationProblems")
+            logger.debug("onAuthenticationProblems")
             accountStateDontUseMeYet.onNext(NEEDS_REAUTHENTICATION)
         }
 
         override fun onError(error: Exception) {
             // This is for internal errors in the sync library and is an unexpected state.
-            Log.d(LOGTAG, "onError")
+            logger.debug("onError")
         }
 
         override fun onLoggedOut() {
-            Log.d(LOGTAG, "onLoggedOut")
+            logger.debug("onLoggedOut")
             accountStateDontUseMeYet.onNext(NOT_AUTHENTICATED)
         }
 
         override fun onProfileUpdated(profile: Profile) {
-            Log.d(LOGTAG, "onProfileUpdated")
+            logger.debug("onProfileUpdated")
             // todo: update state.
         }
     }
 
     private inner class FirefoxDeviceEventsObserver : DeviceEventsObserver {
         override fun onEvents(events: List<DeviceEvent>) {
-            Log.d(LOGTAG, "received device events: $events")
+            logger.debug("received device events: $events")
         }
     }
 

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -31,7 +31,7 @@ import io.reactivex.rxkotlin.addTo
 import kotlinx.android.synthetic.main.fragment_navigation_overlay_orig.channelsContainer
 import kotlinx.android.synthetic.main.fragment_navigation_overlay_orig.navUrlInput
 import kotlinx.android.synthetic.main.fragment_navigation_overlay_orig.settingsTileContainer
-import kotlinx.android.synthetic.main.fragment_navigation_overlay_top_nav.exitButton
+import kotlinx.android.synthetic.main.fragment_navigation_overlay_top_nav.*
 import kotlinx.android.synthetic.main.hint_bar.hintBarContainer
 import kotlinx.coroutines.Job
 import org.mozilla.tv.firefox.MainActivity
@@ -63,7 +63,7 @@ private const val MAX_UNPIN_TOAST_COUNT = 3
 private val uiHandler = Handler(Looper.getMainLooper())
 
 enum class NavigationEvent {
-    BACK, FORWARD, RELOAD, LOAD_URL, LOAD_TILE, TURBO, PIN_ACTION, DESKTOP_MODE, EXIT_FIREFOX,
+    BACK, FORWARD, RELOAD, LOAD_URL, LOAD_TILE, TURBO, PIN_ACTION, DESKTOP_MODE, EXIT_FIREFOX, FXA_BUTTON,
     SETTINGS_DATA_COLLECTION, SETTINGS_CLEAR_COOKIES;
 
     companion object {
@@ -74,6 +74,7 @@ enum class NavigationEvent {
             R.id.turboButton -> TURBO
             R.id.pinButton -> PIN_ACTION
             R.id.desktopModeButton -> DESKTOP_MODE
+            R.id.fxaButton -> FXA_BUTTON
             R.id.exitButton -> EXIT_FIREFOX
             else -> null
         }
@@ -114,6 +115,10 @@ class NavigationOverlayFragment : Fragment() {
             NavigationEvent.SETTINGS_CLEAR_COOKIES -> {
                 serviceLocator.screenController.showSettingsScreen(fragmentManager!!, SettingsScreen.CLEAR_COOKIES)
             }
+
+            // TODO: change button action based on profile state.
+            NavigationEvent.FXA_BUTTON -> serviceLocator.fxaLoginUseCase.beginLogin(fragmentManager!!)
+
             NavigationEvent.TURBO, NavigationEvent.PIN_ACTION, NavigationEvent.DESKTOP_MODE, NavigationEvent.BACK,
             NavigationEvent.FORWARD, NavigationEvent.RELOAD, NavigationEvent.EXIT_FIREFOX -> { /* not handled by this object */ }
         }
@@ -218,6 +223,8 @@ class NavigationOverlayFragment : Fragment() {
             .forEach { compositeDisposable.add(it) }
         HintBinder.bindHintsToView(hintViewModel, hintBarContainer, animate = false)
                 .forEach { compositeDisposable.add(it) }
+
+        fxaButton.isVisible = serviceLocator.experimentsProvider.shouldShowSendTab()
     }
 
     override fun onStop() {

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/SentryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/SentryIntegration.kt
@@ -5,6 +5,7 @@
 package org.mozilla.tv.firefox.telemetry
 
 import android.content.Context
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.NONE
 import io.sentry.Sentry
@@ -60,7 +61,24 @@ object SentryIntegration {
         }
     }
 
+    /**
+     * Sends the given [exception] to the Sentry servers without crashing the app.
+     *
+     * @see [Sentry.capture]
+     */
     fun capture(exception: Exception) {
         Sentry.capture(exception)
+    }
+
+    /**
+     * Sends the given [exception] to the Sentry servers without crashing the app
+     * and logs its message at the error level.
+     *
+     * @see [Sentry.capture]
+     */
+    fun captureAndLogError(tag: String, exception: Exception) {
+        // Note: instead, by adding the Log4j dependency, we may be able to get Sentry to log captures to logcat automatically.
+        Log.e(tag, exception.message)
+        capture(exception)
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/SentryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/SentryIntegration.kt
@@ -5,11 +5,11 @@
 package org.mozilla.tv.firefox.telemetry
 
 import android.content.Context
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.NONE
 import io.sentry.Sentry
 import io.sentry.android.AndroidSentryClientFactory
+import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.tv.firefox.BuildConfig
 import org.mozilla.tv.firefox.settings.SettingsRepo
 
@@ -76,9 +76,9 @@ object SentryIntegration {
      *
      * @see [Sentry.capture]
      */
-    fun captureAndLogError(tag: String, exception: Exception) {
+    fun captureAndLogError(logger: Logger, exception: Exception) {
         // Note: instead, by adding the Log4j dependency, we may be able to get Sentry to log captures to logcat automatically.
-        Log.e(tag, exception.message)
+        logger.error(message = exception.message)
         capture(exception)
     }
 }

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
@@ -340,6 +340,8 @@ open class TelemetryIntegration protected constructor(
 
             // Load is handled in a separate event
             NavigationEvent.LOAD_URL, NavigationEvent.LOAD_TILE -> return
+
+            NavigationEvent.FXA_BUTTON -> return // TODO: #2512 add telemetry for FxA login.
         }
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.MENU, telemetryValue).queue()
     }

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -11,6 +11,7 @@ package org.mozilla.tv.firefox.utils
 import android.app.Application
 import androidx.lifecycle.MutableLiveData
 import mozilla.components.support.base.observer.Consumable
+import org.mozilla.tv.firefox.fxa.FxaRepo
 import org.mozilla.tv.firefox.ScreenController
 import org.mozilla.tv.firefox.ValidatedIntentData
 import org.mozilla.tv.firefox.architecture.ViewModelFactory
@@ -93,6 +94,7 @@ open class ServiceLocator(val app: Application) {
     val pocketEndpointRaw by lazy { PocketEndpointRaw(appVersion, buildConfigDerivables.globalPocketVideoEndpoint) }
     val pocketVideoStore by lazy { PocketVideoStore(app, app.assets, pocketVideoJSONValidator) }
     val pocketVideoFetchScheduler by lazy { PocketVideoFetchScheduler(isPocketEnabledByLocale) }
+    val fxaRepo by lazy { FxaRepo(app) }
 
     // These open vals are overridden in testing
     open val frameworkRepo = FrameworkRepo.newInstanceAndInit(app.getAccessibilityManager())

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/ServiceLocator.kt
@@ -11,6 +11,7 @@ package org.mozilla.tv.firefox.utils
 import android.app.Application
 import androidx.lifecycle.MutableLiveData
 import mozilla.components.support.base.observer.Consumable
+import org.mozilla.tv.firefox.fxa.FxaLoginUseCase
 import org.mozilla.tv.firefox.fxa.FxaRepo
 import org.mozilla.tv.firefox.ScreenController
 import org.mozilla.tv.firefox.ValidatedIntentData
@@ -95,6 +96,7 @@ open class ServiceLocator(val app: Application) {
     val pocketVideoStore by lazy { PocketVideoStore(app, app.assets, pocketVideoJSONValidator) }
     val pocketVideoFetchScheduler by lazy { PocketVideoFetchScheduler(isPocketEnabledByLocale) }
     val fxaRepo by lazy { FxaRepo(app) }
+    val fxaLoginUseCase by lazy { FxaLoginUseCase(fxaRepo, sessionRepo, screenController) }
 
     // These open vals are overridden in testing
     open val frameworkRepo = FrameworkRepo.newInstanceAndInit(app.getAccessibilityManager())

--- a/app/src/main/res/layout/fragment_navigation_overlay_top_nav.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay_top_nav.xml
@@ -48,6 +48,16 @@
         android:layout_height="0dp"
         android:layout_weight="1" />
 
+    <!-- This button is set visible if the user is in the experiment. -->
+    <!-- TODO: add content description dynamically -->
+    <!-- TODO: use production icon. -->
+    <ImageButton
+        android:id="@+id/fxaButton"
+        style="@style/NavigationButton"
+        android:src="@drawable/lb_ic_cc"
+        android:contentDescription="@null"
+        android:visibility="gone"/>
+
     <ImageButton
         android:id="@+id/exitButton"
         style="@style/NavigationButton"


### PR DESCRIPTION
Grisha is adding breaking changes to the API so we'll soon need to rebase on it (blocked on a-c 4.0.0 upgrade - might as well land this first): leaving this issue open. I'd also still like to:
- ~~Actually test the experiment config~~ Done.
- Add some tests (after the rebase)
- Improve the docs

---

Connected to #2445 ???
<!-- Optional: the primary or additional issues or pull requests related to this, but merging this would not close it unless in the commit message -->

## Testing and Review Notes
<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->
- Enable with flag: `adb shell am start -n org.mozilla.tv.firefox.debug/org.mozilla.tv.firefox.MainActivity --esa qaActiveExperiments SendTab-2511`
- Click placeholder icon
- Sign in

## Screenshots or Videos
<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->


## Checklist
<!-- Before submitting and merging the PR, please address each item -->

- [ ] Confirm the  **acceptance criteria is/are fully satisfied** in the issue(s) this PR will close
- [x] Add **testing notes and/or screenshots** in PR description to help guide all potential reviewers
- [x] Add thorough **tests** or an explanation of why it does not
  - Follow-up PR after rebasing on breaking changes
- [ ] Add a **CHANGELOG entry** if applicable
  - Feature is not complete yet
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
  - Not ready for QA yet, I think