### PR TITLE
Fixes #2727: fixed crash when scrolling pocket quickly

### DIFF
--- a/app/src/main/res/layout/home_tile.xml
+++ b/app/src/main/res/layout/home_tile.xml
@@ -53,6 +53,7 @@
             android:id="@+id/tile_pocket_author"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:maxLines="1"
             android:ellipsize="end"
             android:fontFamily="@string/font_ember_regular"
             android:gravity="start"


### PR DESCRIPTION
RCA:
This crash occurs when:
- The user scrolls quickly
- The list contains a tile with a title (not description) of 2 or more lines
- This 2 line title is neither the 0th nor last tile in the channel
- The tile with a 2 line title enters or exits the screen, forcing the Pinned Tiles channel to move up or down

I have no idea why this doesn't happen when scrolling in reverse.



## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [X] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [X] Add thorough **tests** or an explanation of why it does not
Change is UI only
- [X] Add a **CHANGELOG entry** if applicable
- [X] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
