### PR TITLE
Issue #2490: Fix account image in toolbar

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -55,6 +55,7 @@ import org.mozilla.tv.firefox.fxa.FxaRepo.AccountState
 import org.mozilla.tv.firefox.pocket.PocketViewModel
 import org.mozilla.tv.firefox.telemetry.MenuInteractionMonitor
 import org.mozilla.tv.firefox.telemetry.UrlTextInputLocation
+import org.mozilla.tv.firefox.utils.RoundCornerTransformation
 import org.mozilla.tv.firefox.utils.ServiceLocator
 import org.mozilla.tv.firefox.utils.ViewUtils
 import org.mozilla.tv.firefox.widget.InlineAutocompleteEditText
@@ -266,7 +267,9 @@ class NavigationOverlayFragment : Fragment() {
             .subscribe { accountState ->
                 when (accountState) {
                     is AccountState.AuthenticatedWithProfile -> {
-                        accountState.profile.avatarSetStrategy.invoke(fxaButton)
+                        accountState.profile.avatarSetStrategy
+                            .setTransformation(RoundCornerTransformation(fxaButton.width.toFloat()))
+                            .invoke(fxaButton)
                         fxaButton.contentDescription = resources.getString(R.string.fxa_navigation_item_signed_in2)
                     }
                     AccountState.AuthenticatedNoProfile -> {

--- a/app/src/main/res/layout/fragment_navigation_overlay_top_nav.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay_top_nav.xml
@@ -53,8 +53,10 @@
         tools:ignore="ContentDescription"
         android:id="@+id/fxaButton"
         style="@style/NavigationButton"
+        android:scaleType="fitXY"
         android:src="@drawable/ic_fxa_login"
-        android:visibility="gone" />
+        android:visibility="gone"
+        android:tint="@null"/>
 
     <!-- Content description is set programmatically.-->
     <ImageButton


### PR DESCRIPTION
I also noticed that the icons in the FxA button were the wrong colour because of an alpha applied - so I removed the alpha.
## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
