### PR TITLE
[merge after release] Closes #2721: Change fxa settings text when no display name

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/settings/SettingsFragment.kt
@@ -177,6 +177,7 @@ class SettingsFragment : Fragment() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe {
                     view.userDisplayName.text = ""
+                    view.signedInAs.text = resources.getString(R.string.fxa_settings_body_no_display_name)
                     PicassoWrapper.client.load(R.drawable.ic_default_avatar).into(view.avatarImage)
                 }
         )


### PR DESCRIPTION
The string just landed so this should land after this release so the string has time to be localized.
## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
