### PR TITLE
Issue #2721: Add string for FxA profile screen when no display name

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -274,6 +274,8 @@
     <!-- Body text for Firefox Accounts settings page
     %1$s will be replaced with the signed-in user account email. -->
     <string name="fxa_settings_body">Signed in as %1$s</string>
+    <!-- Body text for Firefox Accounts settings page. -->
+    <string name="fxa_settings_body_no_display_name">Signed in</string>
     <!-- Button text for seeing the onboarding screen on the Firefox Accounts settings page.
      %1$s will be replaced with Firefox. -->
     <string name="fxa_settings_primary_button">%1$s tabs</string>


### PR DESCRIPTION

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
