### PR TITLE
Remove Pocket check from PinTileTests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/tv/firefox/ui/screenshots/PinTileTests.java
+++ b/app/src/androidTest/java/org/mozilla/tv/firefox/ui/screenshots/PinTileTests.java
@@ -67,20 +67,7 @@ public class PinTileTests extends ScreenshotTest {
         final Locale currentLocale = LocaleManager.getInstance()
                 .getCurrentLocale(mActivityTestRule.getActivity());
 
-        final boolean pocketIsDisplayed = currentLocale.getLanguage().equals("en");
-        // TODO it would be better to condition this on view visibility, but I'm not sure
-        // how to do that here.
-        if (pocketIsDisplayed) {
-            // Navigate down to pinned tiles, to ensure that they are on screen. This
-            // is important because some of our tests are run on small devices, where
-            // not doing this can cause errors
-            mDevice.pressDPadDown();
-            mDevice.pressDPadDown();
-        } else {
-            // The pocket channel is only displayed in EN locales, so elsewhere we only
-            // need to nav down once.
-            mDevice.pressDPadDown();
-        }
+        mDevice.pressDPadDown();
 
         onView(withText(R.string.homescreen_unpin_tutorial_toast))
                 .inRoot(withDecorView(not(is(mActivityTestRule.getActivity().getWindow().getDecorView()))))


### PR DESCRIPTION
This patch removes a check for Pocket from PinTileTests. (Pocket is not part of this product anymore)

## Checklist
<!-- Before submitting and merging the PR, please address each item -->
- [ ] Confirm the **acceptance criteria** is fully satisfied in the issue(s) this PR will close
- [ ] Add thorough **tests** or an explanation of why it does not
- [ ] Add a **CHANGELOG entry** if applicable
- [ ] Add **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-notneeded`)
