### PR TITLE
temp

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayViewModel.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayViewModel.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModel
 import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
 import org.mozilla.tv.firefox.R
 import org.mozilla.tv.firefox.ScreenController
 import org.mozilla.tv.firefox.ScreenControllerStateMachine.ActiveScreen
@@ -74,6 +75,8 @@ class NavigationOverlayViewModel(
                 }
             }
 
+    val LOGIN_STARTED = PublishSubject.create<Boolean>()
+
     fun fxaButtonClicked(fragmentManager: FragmentManager) {
         fun showFxaProfileScreen() {
             screenController.showSettingsScreen(fragmentManager, SettingsScreen.FXA_PROFILE)
@@ -93,6 +96,7 @@ class NavigationOverlayViewModel(
             is AccountState.NotAuthenticated -> {
                 TelemetryIntegration.INSTANCE.fxaLoginButtonClickEvent()
                 fxaLoginUseCase.beginLogin(fragmentManager)
+                LOGIN_STARTED.onNext(true)
             }
         }
     }

--- a/app/src/main/java/org/mozilla/tv/firefox/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/utils/Settings.kt
@@ -57,8 +57,7 @@ class Settings private constructor(context: Context) {
     fun shouldShowTurboModeOnboarding(): Boolean =
             !preferences.getBoolean(OnboardingActivity.ONBOARD_SHOWN_PREF, false)
 
-    fun shouldShowFxaOnboarding(): Boolean = experimentsProvider.shouldShowSendTab() &&
-            !preferences.getBoolean(FXA_ONBOARD_SHOWN_PREF, false)
+    fun shouldShowFxaOnboarding(): Boolean = experimentsProvider.shouldShowSendTab()
 
     fun shouldShowReceiveTabsPreboarding(): Boolean = experimentsProvider.shouldShowSendTab() &&
         !preferences.getBoolean(ReceiveTabPreboardingActivity.ONBOARD_RECEIVE_TABS_SHOWN_PREF, false)


### PR DESCRIPTION
While it fixes the bug, this is a *__terrible solution__*.  Hopefully it helps point us in the right direction.  The base problems here:

- If we remove the shared prefs check, onboarding is shown any time we are in an Auth state
- We go through Auth states all the time
  - Specifically, when a user starts the app already logged in, we travel through the normal flow
- AFAICT, what we really want is to show onboarding any time we go through Auth *_after_* the user has finished clicking through FxA login
  - We don't have a callback for that, so this solution sets the listener when they *_begin_* logging in
  - There are probably bad edge cases due to setting the listener on sign in start instead of sign in completion