### PR TITLE
Bug 1595808 - Bump taskgraph to the latest revision

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -11,7 +11,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: bbd657c72f8a5fb113f14ca0a8bd02d9cbd06189
+              revision: d302e95cc988706ba746bfecbf1dae31090d212f
           trustDomain: mobile
       in:
           $let:


### PR DESCRIPTION
Same as mozilla-mobile/android-components#5043. If we don't take this patch, then any github-release will just build and ship whatever is on the top of the target branch.

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
