### PR TITLE
Modify UI Test for FxA feature (For #2648)

### DIFF
--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/screenshots/FxaPageTest.java
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/screenshots/FxaPageTest.java
@@ -1,0 +1,116 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.tv.firefox.ui.screenshots;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mozilla.tv.firefox.MainActivity;
+import org.mozilla.tv.firefox.R;
+import org.mozilla.tv.firefox.channels.SettingsScreen;
+import org.mozilla.tv.firefox.ext.ServiceLocatorKt;
+import org.mozilla.tv.firefox.helpers.MainActivityTestRule;
+
+import tools.fastlane.screengrab.Screengrab;
+import tools.fastlane.screengrab.locale.LocaleTestRule;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static org.mozilla.tv.firefox.channels.ChannelOnboardingActivity.TV_ONBOARDING_SHOWN_PREF;
+import static org.mozilla.tv.firefox.onboarding.OnboardingActivity.ONBOARD_SHOWN_PREF;
+import static org.mozilla.tv.firefox.onboarding.ReceiveTabPreboardingActivity.ONBOARD_RECEIVE_TABS_SHOWN_PREF;
+
+public class FxaPageTest extends ScreenshotTest {
+
+    private Intent intent;
+    private SharedPreferences.Editor preferencesEditor;
+
+    @ClassRule
+    public static final LocaleTestRule localeTestRule = new LocaleTestRule();
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityTestRule = new MainActivityTestRule(false, false, false);
+
+    @Before
+    public void setUp() {
+        intent = new Intent();
+
+        Context appContext = InstrumentationRegistry.getInstrumentation()
+                .getTargetContext()
+                .getApplicationContext();
+
+        preferencesEditor = PreferenceManager.getDefaultSharedPreferences(appContext).edit();
+
+        PreferenceManager.getDefaultSharedPreferences(appContext)
+                .edit()
+                .clear()
+                .putBoolean(ONBOARD_RECEIVE_TABS_SHOWN_PREF, true)
+                .apply();
+    }
+
+    @After
+    public void tearDown() {
+        mActivityTestRule.getActivity().finishAndRemoveTask();
+    }
+
+    @Test
+    public void showFxaPreboardingTest() {
+        preferencesEditor
+                .putBoolean(ONBOARD_SHOWN_PREF, true)
+                .putBoolean(TV_ONBOARDING_SHOWN_PREF, true)
+                .putBoolean(ONBOARD_RECEIVE_TABS_SHOWN_PREF, false)
+                .apply();
+
+        mActivityTestRule.launchActivity(intent);
+
+        // Check dialog is displayed
+        onView(withId(R.id.receiveTabGraphic))
+                .check(matches(isDisplayed()));
+
+        Screengrab.screenshot("fxa-preboarding");
+    }
+
+    @Test
+    public void showFxaOnboardingTest() throws Throwable {
+        preferencesEditor
+                .putBoolean(ONBOARD_SHOWN_PREF, true)
+                .putBoolean(TV_ONBOARDING_SHOWN_PREF, true)
+                .putBoolean(ONBOARD_RECEIVE_TABS_SHOWN_PREF, true)
+                .apply();
+
+        mActivityTestRule.launchActivity(intent);
+
+        mActivityTestRule.runOnUiThread(new Runnable() {
+            public void run() {
+                ServiceLocatorKt.getServiceLocator(mActivityTestRule.getActivity()).getScreenController()
+                        .showSettingsScreen (mActivityTestRule.getActivity().getSupportFragmentManager(), SettingsScreen.FXA_PROFILE);
+            } } );
+
+        // Check dialog is displayed
+        onView(withId(R.id.buttonFirefoxTabs))
+                .check(matches(isDisplayed()));
+
+        Screengrab.screenshot("sent_tabs_page");
+
+        onView(withId(R.id.buttonFirefoxTabs)).perform(click());
+        Thread.sleep(5000);
+
+        Screengrab.screenshot("fxa_onboarding_page");
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/screenshots/TooltipCaptureTest.java
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/screenshots/TooltipCaptureTest.java
@@ -92,10 +92,11 @@ public class TooltipCaptureTest extends ScreenshotTest {
         takeScreenshotsAfterWait("tooltip-requestdesktop", 500);
         device.pressDPadRight();
         checkTooltipDisplayed();
-        takeScreenshotsAfterWait("tooltip-exit", 500);
+        takeScreenshotsAfterWait("tooltip-fxa", 500);
         device.pressDPadRight();
         checkTooltipDisplayed();
-        takeScreenshotsAfterWait("tooltip-settings", 500);
+        takeScreenshotsAfterWait("tooltip-exit", 500);
+        device.pressDPadLeft();
         device.pressDPadLeft();
         device.pressDPadCenter();
 


### PR DESCRIPTION
For #2648 
- Add skip FxA preboarding dialog for UI tests
- Add screenshot test for preboarding dialog
- Modify TooltipCaptureTest to accomodate for extra icon

This should be merged after FxA feature is enabled, otherwise UI Tests will fail.



## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
