### PR TITLE
Issue #2591: upgrade a-c to 7.0.0

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -95,7 +95,7 @@ class FxaRepo(
      */
     @VisibleForTesting(otherwise = NONE)
     inner class FirefoxAccountObserver : AccountObserver {
-        override fun onAuthenticated(account: OAuthAccount) {
+        override fun onAuthenticated(account: OAuthAccount, newAccount: Boolean) {
             _accountState.onNext(AUTHENTICATED_NO_PROFILE)
         }
 

--- a/app/src/test/java/org/mozilla/tv/firefox/fxa/FxaRepoTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/fxa/FxaRepoTest.kt
@@ -45,9 +45,16 @@ class FxaRepoTest {
     }
 
     @Test
-    fun `WHEN on authenticated callback is called THEN account state is authenticated no profile`() {
+    fun `WHEN on authenticated callback is called with newAccount as false THEN account state is authenticated no profile`() {
         val account = mockk<OAuthAccount>()
-        fxaRepo.accountObserver.onAuthenticated(account)
+        fxaRepo.accountObserver.onAuthenticated(account, false)
+        accountStateTestObs.assertValueAt(1, FxaRepo.AccountState.AUTHENTICATED_NO_PROFILE)
+    }
+
+    @Test
+    fun `WHEN on authenticated callback is called with newAccount as true THEN account state is authenticated no profile`() {
+        val account = mockk<OAuthAccount>()
+        fxaRepo.accountObserver.onAuthenticated(account, true)
         accountStateTestObs.assertValueAt(1, FxaRepo.AccountState.AUTHENTICATED_NO_PROFILE)
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.architecture_components_version = '2.0.0'
     ext.kotlin_version = '1.3.31'
     ext.coroutines_version = '1.0.1'
-    ext.moz_components_version = '6.0.0'
+    ext.moz_components_version = '7.0.0'
     ext.androidx_work_version = '2.0.1'
 
     ext.robolectric_version = '4.0.2' // required for SDK 28.


### PR DESCRIPTION
@dnarcese Please merge this when you review it, assuming an r+.

To highlight the second commit extended summary:

> The `newAccount` parameter was added. I don't know what a new account is
> so I filed mozilla-mobile/android-components#4069.
> That being said, it doesn't seem like it'd affect our code so I didn't
> make any changes for it.

Also, I checked the changelog and nothing else stood out as problematic. I noticed:

> The FirefoxAccountsAuthFeature no longer needs an TabsUseCases, instead is taking a lambda to allow applications to decide which action should be taken.

In theory, we might be able to adapt our FxA code to use this but it'd be functionally equivalent to what we have so it's probably not worth the time to refactor.

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
