### PR TITLE
Closes #2776: Add wake_lock permission to manifest

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -36,6 +36,8 @@
         android:protectionLevel="signature"/>
     <uses-permission android:name="${applicationId}.permission.RECEIVE_ADM_MESSAGE" />
     <uses-permission android:name="com.amazon.device.messaging.permission.RECEIVE" />
+    <!-- This permission is also brought in by androidx.work:work-runtime dependency. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <!-- *** ADM permissions end *** -->
 
     <application>


### PR DESCRIPTION
This permission is needed for ADM. It is currently brought in by a dependency, but it is safer if we also add it ourselves.



## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
