### PR TITLE
No issue: make scroll event listener log statement consistent.

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/ext/Js.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ext/Js.kt
@@ -49,7 +49,7 @@ var _firefoxTV_isScrollPositionObserverLoaded;
     if (_firefoxTV_isScrollPositionObserverLoaded) { return; }
     _firefoxTV_isScrollPositionObserverLoaded = true;
 
-    console.log('adding scroll event listener');
+    console.log('FFTV workaround - adding scroll event listener');
     window.addEventListener('scroll', (e) => {
         /* During the transition to fullscreen, the WebView may or may not change the scroll position to an incorrect
          * value so we add a short delay before caching. This creates a race condition & is imperfect: on a slow page,


### PR DESCRIPTION
While I don't expect us to heavily use this log statement, if the hack
is not working, it's can be a helpful statement to help us debug.



## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
