### PR TITLE
No issue: correct RepoMatching a11y-test-framework declaration.

### DIFF
--- a/buildSrc/src/main/java/org/mozilla/gradle/Dependencies.kt
+++ b/buildSrc/src/main/java/org/mozilla/gradle/Dependencies.kt
@@ -25,6 +25,6 @@ object Dependencies {
          * explicitly exclude it from this regex so it can be found on jcenter. Note that the transitive dependency
          * com.google.guava is also not available on google's repo.
          */
-        const val comGoogleAndroid = "com\\.google\\.android\\.(?!apps.common.testing.accessibility.frame).*"
+        const val comGoogleAndroid = "com\\.google\\.android\\.(?!apps\\.common\\.testing\\.accessibility\\.framework).*"
     }
 }


### PR DESCRIPTION
Sebastian pointed out the current definition is lax in a code review:
https://github.com/mozilla-mobile/android-components/pull/3884#discussion_r307685107



## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
  - No issue
- [x] Add thorough **tests** or an explanation of why it does not
  - Build code
- [x] Add a **CHANGELOG entry** if applicable
  - N/A
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
  - No issue