### PR TITLE
Issue #2540, #2541: add mp4 video translation workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ It diverges in the following ways:
 
 ### Fixed
 - Remote Settings URL goes through the CDN (#2651)
+- Fullscreen videos were offset if the page was scrolled down before fullscreening. This fix will not work under certain conditions and on certain sites (#2540. #2541)
 
 ## 4.1 - 2019-07-29
 ### Fixed

--- a/app/src/gecko/java/org/mozilla/tv/firefox/ext/EngineView.kt
+++ b/app/src/gecko/java/org/mozilla/tv/firefox/ext/EngineView.kt
@@ -66,6 +66,14 @@ fun EngineView.observePlaybackState() {
     evalJS(JS_OBSERVE_PLAYBACK_STATE)
 }
 
+fun EngineView.observeScrollPosition() {
+    // No action necessary.
+}
+
+fun EngineView.updateFullscreenScrollPosition() {
+    // No action necessary.
+}
+
 private fun EngineView.evalJSWithTargetVideo(getExpressionToEval: (videoId: String) -> String) {
     val ID_TARGET_VIDEO = "targetVideo"
     val GET_TARGET_VIDEO_OR_RETURN = """

--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentConfig.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentConfig.kt
@@ -16,7 +16,13 @@ enum class ExperimentConfig(val value: String) {
     AA_TEST("AAtest-1675"),
     HINT_BAR_TEST("HintBar-2011"),
     TV_GUIDE_CHANNELS("TvGuideChannels-2195"),
-    SEND_TAB("SendTab-2511")
+    SEND_TAB("SendTab-2511"),
+
+    /**
+     * This is not an experiment. If Amazon deploys a fix for this bug, our workaround
+     * may break it: we use this flag as an option to disable this workaround remotely.
+     */
+    MP4_VIDEO_WORKAROUND("Mp4VideoWorkaround-2540")
 }
 
 /**

--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
@@ -87,6 +87,20 @@ class ExperimentsProvider(private val fretboard: Fretboard, private val context:
         }
     }
 
+    /** This is not an experiment: see [ExperimentConfig.MP4_VIDEO_WORKAROUND] for details. */
+    fun shouldUseMp4VideoWorkaround(): Boolean {
+        val expDescriptor = checkBranchVariants(ExperimentConfig.MP4_VIDEO_WORKAROUND)
+        return when {
+            expDescriptor == null -> false // Experiment unknown, or overridden to be false.
+            expDescriptor.name.endsWith(ExperimentSuffix.A.value) -> false
+            expDescriptor.name.endsWith(ExperimentSuffix.B.value) -> true
+            else -> {
+                Sentry.capture(ExperimentIllegalStateException("MP4 Video Workaround Illegal Branch Name"))
+                false
+            }
+        }
+    }
+
     /**
      * Check if [ExperimentConfig] + [ExperimentSuffix] is in the experiment and return its
      * corresponding [ExperimentDescriptor].

--- a/app/src/main/java/org/mozilla/tv/firefox/ext/Js.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ext/Js.kt
@@ -91,6 +91,7 @@ var $CACHED_SCROLL_POSITION;
      *   observer to attach listeners to new <video> nodes as well
      * - On playback state change, notify Java about the current playback state
      * - Prevent this script from being injected more than once per page
+     * - As a workaround to a WebView bug, modify certain videos' CSS tags.
      *
      * Note that `//` style comments are not supported in `evalJS`.
      *
@@ -179,7 +180,7 @@ var _firefoxTV_isPlaybackStateObserverLoaded;
             if (translateNegatesLeft) {
                 vid.style.left = '0px';
                 vid.style.transform = 'translate(0px, 0px)';
-                console.log('FFTV - adjusted video tag CSS');
+                console.log('FFTV workaround - removed CSS transform "translate"');
             }
         });
     }

--- a/app/src/main/java/org/mozilla/tv/firefox/ext/Js.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ext/Js.kt
@@ -57,6 +57,8 @@ var _firefoxTV_isScrollPositionObserverLoaded;
          * incorrect position. Also, if the user is fast enough, they can open fullscreen before we cache the value.
          * This value was set through manual testing. I did not find better solutions. */
         if (typeof _firefoxTV_lastTimeout !== 'undefined') {
+            /* We clear the timeout as an optimization: there are many scroll events so there might be performance
+             * problems if we kept every event on the JS thread. */
             window.clearTimeout(_firefoxTV_lastTimeout);
         }
 
@@ -71,9 +73,10 @@ var _firefoxTV_isScrollPositionObserverLoaded;
         val UPDATE_FULLSCREEN_SCROLL_POSITION = """
 var $CACHED_SCROLL_POSITION;
 (function () {
-    /* We delay restoring the cached value because WebView may override the value we restore. This creates a race
-     * condition & is imperfect: on a slow page, sometimes WebView will override us anyway. This value was set through
-     * manual testing. I did not find better solutions.
+    /* When fullscreen is pressed, the WebView sometimes updates the scroll position of the page. We delay a short
+     * duration so that we can ensure the WebView scroll position update occurs before we write our final scroll
+     * position. This creates a race condition & is imperfect: on a slow page, sometimes WebView will overwrite our
+     * scroll position anyway. This delay duration was set through manual testing. I did not find better solutions.
      *
      * We use the cached scroll position from when this method is initially called so that we're less likely to use one
      * of WebView's incorrect positions (see OBSERVE_SCROLL_POSITION). */

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -39,11 +39,13 @@ import org.mozilla.tv.firefox.architecture.FirefoxViewModelProviders
 import org.mozilla.tv.firefox.ext.couldScrollInDirection
 import org.mozilla.tv.firefox.ext.focusedDOMElement
 import org.mozilla.tv.firefox.ext.isYoutubeTV
+import org.mozilla.tv.firefox.ext.observeScrollPosition
 import org.mozilla.tv.firefox.ext.pauseAllVideoPlaybacks
 import org.mozilla.tv.firefox.ext.requireWebRenderComponents
 import org.mozilla.tv.firefox.ext.resetView
 import org.mozilla.tv.firefox.ext.scrollByClamped
 import org.mozilla.tv.firefox.ext.serviceLocator
+import org.mozilla.tv.firefox.ext.updateFullscreenScrollPosition
 import org.mozilla.tv.firefox.ext.webRenderComponents
 import org.mozilla.tv.firefox.hint.HintBinder
 import org.mozilla.tv.firefox.hint.InactiveHintViewModel
@@ -106,6 +108,10 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
 
         if (enabled) window.addFlags(dontSleep)
         else window.clearFlags(dontSleep)
+
+        if (enabled) {
+            engineView?.updateFullscreenScrollPosition()
+        }
     }
 
     override fun onUrlChanged(session: Session, url: String) {
@@ -114,7 +120,12 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
     }
 
     override fun onLoadingStateChanged(session: Session, loading: Boolean) {
-        if (!loading) youtubeBackHandler.onLoadComplete()
+        if (!loading) {
+            // If the page isn't finished loading, our observers won't be attached to capture the scroll position
+            // and the fix won't work. Unfortunately, I've spent too much time on this so I did not prepare a fix.
+            engineView?.observeScrollPosition()
+            youtubeBackHandler.onLoadComplete()
+        }
     }
 
     override fun onDesktopModeChanged(session: Session, enabled: Boolean) {

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -109,7 +109,8 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
         if (enabled) window.addFlags(dontSleep)
         else window.clearFlags(dontSleep)
 
-        if (enabled) {
+        if (enabled &&
+                serviceLocator?.experimentsProvider?.shouldUseMp4VideoWorkaround() == true) {
             engineView?.updateFullscreenScrollPosition()
         }
     }

--- a/app/src/system/java/org/mozilla/tv/firefox/ext/EngineView.kt
+++ b/app/src/system/java/org/mozilla/tv/firefox/ext/EngineView.kt
@@ -84,6 +84,14 @@ fun EngineView.observePlaybackState() {
     evalJS(JS_OBSERVE_PLAYBACK_STATE)
 }
 
+fun EngineView.observeScrollPosition() {
+    evalJS(Js.MP4TranslationWorkaround.OBSERVE_SCROLL_POSITION)
+}
+
+fun EngineView.updateFullscreenScrollPosition() {
+    evalJS(Js.MP4TranslationWorkaround.UPDATE_FULLSCREEN_SCROLL_POSITION)
+}
+
 private fun EngineView.evalJSWithTargetVideo(getExpressionToEval: (videoId: String) -> String) {
     val ID_TARGET_VIDEO = "targetVideo"
     val GET_TARGET_VIDEO_OR_RETURN = """


### PR DESCRIPTION
@dnarcese Can you additionally review my Remote Settings changes? It's necessary to enable this feature. Note that I haven't had the ability to test the Remote Settings code thoroughly because the experiment needs to exist before you can use command line overrides.

This code is confusing because it uses multiple fairly-arbitrary delays to make it work: let me know if you run into trouble.

---

This is a partial workaround that fixes:
- My test page: http://mcomella.xyz/test/video.html
- https://www.travelandleisure.com/video
- sbnation.com/videos

On the 4K Stick, 2nd gen Stick, and 4K pendant. However, the following sites are not fixed:
- youtube.com desktop (I assume there's either a CSS property that prevents this or specific code that runs for YouTube on the Fire OS WebView)

Caveats to the workaround:
- If the site is not finished loading (as considered by internal state), the hack won't work

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
  - This issue is not being closed
- [x] Add thorough **tests** or an explanation of why it does not
  - Hard to test: this is a UI issue (hard to test) in WebView (harder to test) that works around Fire OS-specific behavior (harder to test).
- [x] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
