### PR TITLE
Issue #2865: adds FxA Object to receive tab telemetry event

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/telemetry/TelemetryIntegration.kt
@@ -486,7 +486,7 @@ open class TelemetryIntegration protected constructor(
             DeviceType.UNKNOWN -> ReceivedTabDeviceType.UNKNOWN
         }.extra
 
-        TelemetryEvent.create(Category.ACTION, Method.RECEIVED_TAB, null)
+        TelemetryEvent.create(Category.ACTION, Method.RECEIVED_TAB, Object.FXA)
             .extra(Extra.DEVICE_TYPE, internalDeviceType)
             .extra(Extra.TOTAL, metadata.receivedUrlCount.toString())
             .queue()

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -61,7 +61,7 @@ The event ping contains a list of events ([see event format on readthedocs.io](h
 | App opened from view intent                          | action     | view_intent             | app               |            |            |
 | Opening the overlay forced a video out of fullscreen | action     | programmatically_closed | full_screen_video |            |            |
 | Show Fxa onboarding screen* 						   | action     | user_show				  | fxa 			  | fxa_show_onboarding |            |
-| Received tab(s) (via FxA send tab feature)\*\*         | action     | received_tab            |                   |            | `device_type`\*\*\* / `total`\*\*\*\* |
+| Received tab(s) (via FxA send tab feature)\*\*         | action     | received_tab          | fxa               |            | `device_type`\*\*\* / `total`\*\*\*\* |
 
 (*) Fxa onboarding screen shown when the user first successfully authenticates or when linked to from the accounts page.
 (\*) This event is sent at the end of every session.


### PR DESCRIPTION

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [X] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [X] Add a **CHANGELOG entry** if applicable
This has not yet been released
- [X] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
