### PR TITLE
Closes #2861: Show FxA onboarding on every login

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -76,13 +76,14 @@ class FxaRepo(
          */
         object AuthenticatedNoProfile : AccountState() // Before the profile is fetched async
         object NeedsReauthentication : AccountState()
-        object NotAuthenticated : AccountState() // Initial state
+        object NotAuthenticated : AccountState()
+        object Initial : AccountState()
     }
 
     @VisibleForTesting(otherwise = NONE)
     val accountObserver = FirefoxAccountObserver()
 
-    private val _accountState: BehaviorSubject<AccountState> = BehaviorSubject.createDefault(NotAuthenticated)
+    private val _accountState: BehaviorSubject<AccountState> = BehaviorSubject.createDefault(AccountState.Initial)
     val accountState: Observable<AccountState> = _accountState.hide()
 
     val receivedTabs: Observable<Consumable<FxaReceivedTab>> = admIntegration.receivedTabsRaw

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -288,14 +288,27 @@ class NavigationOverlayFragment : Fragment() {
                         fxaButton.contentDescription =
                             resources.getString(R.string.fxa_navigation_item_new,
                                 resources.getString(R.string.app_name))
+                        resetFxaOnboardingShown()
                     }
                     AccountState.NeedsReauthentication -> {
                         fxaButton.setImageResource(R.drawable.ic_fxa_needs_reauthentication)
                         fxaButton.contentDescription =
                             resources.getString(R.string.fxa_navigation_item_sign_in_again)
+                        resetFxaOnboardingShown()
                     }
                 }
             }
+    }
+
+    /**
+     * Reset FxA onboarding shown value to false in shared prefs.
+     * We need to reset the state of FxA onboarding screen to ensure that we do not show onboarding on every startup (#2861).
+     */
+    private fun resetFxaOnboardingShown() {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .putBoolean(Settings.FXA_ONBOARD_SHOWN_PREF, false)
+            .apply()
     }
 
     private fun observePinnedTiles(): Disposable {

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -283,7 +283,7 @@ class NavigationOverlayFragment : Fragment() {
                             fxaRepo.showFxaOnboardingScreen(context!!)
                         }
                     }
-                    AccountState.NotAuthenticated -> {
+                    AccountState.NotAuthenticated, AccountState.Initial -> {
                         fxaButton.setImageResource(R.drawable.ic_fxa_login)
                         fxaButton.contentDescription =
                             resources.getString(R.string.fxa_navigation_item_new,

--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayViewModel.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayViewModel.kt
@@ -90,7 +90,7 @@ class NavigationOverlayViewModel(
                 TelemetryIntegration.INSTANCE.fxaReauthorizeButtonClickEvent()
                 fxaLoginUseCase.beginLogin(fragmentManager)
             }
-            is AccountState.NotAuthenticated -> {
+            is AccountState.NotAuthenticated, AccountState.Initial -> {
                 TelemetryIntegration.INSTANCE.fxaLoginButtonClickEvent()
                 fxaLoginUseCase.beginLogin(fragmentManager)
             }

--- a/app/src/test/java/org/mozilla/tv/firefox/fxa/FxaRepoTest.kt
+++ b/app/src/test/java/org/mozilla/tv/firefox/fxa/FxaRepoTest.kt
@@ -75,8 +75,8 @@ class FxaRepoTest {
     }
 
     @Test
-    fun `WHEN fxa repo is initialized THEN account state is not authenticated`() {
-        accountStateTestObs.assertValue(FxaRepo.AccountState.NotAuthenticated)
+    fun `WHEN fxa repo is initialized THEN account state is initial`() {
+        accountStateTestObs.assertValue(FxaRepo.AccountState.Initial)
     }
 
     @Test


### PR DESCRIPTION
The main problem after making the onboarding screen show every time was that it also starting showing up on startup when already logged in. This happened because we set the default account state to `NotAuthenticated`, so on startup, it would emit `NotAuthenticated` followed by `AuthenticatedNoProfile`. To fix this, I added a default account state.
## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
