### PR TITLE
Closes #2862: Clear compositeDisposible in MainActivity.

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -220,6 +220,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
         super.onStop()
         LocaleManager.getInstance().resetLocaleIfChanged(applicationContext)
         TelemetryIntegration.INSTANCE.stopMainActivity()
+        compositeDisposable.clear()
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Problem: when sign in was attempted, it didn't complete successfully.

RCA: beginLogin was getting called twice, clearing the FxA library state,
because there were two subscribers in MainActivity. Clearing the
disposable removes the one outdated subscriber.

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
