### PR TITLE
 Automation: Fix artifact paths

### DIFF
--- a/tools/taskcluster/tasks.py
+++ b/tools/taskcluster/tasks.py
@@ -43,7 +43,7 @@ class TaskBuilder:
             script,
             ['secrets:get:project/mobile/firefox-tv/tokens'],
             {
-                'public/reports': artifact('directory', '/opt/firefox-tv/app/builds/reports')
+                'public/reports': artifact('directory', '/opt/firefox-tv/app/build/reports')
             }
         )
 
@@ -63,7 +63,7 @@ class TaskBuilder:
             script,
             ['secrets:get:project/mobile/firefox-tv/tokens'],
             {
-                'public': artifact('directory', '/opt/firefox-tv/app/builds/reports')
+                'public': artifact('directory', '/opt/firefox-tv/app/build/reports')
             }
         )
 


### PR DESCRIPTION
#2796 introduced some incorrect artifact paths, so APKs and reports aren't shown in the "artifacts" tab on Taskcluster

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
