### PR TITLE
Disable youtubeNavigationTest due to the popup warning message from YT

### DIFF
--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/YouTubeNavigationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/YouTubeNavigationTest.kt
@@ -7,6 +7,7 @@ package org.mozilla.tv.firefox.ui
 import android.app.Application
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.tv.firefox.TestDependencyFactory
@@ -70,6 +71,7 @@ class YouTubeNavigationTest {
         customPocketFeedStateProvider.fakedPocketRepoState.onNext(mockedState)
     }
 
+    @Ignore("Disabled due to the Youtube warning dialog")
     @Test
     fun youtubeNavigationTest() {
         val youtubeUrl = "youtube.com/tv"


### PR DESCRIPTION
Disable currently failing test due to the "we are going away" warning message for Youtube.



## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
