### PR TITLE
Issue #2491: move receive tabs to push; add tests, telemetry!

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -57,7 +57,6 @@ class FxaRepo(
      * the profile is not and needs to be fetched.
      */
     sealed class AccountState {
-        // TODO: Later, may need "failed to login": https://github.com/mozilla-mobile/android-components/issues/3712
         /**
          *  After the profile is fetched async
          */

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -28,6 +28,7 @@ import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.AuthenticatedWithProfile
 import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.NeedsReauthentication
 import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState.NotAuthenticated
 import org.mozilla.tv.firefox.telemetry.SentryIntegration
+import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 
 private val logger = Logger("FxaRepo")
 
@@ -47,6 +48,7 @@ class FxaRepo(
     val context: Context,
     val accountManager: FxaAccountManager = newInstanceDefaultAccountManager(context),
     val admIntegration: ADMIntegration, // Consider moving to an FxaReceiveTabsUseCase or rm this comment.
+    private val telemetryIntegration: TelemetryIntegration = TelemetryIntegration.INSTANCE,
     private val sentryIntegration: SentryIntegration = SentryIntegration
 ) {
 
@@ -79,6 +81,7 @@ class FxaRepo(
     val receivedTabs: Observable<ReceivedTabs> = admIntegration.receivedTabsRaw
         .mapToReceivedTabs()
         .filterInvalidTabs(sentryIntegration)
+        .doOnNext { telemetryIntegration.receivedTabEvent(it) }
 
     init {
         accountManager.register(accountObserver)

--- a/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/webrender/WebRenderFragment.kt
@@ -260,7 +260,7 @@ class WebRenderFragment : EngineViewLifecycleFragment(), Session.Observer {
 
     private fun observeReceivedTabs(): Disposable {
         return serviceLocator!!.fxaRepo.receivedTabs.subscribe {
-            // TODO: what do we do if we receive more than one url?
+            // TODO: Gracefully handle receiving multiple tabs around the same time. #2777
             serviceLocator!!.screenController.showBrowserScreenForUrl(fragmentManager!!, it.urls[0])
 
             val toastText = if (it.sendingDevice == null) {

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -60,8 +60,21 @@ The event ping contains a list of events ([see event format on readthedocs.io](h
 | Pocket channel: unique videos clicked per session    | aggregate  | click                   | pocket_video      | `<int>`    |            |
 | App opened from view intent                          | action     | view_intent             | app               |            |            |
 | Opening the overlay forced a video out of fullscreen | action     | programmatically_closed | full_screen_video |            |            |
+| Received tab(s) (via FxA send tab feature)**         | action     | received_tab            |                   |            | `device_type`*** / `total`**** |
 
 (*) This event is sent at the end of every session.
+(**) If a user's tab appears in the UI, this event is sent. If we receive a tab push event that the user does not see
+because it does not pass validation (e.g. it contains blank URLs), we record the error in Sentry instead.
+(**) `device_type` is the type of the device that sent the tabs. These can currently be:
+- `desktop`
+- `mobile`
+- `tablet`
+- `tv`
+- `vr`
+- `unknown`
+(***) In a single send tab event, the server can send multiple tabs from a single device: `total` is the number of tabs received in this event.
+
+``
 
 ### Browser Overlay
 | Event                                  | category | method                | object       | value                    | extra.       |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -60,21 +60,20 @@ The event ping contains a list of events ([see event format on readthedocs.io](h
 | Pocket channel: unique videos clicked per session    | aggregate  | click                   | pocket_video      | `<int>`    |            |
 | App opened from view intent                          | action     | view_intent             | app               |            |            |
 | Opening the overlay forced a video out of fullscreen | action     | programmatically_closed | full_screen_video |            |            |
-| Received tab(s) (via FxA send tab feature)**         | action     | received_tab            |                   |            | `device_type`*** / `total`**** |
+| Received tab(s) (via FxA send tab feature)\*\*         | action     | received_tab            |                   |            | `device_type`\*\*\* / `total`\*\*\*\* |
 
-(*) This event is sent at the end of every session.
-(**) If a user's tab appears in the UI, this event is sent. If we receive a tab push event that the user does not see
+(\*) This event is sent at the end of every session.
+(\*\*) If a user's tab appears in the UI, this event is sent. If we receive a tab push event that the user does not see
 because it does not pass validation (e.g. it contains blank URLs), we record the error in Sentry instead.
-(**) `device_type` is the type of the device that sent the tabs. These can currently be:
+(\*\*\*) `device_type` is the type of the device that sent the tabs. These can currently be:
+
 - `desktop`
 - `mobile`
 - `tablet`
 - `tv`
 - `vr`
 - `unknown`
-(***) In a single send tab event, the server can send multiple tabs from a single device: `total` is the number of tabs received in this event.
-
-``
+(\*\*\*\*) In a single send tab event, the server can send multiple tabs from a single device: `total` is the number of tabs received in this event.
 
 ### Browser Overlay
 | Event                                  | category | method                | object       | value                    | extra.       |


### PR DESCRIPTION
That was a lot more work than I expected. x_x btw, now that ADMIntegration contains logic, I think `FxaRepo` shouldn't know about the adm integration: we should add a `FxaReceiveTabsUseCase`. I didn't want to spend the time to refactor it but, given how long it took me to write the tests for the code as is, maybe it would have been a good use of time so someone didn't have to redo it (and the tests!) later.

@liuche Please data review.

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
  - Issue incomplete
- [x] Add thorough **tests** or an explanation of why it does not
  - _edit:_ Some (all?) tests were removed due to failing UI tests and it not being worth the time to work around the error.
- [ ] Add a **CHANGELOG entry** if applicable
  - Issue incomplete
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
  - Issue incomplete
