### PR TITLE
Disable tasks we don't use right now

### DIFF
--- a/taskcluster/ci/email/kind.yml
+++ b/taskcluster/ci/email/kind.yml
@@ -13,7 +13,7 @@ jobs:
     label: Email that automation is complete
     description: ''
     worker-type: succeed
-    run-on-tasks-for: [github-release]
+    run-on-tasks-for: []
     dependencies:
       build: build-release
       sign: 'Sign for Github'

--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -21,7 +21,7 @@ job-template:
   label: Push to Amazon
   description: ''
   worker-type: push-apk
-  run-on-tasks-for: [github-release]
+  run-on-tasks-for: []
   worker:
     product: firefox-tv
     channel: production

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -19,4 +19,4 @@ job-template:
   label: Sign for Github
   description: ''
   worker-type: signing
-  run-on-tasks-for: [github-release]
+  run-on-tasks-for: []


### PR DESCRIPTION
This patch removes `github-release` from the `run-on-tasks-for` setting for `email`, `push-apk` and `signing` tasks.