### PR TITLE
Issue #2643: Add fxa string for sent tab toast

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,6 +244,8 @@
     <!-- Toast shown on webpage when tab is sent from another device
      %1$s will be replaced with the device name where the tab was sent from. -->
     <string name="fxa_tab_sent_toast">Tab sent from %1$s</string>
+    <!-- Toast shown on webpage when tab is sent from another device that does not have a device name specified -->
+    <string name="fxa_tab_sent_toast_no_device">Tab received</string>
     <!-- Description for header text for Firefox Accounts settings page. -->
     <string name="fxa_settings_header">Sent tabs</string>
     <!-- Body text for Firefox Accounts settings page


### PR DESCRIPTION
The device name can be empty, so we need a string for that case



## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
