### PR TITLE
Issue #2155: Disable NotInExperimentException collection.

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/experiments/ExperimentsProvider.kt
@@ -39,7 +39,10 @@ class ExperimentsProvider(private val fretboard: Fretboard, private val context:
             }
         } else {
             // The user is currently not part of the experiment
-            Sentry.capture(NotInExperimentException("AAExperiment"))
+
+            // Sentry disabled because I'm concerned about the impact of sending this error to our servers so many times
+            // a day and we take no action when we see this error. See #2155 for a proper investigation.
+            // Sentry.capture(NotInExperimentException("AAExperiment"))
             context.resources.getString(R.string.exit_firefox_a11y,
                 context.resources.getString(R.string.firefox_tv_brand_name_short))
         }


### PR DESCRIPTION
There are 100k+ events a day now: I'm concerned about the impact this
has on our servers and for our clients. Since we're not using this
metric for anything actionable, I propose we disable it.



## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
