### PR TITLE
Fixes #2854: freeze when sending tab while on FxA profile

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/ScreenController.kt
@@ -10,14 +10,15 @@ import android.view.KeyEvent
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.NONE
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 import mozilla.components.browser.session.Session
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.ActiveScreen
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.Transition
+import org.mozilla.tv.firefox.channels.SettingsScreen
 import org.mozilla.tv.firefox.ext.serviceLocator
 import org.mozilla.tv.firefox.navigationoverlay.NavigationOverlayFragment
-import org.mozilla.tv.firefox.channels.SettingsScreen
 import org.mozilla.tv.firefox.session.SessionRepo
 import org.mozilla.tv.firefox.settings.SettingsFragment
 import org.mozilla.tv.firefox.telemetry.MenuInteractionMonitor
@@ -252,6 +253,7 @@ class ScreenController(private val sessionRepo: SessionRepo) {
             Transition.SHOW_BROWSER -> {
                 _currentActiveScreen.onNext(ActiveScreen.WEB_RENDER)
                 fragmentManager.beginTransaction()
+                    .maybeRemoveSettingsScreen(fragmentManager)
                     .hide(fragmentManager.navigationOverlayFragment())
                     .commitNow()
             }
@@ -267,3 +269,15 @@ private fun FragmentManager.webRenderFragment(): WebRenderFragment =
 
 private fun FragmentManager.navigationOverlayFragment(): NavigationOverlayFragment =
     this.findFragmentByTag(NavigationOverlayFragment.FRAGMENT_TAG) as NavigationOverlayFragment
+
+private fun FragmentTransaction.maybeRemoveSettingsScreen(
+    fragmentManager: FragmentManager
+): FragmentTransaction {
+    val settingsScreen = fragmentManager.findFragmentByTag(SettingsFragment.FRAGMENT_TAG)
+
+    return if (settingsScreen != null) {
+        this.remove(settingsScreen)
+    } else {
+        this
+    }
+}


### PR DESCRIPTION
RCA:
Previously, we were adding the browser fragment and moving focus to it as expected. However, we were not removing the settings fragment, which covered the content. This left the user unable to do anything.

In the future, we may need to reevaluate our ScreenControllerStateMachine. Pushes can occur at any point of the application lifecycle, which complicates the defined edges between our points.



## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
Never reached users
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
