### PR TITLE
Issue #2643: Edit fxa string to make tab plural for consistency

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,7 +220,7 @@
     <string name="fxa_navigation_item_new">New! Send %1$s tabs to Fire TV</string>
     <!-- Description for Sent tab button in navigation toolbar
      that will launch the Firefox Account settings after the user is signed in. -->
-    <string name="fxa_navigation_item_signed_in">Sent tab settings</string>
+    <string name="fxa_navigation_item_signed_in">Sent tabs settings</string>
     <!-- Description for Sent tab buttons (in navigation toolbar & settings, both on the homescreen)
      that will launch the Firefox Account sign-in experience when the user needs to sign in again. -->
     <string name="fxa_navigation_item_sign_in_again">Sent tabs - sign in again</string>


### PR DESCRIPTION
Caught here: https://github.com/mozilla-l10n/android-l10n/pull/63#discussion_r312579443
"tab" should be consistently plural
## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
