### PR TITLE
Automation: enhanced release task group

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -39,6 +39,10 @@ tasks:
         provisionerId: aws-provisioner-v1
         workerType: mobile-${trust_level}-decision
         requires: all-completed
+        retries: 5
+        priority: lowest
+        routes:
+          - statuses
         payload:
           maxRunTime: 6000
           image: mozillamobile/firefox-tv:2.3
@@ -52,6 +56,7 @@ tasks:
             MOBILE_HEAD_REPOSITORY: ${repository}
             MOBILE_HEAD_REV: ${head_rev}
           features:
+            chainOfTrust: true
             taskclusterProxy: true
           artifacts:
             public/task-graph.json:
@@ -66,6 +71,8 @@ tasks:
               type: file
               path: /opt/firefox-tv/parameters.yml
               expires: {$fromNow: '1 year'}
+        extra:
+          tasks_for: ${tasks_for} # for chain of trust to re-build the task
         metadata:
           name: 'Decision task'
           description: ''

--- a/tools/taskcluster/decision_task.py
+++ b/tools/taskcluster/decision_task.py
@@ -21,9 +21,11 @@ def master(builder):
 
 def release(builder, tag, is_staging):
     build_task_id = taskcluster.slugId()
+    sign_task_id = taskcluster.slugId()
     return (
         (build_task_id, builder.craft_release_build_task(tag)),
-        (taskcluster.slugId(), builder.craft_sign_for_github_task(build_task_id, is_staging)),
+        (sign_task_id, builder.craft_sign_for_github_task(build_task_id, is_staging)),
+        (taskcluster.slugId(), builder.craft_email_task(sign_task_id, tag)),
         (taskcluster.slugId(), builder.craft_amazon_task(build_task_id, is_staging)),
     )
 

--- a/tools/taskcluster/decision_task.py
+++ b/tools/taskcluster/decision_task.py
@@ -20,7 +20,7 @@ def master(builder):
 
 
 def release(builder, tag):
-    return (taskcluster.slugId(), builder.craft_release_task(tag)),
+    return (taskcluster.slugId(), builder.craft_release_build_task(tag)),
 
 
 def main():

--- a/tools/taskcluster/decision_task.py
+++ b/tools/taskcluster/decision_task.py
@@ -22,11 +22,12 @@ def master(builder):
 def release(builder, tag, is_staging):
     build_task_id = taskcluster.slugId()
     sign_task_id = taskcluster.slugId()
+    push_task_id = taskcluster.slugId()
     return (
         (build_task_id, builder.craft_release_build_task(tag)),
         (sign_task_id, builder.craft_sign_for_github_task(build_task_id, is_staging)),
-        (taskcluster.slugId(), builder.craft_email_task(sign_task_id, tag)),
-        (taskcluster.slugId(), builder.craft_amazon_task(build_task_id, is_staging)),
+        (push_task_id, builder.craft_amazon_task(build_task_id, is_staging)),
+        (taskcluster.slugId(), builder.craft_email_task(sign_task_id, push_task_id, tag)),
     )
 
 

--- a/tools/taskcluster/tasks.py
+++ b/tools/taskcluster/tasks.py
@@ -93,7 +93,8 @@ class TaskBuilder:
 
     def craft_email_task(self, sign_task_id, push_task_id, tag):
         # The "\\n" are hard-coded on purpose, since we don't want a newline in the string, but
-        # we do want the JSON to have the escaped newline
+        # we do want the JSON to have the escaped newline.
+        # This email content is formatted with markdown by Taskcluster
         content = 'Automation for this release is ready. Please: \\n' \
                   f'* Download the APK and attach it to the [Github release](https://github.com/mozillamobile/firefox-tv/releases/tag/{tag})\\n' \
                   '* [Deploy the new release on Amazon](https://developer.amazon.com/apps-and-games/console/app/amzn1.devportal.mobileapp.7f334089688646ef8953d041021029c9/release/amzn1.devportal.apprelease.4ca3990c43f34101bf5729543343747a/general/detail)'

--- a/tools/taskcluster/tasks.py
+++ b/tools/taskcluster/tasks.py
@@ -67,9 +67,9 @@ class TaskBuilder:
             }
         )
 
-    def craft_release_task(self, tag):
+    def craft_release_build_task(self, tag):
         script = f'''
-        git fetch origin --tags
+        git fetch {self.repo_url} --tags
         git config advice.detachedHead false
         git checkout {tag}
         yes | sdkmanager --licenses

--- a/tools/taskcluster/tasks.py
+++ b/tools/taskcluster/tasks.py
@@ -84,10 +84,11 @@ class TaskBuilder:
             ['secrets:get:project/mobile/firefox-tv/tokens'],
             {
                 'public': artifact('directory', '/opt/firefox-tv/app/build/outputs/apk')
-            }
+            },
+            chain_of_trust=True,  # Needed for sign and push task verification
         )
 
-    def _craft_shell_task(self, name, script, scopes, artifacts):
+    def _craft_shell_task(self, name, script, scopes, artifacts, *, chain_of_trust=False):
         single_command = ' && '.join([line.strip() for line in script.split('\n') if line.strip()])
         bash_command = [
             '/bin/bash',
@@ -96,13 +97,9 @@ class TaskBuilder:
             f'export TERM=dumb && {single_command}'
         ]
 
-        return {
-            'taskGroupId': self.task_group_id,
+        return self._craft_base_task(name, {
             'provisionerId': 'aws-provisioner-v1',
-            'schedulerId': 'taskcluster-github',
             'workerType': 'github-worker',
-            'created': taskcluster.stringDate(datetime.datetime.now()),
-            'deadline': taskcluster.stringDate(taskcluster.fromNow('1 day')),
             'scopes': scopes,
             'payload': {
                 'maxRunTime': 3600,
@@ -111,14 +108,65 @@ class TaskBuilder:
                 'artifacts': artifacts,
                 'features': {
                     'taskclusterProxy': True,
+                    'chainOfTrust': chain_of_trust,
                 }
+            }
+        })
+
+    def craft_sign_for_github_task(self, build_task_id, is_staging):
+        return self._craft_base_task('Sign for Github', {
+            'provisionerId': 'scriptworker-prov-v1',
+            'workerType': 'mobile-signing-dep-v1' if is_staging else 'mobile-signing-v1',
+            'scopes': [
+                'project:mobile:firefox-tv:releng:signing:format:autograph_apk',
+                'project:mobile:firefox-tv:releng:signing:cert:{}-signing'.format(
+                    'dep' if is_staging else 'production')
+            ],
+            'dependencies': [build_task_id],
+            'payload': {
+                'upstreamArtifacts': [{
+                    'paths': ['public/build/target.apk'],
+                    'formats': ['autograph_apk'],
+                    'taskId': build_task_id,
+                    'taskType': 'build',
+                }]
             },
+        })
+
+    def craft_amazon_task(self, build_task_id, is_staging):
+        return self._craft_base_task('Push to Amazon', {
+            'provisionerId': 'scriptworker-prov-v1',
+            'workerType': 'mobile-pushapk-dep-v1' if is_staging else 'mobile-pushapk-v1',
+            'scopes': [
+                'project:mobile:firefox-tv:releng:googleplay:product:firefox-tv{}'.format(
+                    ':dep' if is_staging else ''
+                )
+            ],
+            'dependencies': [build_task_id],
+            'payload': {
+                'target_store': 'amazon',
+                'channel': 'production',
+                'upstreamArtifacts': [{
+                    'paths': ['public/build/target.apk'],
+                    'taskId': build_task_id,
+                    'taskType': 'build',
+                }]
+            }
+        })
+
+    def _craft_base_task(self, name, extend_task):
+        return {
+            'taskGroupId': self.task_group_id,
+            'schedulerId': 'taskcluster-github',
+            'created': taskcluster.stringDate(datetime.datetime.now()),
+            'deadline': taskcluster.stringDate(taskcluster.fromNow('1 day')),
             'metadata': {
                 'name': name,
                 'description': '',
                 'owner': self.owner,
                 'source': f'{self.repo_url}/raw/{self.commit}/.taskcluster.yml',
-            }
+            },
+            **extend_task
         }
 
 

--- a/tools/taskcluster/tasks.py
+++ b/tools/taskcluster/tasks.py
@@ -127,7 +127,7 @@ class TaskBuilder:
             '/bin/bash',
             '--login',
             '-c',
-            'bash -e <<"SCRIPT"\n'
+            'cat <<"SCRIPT" script.sh && bash -e script.sh\n'
             'export TERM=dumb\n'
             f'{trimmed_script}\n'
             'SCRIPT'

--- a/tools/taskcluster/tasks.py
+++ b/tools/taskcluster/tasks.py
@@ -133,6 +133,9 @@ class TaskBuilder:
         )
 
     def _craft_shell_task(self, name, script, scopes, artifacts, *, dependencies=(), chain_of_trust=False):
+        # The script value here is probably produced from a python heredoc string, which means
+        # it has unnecessary whitespace in it. This will iterate over each line and remove the
+        # redundant whitespace
         trimmed_script = '\n'.join([line.strip() for line in script.split('\n') if line.strip()])
         bash_command = [
             '/bin/bash',


### PR DESCRIPTION
:rotating_light: I can't test the signing and pushing-to-amazon without landing the code here first since it uses security-sensitive release tokens. So, there _probably will be breakage_ when this lands, which will require follow-up PRs to be landed :rotating_light: 

-----

This is the "cool" PR :smile::
* APKs to attach to Github Releases are now automatically signed
* New releases are automatically created in Amazon as an "upcoming release"
* Once automation is done, an email goes to `firefox-tv` with links to:
    * The github release
    * The signed APK for the github release
    * The Amazon Developer Console page for FFTV

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
