### PR TITLE
2647 use abi filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ It diverges in the following ways:
 ### Added
 - (disabled by default) Support for Amazon Device Messaging (#2528)
 
+### Changed
+- Stripped code supporting unused architectures (#2647)
+
 ### Fixed
 - Fullscreen videos were offset if the page was scrolled down before fullscreening. This fix will not work under certain conditions and on certain sites (#2540. #2541)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,13 @@ android {
         testInstrumentationRunnerArguments clearPackageData: 'true'
 
         multiDexEnabled true
+
+        ndk {
+            // This strips unused architectures out of our build, lowering out APK size.
+            // At this time, all FFTV devices run ARM v7, and most emulators use x86. See
+            // #2647 for details
+            abiFilters 'armeabi-v7a', 'x86'
+        }
     }
 
     dexOptions {


### PR DESCRIPTION
Verification process:
- Built a debug APK from master (23.8 MB)
- Made code changes
- Built new debug APK (16.0 MB)
- Tested new APK on emulator (Android TV (1080p) API 26) and real device (4k Stick) to verify functionality

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [X] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [X] Add thorough **tests** or an explanation of why it does not
Build change only
- [X] Add a **CHANGELOG entry** if applicable
- [X] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
