### PR TITLE
Switch to aws-provider worker types

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -11,7 +11,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: 0c5a68749f9a7672a7e56604b69a7bd41b036614
+              revision: 8724fdf41562f6eea82d1b905072d4a7c1f5ebbf
           trustDomain: mobile
       in:
           $let:
@@ -86,8 +86,8 @@ tasks:
                                 then:
                                     name: "Decision Task"
                                     description: 'The task that creates all of the other tasks in the task graph'
-                      provisionerId: "aws-provisioner-v1"
-                      workerType: "mobile-${level}-decision"
+                      provisionerId: "mobile-${level}"
+                      workerType: "decision"
                       tags:
                           kind: decision-task
                       routes:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -16,15 +16,15 @@ taskgraph:
 workers:
   aliases:
     b-android:
-      provisioner: aws-provisioner-v1
+      provisioner: 'mobile-{level}'
       implementation: docker-worker
       os: linux
-      worker-type: 'mobile-{level}-b-firefox-tv'
+      worker-type: 'b-linux'
     images:
-      provisioner: aws-provisioner-v1
+      provisioner: 'mobile-{level}'
       implementation: docker-worker
       os: linux
-      worker-type: 'mobile-{level}-images'
+      worker-type: 'images'
     dep-signing:
       provisioner: scriptworker-prov-v1
       implementation: scriptworker-signing


### PR DESCRIPTION
[Equivalent work in `reference-browser`](https://github.com/mozilla-mobile/reference-browser/pull/939).
This will prepare `fenix` for the Taskcluster instance change

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
