### PR TITLE
Cherry-pick Issue #2386: adds two new tiles to the sports channel

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/channels/content/SportsChannels.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/channels/content/SportsChannels.kt
@@ -24,5 +24,21 @@ fun ChannelContent.getSportsChannels(): List<ChannelTile> = listOf(
         setImage = setImage(R.drawable.tile_sports_formula_1),
         tileSource = TileSource.SPORTS,
         id = "formula1"
+    ),
+    ChannelTile(
+        url = "https://www.cbssports.com/videos/",
+        title = "CBS Sports",
+        subtitle = null,
+        setImage = setImage(R.drawable.cursor_active_bg), // TODO add real image
+        tileSource = TileSource.SPORTS,
+        id = "cbsSports"
+    ),
+    ChannelTile(
+        url = "https://www.sbnation.com/videos",
+        title = "SB Nation",
+        subtitle = null,
+        setImage = setImage(R.drawable.cursor_active_bg), // TODO add real image
+        tileSource = TileSource.SPORTS,
+        id = "sbNation"
     )
 )


### PR DESCRIPTION
We believe that these were fixed by the other changes in #2386.  Images will be added in a follow up commit.

Connected to #???
<!-- Optional: the primary or additional issues or pull requests related to this, but merging this would not close it unless in the commit message -->

## Testing and Review Notes
<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos
<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->


## Checklist
<!-- Before submitting and merging the PR, please address each item -->

- [ ] Confirm the  **acceptance criteria is/are fully satisfied** in the issue(s) this PR will close
- [ ] Add **testing notes and/or screenshots** in PR description to help guide all potential reviewers
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
