### PR TITLE
Don't push LAT releases to amazon

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -44,6 +44,8 @@ jobs:
         python ./tools/taskcluster/get-bitbar-token.py
         python ./tools/taskcluster/execute-bitbar-test.py system/debug app-system-debug
   release:
+    attributes:
+      build-type: release
     run-on-tasks-for: [github-release]
     worker:
       artifacts:

--- a/taskcluster/ci/email/kind.yml
+++ b/taskcluster/ci/email/kind.yml
@@ -15,13 +15,19 @@ jobs:
     worker-type: succeed
     run-on-tasks-for: [github-release]
     dependencies:
+      build: build-release
       sign: 'Sign for Github'
       push: 'Push to Amazon'
     worker:
       to-address: firefox-tv@mozilla.com
-      content: |
-        Automation for this release is ready. Please:
-        * Download the APK and attach it to the [Github release](https://github.com/mozilla-mobile/firefox-tv/releases/tag/{tag})
-        * [Deploy the new release on Amazon](https://developer.amazon.com/apps-and-games/console/app/amzn1.devportal.mobileapp.7f334089688646ef8953d041021029c9/release/amzn1.devportal.apprelease.4ca3990c43f34101bf5729543343747a/general/detail)
+      content:
+        by-release-type:
+          production: |
+            Automation for this release is ready. Please:
+            * Download [the signed APK](<sign/public/build/target.apk>) and attach it to the [Github release](https://github.com/mozilla-mobile/firefox-tv/releases/tag/{tag})
+            * [Deploy the new release on Amazon](https://developer.amazon.com/apps-and-games/console/app/amzn1.devportal.mobileapp.7f334089688646ef8953d041021029c9/release/amzn1.devportal.apprelease.4ca3990c43f34101bf5729543343747a/general/detail)
+          lat: |
+            Automation for this release is ready. Please:
+            * Download [the signed APK](<sign/public/build/target.apk>) and attach it to the [Github release](https://github.com/mozilla-mobile/firefox-tv/releases/tag/{tag})
+            * Download [the unsigned APK](<build/public/build/target.apk>) and [deploy the new release on Amazon](https://developer.amazon.com/apps-and-games/console/app/amzn1.devportal.mobileapp.7f334089688646ef8953d041021029c9/release/amzn1.devportal.apprelease.4ca3990c43f34101bf5729543343747a/general/detail)
       subject: "Release {tag} is ready for deployment"
-      link-text: "{tag} APK"

--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -2,29 +2,27 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-loader: taskgraph.loader.transform:loader
+loader: firefox_tv_taskgraph.loader.single_dep:loader
 
 transforms:
+  - firefox_tv_taskgraph.single_dep:transforms
   - firefox_tv_taskgraph.pushapk:transforms
   - taskgraph.transforms.task:transforms
 
-jobs:
-  push:
-    attributes:
-      release-type: production
-    label: Push to Amazon
-    description: ''
-    worker-type: push-apk
-    run-on-tasks-for: [github-release]
-    dependencies:
-      build: build-release
-    worker:
-      product: firefox-tv
-      channel: production
-      target-store: amazon
-      upstream-artifacts:
-        - taskType: build
-          paths:
-            - public/build/target.apk
-          taskId:
-            task-reference: <build>
+kind-dependencies:
+  - build
+
+only-for-build-types:
+  - release
+
+job-template:
+  attributes:
+    release-type: production
+  label: Push to Amazon
+  description: ''
+  worker-type: push-apk
+  run-on-tasks-for: [github-release]
+  worker:
+    product: firefox-tv
+    channel: production
+    target-store: amazon

--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -10,6 +10,8 @@ transforms:
 
 jobs:
   push:
+    attributes:
+      release-type: production
     label: Push to Amazon
     description: ''
     worker-type: push-apk

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -2,26 +2,21 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-loader: taskgraph.loader.transform:loader
+loader: firefox_tv_taskgraph.loader.single_dep:loader
 
 transforms:
+  - firefox_tv_taskgraph.single_dep:transforms
   - firefox_tv_taskgraph.signing:transforms
   - taskgraph.transforms.task:transforms
 
-jobs:
-  sign:
-    label: Sign for Github
-    description: ''
-    worker-type: signing
-    run-on-tasks-for: [github-release]
-    dependencies:
-      build: build-release
-    worker:
-      upstream-artifacts:
-        - taskType: build
-          paths:
-            - public/build/target.apk
-          formats:
-            - autograph_apk
-          taskId:
-            task-reference: <build>
+kind-dependencies:
+  - build
+
+only-for-build-types:
+  - release
+
+job-template:
+  label: Sign for Github
+  description: ''
+  worker-type: signing
+  run-on-tasks-for: [github-release]

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -9,7 +9,7 @@ transforms:
   - taskgraph.transforms.task:transforms
 
 jobs:
-  push:
+  sign:
     label: Sign for Github
     description: ''
     worker-type: signing

--- a/taskcluster/firefox_tv_taskgraph/__init__.py
+++ b/taskcluster/firefox_tv_taskgraph/__init__.py
@@ -20,6 +20,7 @@ def register(graph_config):
     _import_modules(["worker_types", "target_tasks"])
     extend_parameters_schema({
         Required("head_tag"): Any(text_type, None),
+        Required("release_type"): Any(text_type, None),
     })
 
 
@@ -30,9 +31,17 @@ def _import_modules(modules):
 
 def get_decision_parameters(graph_config, parameters):
     parameters["head_tag"] = None
+    parameters["release_type"] = None
     if parameters["tasks_for"] == "github-release":
         head_tag = os.environ.get("MOBILE_HEAD_TAG")
         if head_tag is None:
             raise ValueError("Cannot run github-release if the environment variable "
                              "'MOBILE_HEAD_TAG' is not defined")
-        parameters["head_tag"] = head_tag.decode("utf-8")
+        head_tag = head_tag.decode("utf-8")
+        release_type = "lat" if "LAT" in head_tag else "production"
+        parameters["head_tag"] = head_tag
+        parameters["release_type"] = release_type
+        if release_type == "lat":
+            parameters["target_tasks_method"] = "lat"
+        else:
+            parameters["target_tasks_method"] = "production"

--- a/taskcluster/firefox_tv_taskgraph/build.py
+++ b/taskcluster/firefox_tv_taskgraph/build.py
@@ -14,6 +14,14 @@ NOTIFY_EMAIL_ADDRESS = 'firefox-tv@mozilla.com'
 
 
 @transforms.add
+def expose_artifacts_in_attributes(config, tasks):
+    for task in tasks:
+        task.setdefault("attributes", {})
+        task["attributes"]["apks"] = [artifact["name"] for artifact in task["worker"].get("artifacts", [])]
+        yield task
+
+
+@transforms.add
 def build_task(config, tasks):
     for task in tasks:
         script = task["worker"]["script"].format(

--- a/taskcluster/firefox_tv_taskgraph/email.py
+++ b/taskcluster/firefox_tv_taskgraph/email.py
@@ -22,7 +22,7 @@ def email_task(config, tasks):
 
     for task in tasks:
         resolve_keyed_by(task, "worker.content", task["name"], **{
-            "release-type": release_type
+            "release-type": release_type or "production"
         })
 
         if release_type == 'lat':

--- a/taskcluster/firefox_tv_taskgraph/email.py
+++ b/taskcluster/firefox_tv_taskgraph/email.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 from taskgraph.transforms.base import TransformSequence
-
+from taskgraph.util.schema import resolve_keyed_by
 
 transforms = TransformSequence()
 
@@ -18,23 +18,26 @@ NOTIFY_EMAIL_ADDRESS = 'firefox-tv@mozilla.com'
 @transforms.add
 def email_task(config, tasks):
     tag = config.params.get("head_tag")
+    release_type = config.params.get("release_type")
 
     for task in tasks:
+        resolve_keyed_by(task, "worker.content", task["name"], **{
+            "release-type": release_type
+        })
+
+        if release_type == 'lat':
+            task["dependencies"].pop("push")
+
         to_address = task["worker"].pop("to-address")
         content = task["worker"].pop("content")
         subject = task["worker"].pop("subject")
-        link_text = task["worker"].pop("link-text")
         task["scopes"] = ["queue:route:notify.email.{}.on-completed".format(to_address)]
         task["routes"] = ["notify.email.{}.on-completed".format(to_address)]
         task["extra"] = {
             "notify": {
                 "email": {
-                    "content": content.format(tag=tag),
+                    "content": {"artifact-reference": content.format(tag=tag)},
                     "subject": subject.format(tag=tag),
-                    "link": {
-                        "href": {"artifact-reference": "<sign/public/build/target.apk>"},
-                        "text": link_text.format(tag=tag)
-                    },
                 }
             }
         }

--- a/taskcluster/firefox_tv_taskgraph/loader/single_dep.py
+++ b/taskcluster/firefox_tv_taskgraph/loader/single_dep.py
@@ -1,0 +1,52 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import copy
+
+from voluptuous import Required
+
+from taskgraph.task import Task
+from taskgraph.util.schema import Schema
+
+schema = Schema({Required("primary-dependency", "primary dependency task"): Task})
+
+
+def loader(kind, path, config, params, loaded_tasks):
+    """
+    Load tasks based on the jobs dependant kinds.
+
+    Optional `only-for-attributes` kind configuration, if specified, will limit
+    the jobs chosen to ones which have the specified attribute, with the specified
+    value.
+
+    Optional `job-template` kind configuration value, if specified, will be used to
+    pass configuration down to the specified transforms used.
+    """
+    only_attributes = config.get("only-for-attributes")
+    only_build_type = config.get('only-for-build-types')
+    job_template = config.get("job-template")
+
+    for task in loaded_tasks:
+        if task.kind not in config.get("kind-dependencies", []):
+            continue
+
+        if only_attributes:
+            config_attrs = set(only_attributes)
+            if not config_attrs & set(task.attributes):
+                # make sure any attribute exists
+                continue
+
+        if only_build_type:
+            build_type = task.attributes.get('build-type')
+            if build_type not in only_build_type:
+                continue
+
+        job = {"primary-dependency": task}
+
+        if job_template:
+            job.update(copy.deepcopy(job_template))
+
+        yield job

--- a/taskcluster/firefox_tv_taskgraph/signing.py
+++ b/taskcluster/firefox_tv_taskgraph/signing.py
@@ -15,3 +15,11 @@ def signing_task(config, tasks):
     for task in tasks:
         task["worker"]["signing-type"] = 'dep-signing' if config.params["level"] != u'3' else 'production-signing'
         yield task
+
+
+@transforms.add
+def set_signing_format(config, tasks):
+    for task in tasks:
+        for upstream_artifact in task["worker"]["upstream-artifacts"]:
+            upstream_artifact["formats"] = ["autograph_apk"]
+        yield task

--- a/taskcluster/firefox_tv_taskgraph/single_dep.py
+++ b/taskcluster/firefox_tv_taskgraph/single_dep.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Apply some defaults and minor modifications to the single_dep jobs.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.treeherder import inherit_treeherder_from_dep, join_symbol
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def build_name_and_attributes(config, tasks):
+    for task in tasks:
+        dep = task["primary-dependency"]
+        task["dependencies"] = {dep.kind: dep.label}
+        copy_of_attributes = dep.attributes.copy()
+        task.setdefault("attributes", copy_of_attributes)
+        # run_on_tasks_for is set as an attribute later in the pipeline
+        task.setdefault("run-on-tasks-for", copy_of_attributes['run_on_tasks_for'])
+        task["name"] = _get_dependent_job_name_without_its_kind(dep)
+
+        yield task
+
+
+def _get_dependent_job_name_without_its_kind(dependent_job):
+    return dependent_job.label[len(dependent_job.kind) + 1:]
+
+
+@transforms.add
+def build_upstream_artifacts(config, tasks):
+    for task in tasks:
+        dep = task.pop("primary-dependency")
+
+        worker_definition = {}
+        worker_definition["upstream-artifacts"] = [{
+            "taskId": {"task-reference": "<{}>".format(dep.kind)},
+            "taskType": dep.kind,
+            "paths": sorted(dep.attributes["apks"]),
+        }]
+
+        task.setdefault("worker", {})
+        task["worker"].update(worker_definition)
+        yield task

--- a/taskcluster/firefox_tv_taskgraph/target_tasks.py
+++ b/taskcluster/firefox_tv_taskgraph/target_tasks.py
@@ -7,11 +7,22 @@ from __future__ import absolute_import, print_function, unicode_literals
 from taskgraph.target_tasks import _target_task, standard_filter
 
 
-@_target_task('default')
-def target_tasks_default(full_task_graph, parameters, graph_config):
-    """Target the tasks which have indicated they should be run on this project
-    via the `run_on_projects` attributes."""
-    def filter(task, params):
-        return standard_filter(task, params)
+def tag_filter(target_release_type, task, params):
+    release_type = task.attributes.get("release-type")
+    return standard_filter(task, params) and (release_type is None or release_type == target_release_type)
 
+
+@_target_task("default")
+def target_tasks_default(full_task_graph, parameters, graph_config):
+    filter = standard_filter
     return [l for l, task in full_task_graph.tasks.iteritems() if filter(task, parameters)]
+
+
+@_target_task("production")
+def target_tasks_production(full_task_graph, parameters, graph_config):
+    return [l for l, task in full_task_graph.tasks.iteritems() if tag_filter("production", task, parameters)]
+
+
+@_target_task("lat")
+def target_tasks_production(full_task_graph, parameters, graph_config):
+    return [l for l, task in full_task_graph.tasks.iteritems() if tag_filter("lat", task, parameters)]


### PR DESCRIPTION
This avoids submitting LAT apps to Amazon (the API doesn't support LAT releases, and existing automation behaviour is to create an "upcoming version"), and adjusts email content to link to the unsigned apk.

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
- [x] This is tested