### PR TITLE
Closes #2506: Use FFTV production FxA clientId.

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -122,8 +122,7 @@ class FxaRepo(
     }
 
     companion object {
-        // TODO #2506: use production FFTV client ID (this ID is from an FxA sample app).
-        private const val CLIENT_ID = "a2270f727f45f648"
+        private const val CLIENT_ID = "85da77264642d6a1"
         const val REDIRECT_URI = "https://accounts.firefox.com/oauth/success/$CLIENT_ID"
 
         private fun newInstanceDefaultAccountManager(context: Context): FxaAccountManager {


### PR DESCRIPTION
~~WIP: it looked like these credentials should be on prod ([bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1566346)) but it's not working so posting this to demonstrate for others.~~

The production client ID appears to be working for me now.

---

Previously, we were temporarily using a production ID from a sample app.

Connected to #2506???
<!-- Optional: the primary or additional issues or pull requests related to this, but merging this would not close it unless in the commit message -->

## Testing and Review Notes
<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos
<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->


## Checklist
<!-- Before submitting and merging the PR, please address each item -->

- [ ] Confirm the  **acceptance criteria is/are fully satisfied** in the issue(s) this PR will close
- [ ] Add **testing notes and/or screenshots** in PR description to help guide all potential reviewers
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
