### PR TITLE
Issue #2995: Disable bitbar in master

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -46,9 +46,10 @@ jobs:
     master:
         run:
             gradlew: ["-PisPullRequest", "clean", "assembleSystem", "assembleAndroidTest", "lint", "checkstyle", "ktlint", "pmd", "detekt", "test"]
-            post-gradlew:
-                - ["python", "./tools/taskcluster/get-bitbar-token.py"]
-                - ["python", "./tools/taskcluster/execute-bitbar-test.py", "system/debug", "app-system-debug"]
+            # Disabling bitbar until the bug is resolved: https://github.com/mozilla-mobile/firefox-tv/issues/2995
+            # post-gradlew:
+                #- ["python", "./tools/taskcluster/get-bitbar-token.py"]
+                #- ["python", "./tools/taskcluster/execute-bitbar-test.py", "system/debug", "app-system-debug"]
         run-on-tasks-for: [github-push]
 
     release:


### PR DESCRIPTION
builds in master are failing from bitbar request 404:
```[task 2020-06-29T23:58:03.400Z] BUILD SUCCESSFUL in 8m 46s
[task 2020-06-29T23:58:03.400Z] 169 actionable tasks: 168 executed, 1 up-to-date
[task 2020-06-29T23:58:03.775Z] + python ./tools/taskcluster/get-bitbar-token.py
[task 2020-06-29T23:58:03.951Z] Imported Bitbar token from secrets service
[task 2020-06-29T23:58:03.952Z] + python ./tools/taskcluster/execute-bitbar-test.py system/debug app-system-debug
[task 2020-06-29T23:58:06.920Z] Traceback (most recent call last):
[task 2020-06-29T23:58:06.920Z]   File "./tools/taskcluster/execute-bitbar-test.py", line 40, in <module>
[task 2020-06-29T23:58:06.920Z]     "instrumentationRunner": "org.mozilla.tv.firefox.FirefoxOnDeviceTestRunner"
[task 2020-06-29T23:58:06.920Z]   File "/usr/local/lib/python2.7/dist-packages/testdroid/__init__.py", line 505, in start_test_run_using_config
[task 2020-06-29T23:58:06.920Z]     test_run = self.post(path=path, payload=test_run_config, headers={'Content-type': 'application/json', 'Accept': 'application/json'})
[task 2020-06-29T23:58:06.920Z]   File "/usr/local/lib/python2.7/dist-packages/testdroid/__init__.py", line 274, in post
[task 2020-06-29T23:58:06.920Z]     raise RequestResponseError(res.text, res.status_code)
[task 2020-06-29T23:58:06.920Z] testdroid.RequestResponseError: Request Error: code 404: {"message":"Project with id 296208 does not exist","statusCode":404}```