### PR TITLE
Uses scriptworker-k8s scriptworkers

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -11,7 +11,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: 0c5a68749f9a7672a7e56604b69a7bd41b036614
+              revision: bbd657c72f8a5fb113f14ca0a8bd02d9cbd06189
           trustDomain: mobile
       in:
           $let:
@@ -86,8 +86,8 @@ tasks:
                                 then:
                                     name: "Decision Task"
                                     description: 'The task that creates all of the other tasks in the task graph'
-                      provisionerId: "aws-provisioner-v1"
-                      workerType: "mobile-${level}-decision"
+                      provisionerId: "mobile-${level}"
+                      workerType: "decision"
                       tags:
                           kind: decision-task
                       routes:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -26,26 +26,23 @@ workers:
       os: linux
       worker-type: 'mobile-{level}-images'
     dep-signing:
-      provisioner: scriptworker-prov-v1
+      provisioner: scriptworker-k8s
       implementation: scriptworker-signing
       os: scriptworker
-      worker-type: mobile-signing-dep-v1
+      worker-type: mobile-t-signing
     signing:
-      provisioner: scriptworker-prov-v1
+      provisioner: scriptworker-k8s
       implementation: scriptworker-signing
       os: scriptworker
       worker-type:
         by-level:
-          "3": mobile-signing-v1
-          default: mobile-signing-dep-v1
+          "3": mobile-3-signing
+          default: mobile-t-signing
     push-apk:
-      provisioner: scriptworker-prov-v1
+      provisioner: scriptworker-k8s
       implementation: scriptworker-push-apk
       os: scriptworker
-      worker-type:
-        by-level:
-          "3": mobile-pushapk-v1
-          default: mobile-pushapk-dep-v1
+      worker-type: 'mobile-{level}-pushapk'
 
 scriptworker:
   scope-prefix: project:mobile:firefox-tv:releng

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -16,15 +16,15 @@ taskgraph:
 workers:
   aliases:
     b-android:
-      provisioner: aws-provisioner-v1
+      provisioner: 'mobile-{level}'
       implementation: docker-worker
       os: linux
-      worker-type: 'mobile-{level}-b-firefox-tv'
+      worker-type: 'b-linux'
     images:
-      provisioner: aws-provisioner-v1
+      provisioner: 'mobile-{level}'
       implementation: docker-worker
       os: linux
-      worker-type: 'mobile-{level}-images'
+      worker-type: 'images'
     dep-signing:
       provisioner: scriptworker-k8s
       implementation: scriptworker-signing


### PR DESCRIPTION
This is another change for [the Taskcluster instance migration](https://github.com/mozilla-mobile/firefox-tv/pull/2952).

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [x] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [x] Add thorough **tests** or an explanation of why it does not
- [x] Add a **CHANGELOG entry** if applicable
- [x] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
