### PR TITLE
Issue #2806: periodically poll for account state

### DIFF
--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -219,6 +219,8 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
             .addTo(startStopCompositeDisposable)
 
         observeReceivedTabs().addTo(startStopCompositeDisposable)
+
+        serviceLocator.fxaRepo.periodicallyPollAccountState().addTo(startStopCompositeDisposable)
     }
 
     override fun onStop() {

--- a/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/MainActivity.kt
@@ -220,7 +220,9 @@ class MainActivity : LocaleAwareAppCompatActivity(), OnUrlEnteredListener, Media
 
         observeReceivedTabs().addTo(startStopCompositeDisposable)
 
-        serviceLocator.fxaRepo.periodicallyPollAccountState().addTo(startStopCompositeDisposable)
+        // TODO remove this after FxA adds push event for revoked logins
+        // See: https://github.com/mozilla/application-services/issues/1418
+        serviceLocator.fxaRepo.pollAccountState()
     }
 
     override fun onStop() {

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -11,6 +11,7 @@ import android.preference.PreferenceManager
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.NONE
 import io.reactivex.Observable
+import io.reactivex.disposables.Disposable
 import io.reactivex.subjects.BehaviorSubject
 import kotlinx.android.synthetic.main.tabs_onboarding.descriptionText
 import kotlinx.android.synthetic.main.tabs_onboarding.tabs_onboarding_button
@@ -138,6 +139,24 @@ class FxaRepo(
         TelemetryIntegration.INSTANCE.fxaShowOnboardingEvent()
         dialog.show()
     }
+
+    /**
+     * Polls for account state.  Any updates will be received through the normal
+     * [FxaRepo.FirefoxAccountObserver] code path. This is important because, as of now, FxA does
+     * not send push events when a user is logged out on another device. We poll so that we will
+     * (eventually) correctly show the user as not logged in.
+     *
+     * TODO remove this after FxA adds push event for revoked logins
+     * See: https://github.com/mozilla/application-services/issues/1418
+     */
+    fun periodicallyPollAccountState(): Disposable =
+        // TODO before merging update this to the period specified in #2806
+        Observable.interval(20, TimeUnit.SECONDS)
+            .subscribe {
+                @Suppress("DeferredResultUnused") // We don't need to do anything when
+                // this finishes
+                accountManager.authenticatedAccount()?.deviceConstellation()?.pollForEventsAsync()
+            }
 
     @SuppressLint("CheckResult") // This survives for the duration of the app
     private fun setupTelemetry() {

--- a/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
+++ b/app/src/main/java/org/mozilla/tv/firefox/fxa/FxaRepo.kt
@@ -11,7 +11,6 @@ import android.preference.PreferenceManager
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.NONE
 import io.reactivex.Observable
-import io.reactivex.disposables.Disposable
 import io.reactivex.subjects.BehaviorSubject
 import kotlinx.android.synthetic.main.tabs_onboarding.descriptionText
 import kotlinx.android.synthetic.main.tabs_onboarding.tabs_onboarding_button
@@ -149,14 +148,11 @@ class FxaRepo(
      * TODO remove this after FxA adds push event for revoked logins
      * See: https://github.com/mozilla/application-services/issues/1418
      */
-    fun periodicallyPollAccountState(): Disposable =
-        // TODO before merging update this to the period specified in #2806
-        Observable.interval(20, TimeUnit.SECONDS)
-            .subscribe {
-                @Suppress("DeferredResultUnused") // We don't need to do anything when
-                // this finishes
-                accountManager.authenticatedAccount()?.deviceConstellation()?.pollForEventsAsync()
-            }
+    fun pollAccountState() {
+        @Suppress("DeferredResultUnused") // We don't need to do anything when
+        // this finishes
+        accountManager.authenticatedAccount()?.deviceConstellation()?.pollForEventsAsync()
+    }
 
     @SuppressLint("CheckResult") // This survives for the duration of the app
     private fun setupTelemetry() {


### PR DESCRIPTION
@dnarcese this needs to be updated with the correct time period, but is otherwise ready for review.

I verified functionality by:
- Signing into FxA on my FFTV device
- Using FF desktop to revoke account access on my FFTV device
- Verifying that, after polling, the "auth problems" icon was shown

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [X] Add a **CHANGELOG entry** if applicable
Feature hasn't been released yet
- [X] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
