### PR TITLE
Closes #2875: Don't reset onboarding shown state for initial state!

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/navigationoverlay/NavigationOverlayFragment.kt
@@ -262,6 +262,13 @@ class NavigationOverlayFragment : Fragment() {
 
     // TODO other toolbar state is set in the ToolbarUiController. Move this there to be consistent
     private fun observeAccountState(): Disposable {
+        fun setUiToNotAuthenticated() {
+            fxaButton.setImageResource(R.drawable.ic_fxa_login)
+            fxaButton.contentDescription =
+                resources.getString(R.string.fxa_navigation_item_new,
+                    resources.getString(R.string.app_name))
+        }
+
         val fxaRepo = serviceLocator.fxaRepo
 
         return fxaRepo.accountState
@@ -283,11 +290,11 @@ class NavigationOverlayFragment : Fragment() {
                             fxaRepo.showFxaOnboardingScreen(context!!)
                         }
                     }
-                    AccountState.NotAuthenticated, AccountState.Initial -> {
-                        fxaButton.setImageResource(R.drawable.ic_fxa_login)
-                        fxaButton.contentDescription =
-                            resources.getString(R.string.fxa_navigation_item_new,
-                                resources.getString(R.string.app_name))
+                    AccountState.Initial -> {
+                        setUiToNotAuthenticated()
+                    }
+                    AccountState.NotAuthenticated -> {
+                        setUiToNotAuthenticated()
                         resetFxaOnboardingShown()
                     }
                     AccountState.NeedsReauthentication -> {


### PR DESCRIPTION
RCA: on cold start, the account state would always hit Initial, resetting the
onboarding state. If the user was signed in, the app would transition to
AuthenticatedNoProfile and the onboarding would be shown.

@dnarcese If you don't have time for this, please pass to Severin!

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
  - We don't really have standards for how to write tests for UI layer and we don't really have time to write it atm
- [x] Add a **CHANGELOG entry** if applicable
  - Bug was not released
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
