### PR TITLE
Closes #2843: Add missing fxa telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -166,6 +166,8 @@ class FxaRepo(
 
             // Push service is only needed when logged in (this saves resources)
             admIntegration.initPushFeature()
+
+            telemetryIntegration.fxaLoggedInEvent()
         }
 
         override fun onAuthenticationProblems() {
@@ -177,6 +179,8 @@ class FxaRepo(
 
             // Push service is not needed after logging out (this saves resources)
             admIntegration.shutdownPushFeature()
+
+            telemetryIntegration.fxaLoggedOutEvent()
         }
 
         /**

--- a/app/src/main/java/org/mozilla/tv/firefox/onboarding/ReceiveTabPreboardingActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/onboarding/ReceiveTabPreboardingActivity.kt
@@ -13,6 +13,7 @@ import kotlinx.android.synthetic.main.receive_tab_preboarding.descriptionText
 import org.mozilla.tv.firefox.FirefoxApplication
 import org.mozilla.tv.firefox.MainActivity
 import org.mozilla.tv.firefox.R
+import org.mozilla.tv.firefox.telemetry.TelemetryIntegration
 
 /**
  * Manages an onboarding screen, which is shown once to users upon app start in order
@@ -31,6 +32,7 @@ class ReceiveTabPreboardingActivity : AppCompatActivity() {
         )
 
         buttonSignIn.setOnClickListener {
+            TelemetryIntegration.INSTANCE.fxaPreboardingSignInButtonClickEvent()
             @Suppress("DEPRECATION") // Couldn't work out a better way to do this. If you
             // think of one, please replace this
             (application as FirefoxApplication).mainActivityCommandBus
@@ -50,6 +52,7 @@ class ReceiveTabPreboardingActivity : AppCompatActivity() {
                 .edit()
                 .putBoolean(ONBOARD_RECEIVE_TABS_SHOWN_PREF, true)
                 .apply()
+        TelemetryIntegration.INSTANCE.fxaPreboardingDismissButtonClickEvent()
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
@@ -119,6 +119,8 @@ open class TelemetryIntegration protected constructor(
         const val FXA_SHOW_ONBOARDING = "fxa_show_onboarding"
         const val FXA_PREBOARDING_NOT_NOW = "fxa_preboarding_not_now"
         const val FXA_PREBOARDING_SIGN_IN = "fxa_preboarding_sign_in"
+        const val FXA_LOGGED_IN = "fxa_logged_in"
+        const val FXA_LOGGED_OUT = "fxa_logged_out"
     }
 
     private object Extra {
@@ -337,6 +339,14 @@ open class TelemetryIntegration protected constructor(
 
     fun fxaPreboardingDismissButtonClickEvent() {
         TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.FXA, Value.FXA_PREBOARDING_NOT_NOW).queue()
+    }
+
+    fun fxaLoggedInEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CHANGE, Object.FXA, Value.FXA_LOGGED_IN).queue()
+    }
+
+    fun fxaLoggedOutEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CHANGE, Object.FXA, Value.FXA_LOGGED_OUT).queue()
     }
 
     /**

--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
@@ -117,6 +117,8 @@ open class TelemetryIntegration protected constructor(
         const val FXA_REAUTHENTICATE_BUTTON = "fxa_reauthenticate_button"
         const val FXA_NEEDS_REAUTHENTICATION = "fxa_needs_reauthentication"
         const val FXA_SHOW_ONBOARDING = "fxa_show_onboarding"
+        const val FXA_PREBOARDING_NOT_NOW = "fxa_preboarding_not_now"
+        const val FXA_PREBOARDING_SIGN_IN = "fxa_preboarding_sign_in"
     }
 
     private object Extra {
@@ -327,6 +329,14 @@ open class TelemetryIntegration protected constructor(
         TelemetryEvent.create(Category.ACTION, Method.CHANGE, Object.FXA, Value.FXA_NEEDS_REAUTHENTICATION)
             .extra(Extra.BOOLEAN, boolean.toString())
             .queue()
+    }
+
+    fun fxaPreboardingSignInButtonClickEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.FXA, Value.FXA_PREBOARDING_SIGN_IN).queue()
+    }
+
+    fun fxaPreboardingDismissButtonClickEvent() {
+        TelemetryEvent.create(Category.ACTION, Method.CLICK, Object.FXA, Value.FXA_PREBOARDING_NOT_NOW).queue()
     }
 
     /**

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -100,6 +100,10 @@ because it does not pass validation (e.g. it contains blank URLs), we record the
 | Fxa profile sign out clicked           | action   | click                 | fxa          | fxa_sign_out_button      |               |
 | Fxa profile back button clicked        | action   | click                 | fxa          | fxa_go_back_button       |               |
 | Fxa needs reauthentication ****        | action   | change                | fxa          | fxa_needs_reauthentication | boolean     |
+| Fxa logged in state                    | action   | change                | fxa          | fxa_logged_in            |               |
+| Fxa logged out state                   | action   | change                | fxa          | fxa_logged_out           |               |
+| Fxa preboarding not now button click   | action   | click                 | fxa          | fxa_preboarding_not_now  |               |
+| Fxa preboarding sign in button click   | action   | click                 | fxa          | fxa_preboarding_sign_in  |               |
 
 (*)When the pin site switch is clicked, the state (on/off) of the desktop mode switch is also sent.
 


### PR DESCRIPTION
I didn't think the debouncing was needed for these cases but I could be thinking of the flows wrong.. @Baron-Severin let me know if you think I need it

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
